### PR TITLE
feat(core-sdk): get offer by id from subgraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14455,6 +14455,12 @@
       "version": "4.1.0",
       "license": "MIT"
     },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "license": "MIT"
@@ -15390,6 +15396,21 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.4.tgz",
+      "integrity": "sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-fetch": {
@@ -17629,6 +17650,15 @@
       },
       "peerDependencies": {
         "react": ">=0.14.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/property-expr": {
@@ -22302,6 +22332,7 @@
       "devDependencies": {
         "eslint": "^8.10.0",
         "jest": "^27.5.1",
+        "nock": "^13.2.4",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.1.3",
         "typescript": "^4.5.5"
@@ -23620,6 +23651,7 @@
         "cross-fetch": "^3.1.5",
         "eslint": "^8.10.0",
         "jest": "^27.5.1",
+        "nock": "*",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.1.3",
         "typescript": "^4.5.5",
@@ -32193,6 +32225,12 @@
     "lodash.repeat": {
       "version": "4.1.0"
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.snakecase": {
       "version": "4.1.1"
     },
@@ -32839,6 +32877,18 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "nock": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.4.tgz",
+      "integrity": "sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
       }
     },
     "node-fetch": {
@@ -34131,6 +34181,12 @@
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "property-expr": {
       "version": "2.0.5",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -37,10 +37,11 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
-    "jest": "^27.5.1",
-    "typescript": "^4.5.5",
     "eslint": "^8.10.0",
+    "jest": "^27.5.1",
+    "nock": "^13.2.4",
     "rimraf": "^3.0.2",
-    "ts-jest": "^27.1.3"
+    "ts-jest": "^27.1.3",
+    "typescript": "^4.5.5"
   }
 }

--- a/packages/core-sdk/src/core-sdk.ts
+++ b/packages/core-sdk/src/core-sdk.ts
@@ -5,7 +5,8 @@ import {
   MetadataStorage,
   Metadata
 } from "@bosonprotocol/common";
-import { handler as offerHandler, CreateOfferArgs } from "./offers";
+import { BigNumberish } from "@ethersproject/bignumber";
+import * as offers from "./offers";
 
 export class CoreSDK {
   private _web3Lib: Web3LibAdapter;
@@ -75,17 +76,23 @@ export class CoreSDK {
   }
 
   public async createOffer(
-    offerToCreate: CreateOfferArgs,
+    offerToCreate: offers.CreateOfferArgs,
     opts: Partial<{
       contractAddress: string;
     }> = {}
   ): Promise<TransactionResponse> {
-    return offerHandler.createOffer({
+    return offers.handler.createOffer({
       offerToCreate,
       web3Lib: this._web3Lib,
       theGraphStorage: this._theGraphStorage,
       metadataStorage: this._metadataStorage,
       contractAddress: opts.contractAddress || this._protocolDiamond
     });
+  }
+
+  public async getOfferById(
+    offerId: BigNumberish
+  ): Promise<offers.RawOfferFromSubgraph> {
+    return offers.subgraph.getOfferById(this._subgraphUrl, offerId);
   }
 }

--- a/packages/core-sdk/src/offers/index.ts
+++ b/packages/core-sdk/src/offers/index.ts
@@ -1,5 +1,5 @@
 export * as handler from "./handler";
-
+export * as subgraph from "./subgraph";
 export * as validation from "./validation";
 
 export * from "./types";

--- a/packages/core-sdk/src/offers/subgraph.ts
+++ b/packages/core-sdk/src/offers/subgraph.ts
@@ -1,15 +1,50 @@
-import fetch from "cross-fetch";
+import { BigNumberish } from "@ethersproject/bignumber";
+import { fetchSubgraph } from "../utils/subgraph";
+import { RawOfferFromSubgraph } from "./types";
 
-/**
- * TODO
- */
-export async function fetchFromSubgraph() {
-  const res = await fetch("https://api.github.com/users/dohaki");
-
-  if (res.status >= 400) {
-    throw new Error("Bad response from server");
+export const getOfferByIdQuery = `
+query GetOfferById($offerId: ID) {
+  offer(id: $offerId) {
+    id
+    createdAt
+    price
+    deposit
+    penalty
+    quantity
+    validFromDate
+    validUntilDate
+    redeemableDate
+    fulfillmentPeriodDuration
+    voucherValidDuration
+    metadataUri
+    metadataHash
+    voidedAt
+    seller {
+      address
+    }
+    exchangeToken {
+      address
+      decimals
+      name
+      symbol
+    }
+    metadata {
+      title
+      description
+    }
   }
+}
+`;
 
-  const user = await res.json();
-  return user;
+export async function getOfferById(
+  subgraphUrl: string,
+  offerId: BigNumberish
+): Promise<RawOfferFromSubgraph> {
+  const { offer } = await fetchSubgraph<{ offer: RawOfferFromSubgraph }>(
+    subgraphUrl,
+    getOfferByIdQuery,
+    { offerId: offerId.toString() }
+  );
+
+  return offer;
 }

--- a/packages/core-sdk/src/offers/types.ts
+++ b/packages/core-sdk/src/offers/types.ts
@@ -15,3 +15,33 @@ export type CreateOfferArgs = {
   metadataUri: string;
   metadataHash: string;
 };
+
+export type RawOfferFromSubgraph = {
+  id: string;
+  createdAt: string;
+  price: string;
+  deposit: string;
+  penalty: string;
+  quantity: string;
+  validFromDate: string;
+  validUntilDate: string;
+  redeemableDate: string;
+  fulfillmentPeriodDuration: string;
+  voucherValidDuration: string;
+  metadataUri: string;
+  metadataHash: string;
+  voidedAt: null | string;
+  seller: {
+    address: string;
+  };
+  exchangeToken: {
+    address: string;
+    decimals: string;
+    name: string;
+    symbol: string;
+  };
+  metadata: null | {
+    title: string;
+    description: string;
+  };
+};

--- a/packages/core-sdk/src/utils/errors.ts
+++ b/packages/core-sdk/src/utils/errors.ts
@@ -1,0 +1,14 @@
+export class FetchError extends Error {
+  statusCode?: number;
+  statusText?: string;
+
+  constructor(args: {
+    message?: string;
+    statusCode?: number;
+    statusText?: string;
+  }) {
+    super(args.message);
+    this.statusCode = args.statusCode;
+    this.statusText = args.statusText;
+  }
+}

--- a/packages/core-sdk/src/utils/subgraph.ts
+++ b/packages/core-sdk/src/utils/subgraph.ts
@@ -1,0 +1,36 @@
+import fetch from "cross-fetch";
+import { FetchError } from "./errors";
+
+export async function fetchSubgraph<T>(
+  subgraphUrl: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  const response = await fetch(subgraphUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      query,
+      variables
+    })
+  });
+
+  if (!response.ok) {
+    throw new FetchError({
+      message: `Failed to fetch: ${response.status} ${response.statusText}`,
+      statusCode: response.status,
+      statusText: response.statusText
+    });
+  }
+
+  const body = await response.json();
+  const { data = {}, errors = [] } = body || {};
+
+  if (errors.length > 0) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(errors)}`);
+  }
+
+  return data as T;
+}

--- a/packages/core-sdk/tests/mocks.ts
+++ b/packages/core-sdk/tests/mocks.ts
@@ -5,7 +5,7 @@ import {
   IPFS_URI,
   ADDRESS
 } from "@bosonprotocol/common/tests/mocks";
-import { CreateOfferArgs } from "../src/offers/types";
+import { CreateOfferArgs, RawOfferFromSubgraph } from "../src/offers/types";
 
 export function mockCreateOfferArgs(
   overrides?: Partial<CreateOfferArgs>
@@ -25,5 +25,51 @@ export function mockCreateOfferArgs(
     metadataUri: IPFS_URI,
     metadataHash: IPFS_HASH,
     ...overrides
+  };
+}
+
+export function mockRawOfferFromSubgraph(
+  overrides: Partial<RawOfferFromSubgraph> = {}
+): RawOfferFromSubgraph {
+  const {
+    seller = {},
+    exchangeToken = {},
+    metadata = {},
+    ...restOverrides
+  } = overrides;
+
+  return {
+    id: "1",
+    createdAt: "1646910946",
+    price: "1",
+    deposit: "2",
+    penalty: "0",
+    quantity: "10",
+    validFromDate: "1646997184",
+    validUntilDate: "1647083584",
+    redeemableDate: "1647083584",
+    fulfillmentPeriodDuration: "864000",
+    voucherValidDuration: "86400",
+    metadataUri:
+      "https://ipfs.io/ipfs/QmUttPYRg6mgDAzpjBjMTCvmfsqcgD6UpXj5PRqjvj6nT6",
+    metadataHash: "QmUttPYRg6mgDAzpjBjMTCvmfsqcgD6UpXj5PRqjvj6nT6",
+    voidedAt: null,
+    seller: {
+      address: "0x0000000000000000000000000000000000000000",
+      ...seller
+    },
+    exchangeToken: {
+      address: "0x0000000000000000000000000000000000000000",
+      decimals: "18",
+      name: "Ether",
+      symbol: "ETH",
+      ...exchangeToken
+    },
+    metadata: {
+      title: "Title",
+      description: "Description",
+      ...metadata
+    },
+    ...restOverrides
   };
 }

--- a/packages/core-sdk/tests/offers/subgraph.test.ts
+++ b/packages/core-sdk/tests/offers/subgraph.test.ts
@@ -1,0 +1,44 @@
+import nock from "nock";
+import { getOfferById } from "../../src/offers/subgraph";
+
+import { mockRawOfferFromSubgraph } from "../mocks";
+
+const SUBGRAPH_URL = "https://api.thegraph.com/subgraphs";
+
+function interceptSubgraph() {
+  return nock(SUBGRAPH_URL).post("", (body) => {
+    return body.query && body.variables;
+  });
+}
+
+describe("#getOfferById()", () => {
+  test("throw if response not okay", async () => {
+    interceptSubgraph().reply(500);
+
+    await expect(getOfferById(SUBGRAPH_URL, "1")).rejects.toThrow();
+  });
+
+  test("throw if graphql errors", async () => {
+    interceptSubgraph().reply(200, {
+      errors: ["some errors"]
+    });
+
+    await expect(getOfferById(SUBGRAPH_URL, "1")).rejects.toThrow();
+  });
+
+  test("return raw offer from subgraph", async () => {
+    const mockedRawOfferFromSubgraph = mockRawOfferFromSubgraph();
+    interceptSubgraph().reply(200, {
+      data: {
+        offer: mockedRawOfferFromSubgraph
+      }
+    });
+
+    const rawOffer = await getOfferById(
+      SUBGRAPH_URL,
+      mockedRawOfferFromSubgraph.id
+    );
+
+    expect(rawOffer).toMatchObject(mockedRawOfferFromSubgraph);
+  });
+});


### PR DESCRIPTION
## Description
Add method to fetch an offer from the subgraph.

## How to test
```js
import { CoreSDK, offers } from "@bosonprotocol/core-sdk"

// via core sdk singleton
const coreSDK = new CoreSDK(...);
const offer = await coreSDK.getOfferById(offerId);

// via offers module
const offer = await offers.subgraph.getOfferById(SUBGRAPH_URL, offerId);
```