### PR TITLE
refactor: use hash router and parameterize widgets url

### DIFF
--- a/packages/example-parent-app/.env
+++ b/packages/example-parent-app/.env
@@ -1,0 +1,1 @@
+REACT_APP_WIDGETS_URL=http://localhost:3000

--- a/packages/example-parent-app/src/views/create/index.tsx
+++ b/packages/example-parent-app/src/views/create/index.tsx
@@ -38,14 +38,17 @@ export function HomeView() {
       });
       const metadataUri = `https://ipfs.io/ipfs/${metadataHash}`;
 
-      createOffer({
-        ...values,
-        price: parseEther(values.price).toString(),
-        deposit: parseEther(values.deposit).toString(),
-        penalty: parseEther(values.penalty).toString(),
-        metadataHash,
-        metadataUri: metadataUri
-      });
+      createOffer(
+        {
+          ...values,
+          price: parseEther(values.price).toString(),
+          deposit: parseEther(values.deposit).toString(),
+          penalty: parseEther(values.penalty).toString(),
+          metadataHash,
+          metadataUri: metadataUri
+        },
+        process.env.REACT_APP_WIDGETS_URL
+      );
     }
   });
 

--- a/packages/widgets-sdk/src/config.tsx
+++ b/packages/widgets-sdk/src/config.tsx
@@ -1,3 +1,0 @@
-export const config = {
-  WIDGETS_URl: "http://localhost:3000"
-};

--- a/packages/widgets-sdk/src/constants.ts
+++ b/packages/widgets-sdk/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_WIDGETS_URl = "http://localhost:3000"; // TODO: replace with official ENS link

--- a/packages/widgets-sdk/src/create-offer/index.tsx
+++ b/packages/widgets-sdk/src/create-offer/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { StyledIframe } from "../lib/StyledIframe";
 import { Modal } from "./components/Modal";
-import { config } from "../config";
+import { DEFAULT_WIDGETS_URl } from "../constants";
 
 interface CreateOfferRequest {
   price: string;
@@ -18,12 +18,18 @@ interface CreateOfferRequest {
   metadataHash: string;
 }
 
-export function createOffer(request: CreateOfferRequest) {
+export function createOffer(
+  request: CreateOfferRequest,
+  widgetsUrl: string = DEFAULT_WIDGETS_URl
+) {
   const el = document.createElement("div");
   el.style.height = "0px";
   el.style.width = "0px";
   document.body.appendChild(el);
-  ReactDOM.render(<CreateOfferWidget request={request} />, el);
+  ReactDOM.render(
+    <CreateOfferWidget request={request} widgetsUrl={widgetsUrl} />,
+    el
+  );
 
   function onMessage(e: MessageEvent) {
     const { target, message } = e.data || {};
@@ -41,9 +47,10 @@ export function createOffer(request: CreateOfferRequest) {
 
 interface Props {
   request: CreateOfferRequest;
+  widgetsUrl: string;
 }
 
-function CreateOfferWidget({ request }: Props) {
+function CreateOfferWidget({ request, widgetsUrl }: Props) {
   const urlParams = new URLSearchParams(
     request as unknown as Record<string, string>
   ).toString();
@@ -52,7 +59,7 @@ function CreateOfferWidget({ request }: Props) {
     <Modal>
       <StyledIframe
         style={{ boxShadow: "none" }}
-        src={`${config.WIDGETS_URl}/create?${urlParams}`}
+        src={`${widgetsUrl}/#/create?${urlParams}`}
         width={600}
         height={582}
       />

--- a/packages/widgets/src/index.tsx
+++ b/packages/widgets/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { HashRouter, Route, Routes } from "react-router-dom";
 import { createGlobalStyle } from "styled-components";
 import reportWebVitals from "./reportWebVitals";
 import { Commit } from "./views/commit";
@@ -17,7 +17,7 @@ const GlobalStyle = createGlobalStyle`
 ReactDOM.render(
   <React.StrictMode>
     <GlobalStyle />
-    <BrowserRouter>
+    <HashRouter>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route
@@ -37,7 +37,7 @@ ReactDOM.render(
           }
         />
       </Routes>
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/packages/widgets/src/views/create-offer/index.tsx
+++ b/packages/widgets/src/views/create-offer/index.tsx
@@ -97,7 +97,7 @@ function useMetadata(metadataUri: string) {
 
 export function CreateOffer() {
   const urlParams = Object.fromEntries(
-    new URLSearchParams(window.location.search).entries()
+    new URLSearchParams(window.location.hash).entries()
   );
 
   const account = hooks.useAccount();

--- a/packages/widgets/src/views/home/index.tsx
+++ b/packages/widgets/src/views/home/index.tsx
@@ -1,11 +1,13 @@
+import { Link } from "react-router-dom";
+
 export function Home() {
   return (
     <ul>
       <li>
-        <a href="/create">"Create Offer" widget page</a>
+        <Link to="/create">"Create Offer" widget page</Link>
       </li>
       <li>
-        <a href="/commit">"Create to Offer" widget page</a>
+        <Link to="/commit">"Create to Offer" widget page</Link>
       </li>
     </ul>
   );


### PR DESCRIPTION
## Description

We have to use a hash router for an IPFS SPA deployment because of how IPFS resolves paths. I also changed the widgets URL to be configurable based on an env var in the example parent app, so that we can have multiple environments.

