### PR TITLE
feat(ethers-sdk): allow custom signer

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -79,7 +79,10 @@ export type TransactionReceipt = {
 export interface Web3LibAdapter {
   getSignerAddress(): Promise<string>;
   getChainId(): Promise<number>;
-  getBalance(address: string): Promise<BigNumberish>;
+  getBalance(
+    addressOrName: string,
+    blockNumber?: string | number
+  ): Promise<BigNumberish>;
   sendTransaction(
     transactionRequest: TransactionRequest
   ): Promise<TransactionResponse>;

--- a/packages/eth-connect-sdk/src/eth-connect-adapter.ts
+++ b/packages/eth-connect-sdk/src/eth-connect-adapter.ts
@@ -18,14 +18,17 @@ export class EthConnectAdapter implements Web3LibAdapter {
   }
 
   public async getChainId(): Promise<number> {
-    return this._requestManager.provider.getChainId();
+    const chainId = await this._requestManager.net_version();
+    return parseInt(chainId);
   }
 
-  public async getBalance(address: string): Promise<string> {
-    const blockNumber = await this._requestManager.eth_blockNumber();
+  public async getBalance(
+    addressOrName: string,
+    blockNumber?: string | number
+  ): Promise<string> {
     const balance = await this._requestManager.eth_getBalance(
-      address,
-      blockNumber.toString()
+      addressOrName,
+      (blockNumber || (await this._requestManager.eth_blockNumber())).toString()
     );
     return balance.toString();
   }

--- a/packages/ethers-sdk/src/ethers-adapter.ts
+++ b/packages/ethers-sdk/src/ethers-adapter.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, ethers } from "ethers";
+import { BigNumberish, providers, Signer } from "ethers";
 import {
   TransactionResponse,
   Web3LibAdapter,
@@ -6,12 +6,15 @@ import {
 } from "@bosonprotocol/common";
 
 export class EthersAdapter implements Web3LibAdapter {
-  private _signer: ethers.providers.JsonRpcSigner;
-  private _provider: ethers.providers.JsonRpcProvider;
+  private _signer: Signer;
+  private _provider: providers.JsonRpcProvider;
 
-  constructor(provider: ethers.providers.JsonRpcProvider) {
+  constructor(provider: providers.JsonRpcProvider, signer?: Signer) {
     this._provider = provider;
-    this._signer = this._provider.getSigner();
+
+    this._signer = signer
+      ? signer.connect(this._provider)
+      : this._provider.getSigner();
   }
 
   public async getSignerAddress() {
@@ -22,8 +25,11 @@ export class EthersAdapter implements Web3LibAdapter {
     return this._signer.getChainId();
   }
 
-  public async getBalance(address: string): Promise<BigNumberish> {
-    return this._signer.getBalance();
+  public async getBalance(
+    addressOrName: string,
+    blockNumber?: string | number
+  ): Promise<BigNumberish> {
+    return this._provider.getBalance(addressOrName, blockNumber);
   }
 
   public async sendTransaction(


### PR DESCRIPTION
## Description

This allows an arbitrary signer instance (e.g. from a private key),
to be used with the `ethers-sdk`.

