### PR TITLE
ci: add workflow to publish next packages

### DIFF
--- a/.github/workflows/publish-next.yaml
+++ b/.github/workflows/publish-next.yaml
@@ -46,5 +46,5 @@ jobs:
           git commit -m "chore(release): publish next [skip ci]"
       - name: Publish to npm
         run: |
-          lerna publish from-package --dist-tag next --yes
+          lerna publish from-package --dist-tag latest --yes
           git push


### PR DESCRIPTION
## Description

This publishes npm packages on every merge into `main` with dist tag `next`. 