### PR TITLE
style: remove react-use as it does not support react v18 yet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4687,10 +4687,6 @@
         "pretty-format": "^27.0.0"
       }
     },
-    "node_modules/@types/js-cookie": {
-      "version": "2.2.7",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "license": "MIT"
@@ -5217,10 +5213,6 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "node_modules/@xobotyi/scrollbar-width": {
-      "version": "1.9.5",
-      "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -7473,13 +7465,6 @@
       "version": "1.0.6",
       "license": "MIT"
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.21.1",
       "hasInstallScript": true,
@@ -7648,14 +7633,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
-      }
-    },
-    "node_modules/css-in-js-utils": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
       }
     },
     "node_modules/css-loader": {
@@ -9736,13 +9713,6 @@
       "version": "2.0.6",
       "license": "MIT"
     },
-    "node_modules/fast-shallow-equal": {
-      "version": "1.0.0"
-    },
-    "node_modules/fastest-stable-stringify": {
-      "version": "2.0.2",
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "license": "ISC",
@@ -11115,10 +11085,6 @@
         "ms": "^2.0.0"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "license": "MIT",
@@ -11278,13 +11244,6 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "license": "ISC"
-    },
-    "node_modules/inline-style-prefixer": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "node_modules/inquirer": {
       "version": "8.2.2",
@@ -12382,6 +12341,7 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13313,10 +13273,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "license": "MIT"
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -14859,24 +14815,6 @@
     "node_modules/nan": {
       "version": "2.15.0",
       "license": "MIT"
-    },
-    "node_modules/nano-css": {
-      "version": "5.3.4",
-      "license": "Unlicense",
-      "dependencies": {
-        "css-tree": "^1.1.2",
-        "csstype": "^3.0.6",
-        "fastest-stable-stringify": "^2.0.2",
-        "inline-style-prefixer": "^6.0.0",
-        "rtl-css-js": "^1.14.0",
-        "sourcemap-codec": "^1.4.8",
-        "stacktrace-js": "^2.0.2",
-        "stylis": "^4.0.6"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
     },
     "node_modules/nanoclone": {
       "version": "0.2.1",
@@ -18051,37 +17989,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/react-universal-interface": {
-      "version": "0.6.2",
-      "peerDependencies": {
-        "react": "*",
-        "tslib": "*"
-      }
-    },
-    "node_modules/react-use": {
-      "version": "17.3.2",
-      "license": "Unlicense",
-      "dependencies": {
-        "@types/js-cookie": "^2.2.6",
-        "@xobotyi/scrollbar-width": "^1.9.5",
-        "copy-to-clipboard": "^3.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
-        "nano-css": "^5.3.1",
-        "react-universal-interface": "^0.6.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.1.0",
-        "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^3.0.1",
-        "ts-easing": "^0.2.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0  || ^17.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0"
-      }
-    },
     "node_modules/read-package-json": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-5.0.1.tgz",
@@ -18595,10 +18502,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "license": "MIT"
-    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "license": "MIT",
@@ -18811,13 +18714,6 @@
         "rsa-unpack": "bin/cmd.js"
       }
     },
-    "node_modules/rtl-css-js": {
-      "version": "1.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -18978,16 +18874,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/screenfull": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
@@ -19144,13 +19030,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "node_modules/set-harmonic-interval": {
-      "version": "1.0.1",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=6.9"
-      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -19548,13 +19427,6 @@
       "version": "0.1.8",
       "license": "MIT"
     },
-    "node_modules/stack-generator": {
-      "version": "2.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.1.1"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.5",
       "license": "MIT",
@@ -19575,30 +19447,6 @@
     "node_modules/stackframe": {
       "version": "1.2.1",
       "license": "MIT"
-    },
-    "node_modules/stacktrace-gps": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.1.1"
-      }
-    },
-    "node_modules/stacktrace-gps/node_modules/source-map": {
-      "version": "0.5.6",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stacktrace-js": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
-      }
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -19876,10 +19724,6 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.0.13",
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -20368,13 +20212,6 @@
       "version": "6.0.1",
       "license": "MIT"
     },
-    "node_modules/throttle-debounce": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "license": "MIT"
@@ -20462,10 +20299,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "license": "MIT"
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "license": "MIT",
@@ -20533,10 +20366,6 @@
       "bin": {
         "write-markdown": "dist/write-markdown.js"
       }
-    },
-    "node_modules/ts-easing": {
-      "version": "0.2.0",
-      "license": "Unlicense"
     },
     "node_modules/ts-essentials": {
       "version": "7.0.3",
@@ -22290,7 +22119,7 @@
     },
     "packages/common": {
       "name": "@bosonprotocol/common",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
@@ -22310,10 +22139,10 @@
     },
     "packages/core-sdk": {
       "name": "@bosonprotocol/core-sdk",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "1.1.0",
+        "@bosonprotocol/common": "1.1.1",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -22332,10 +22161,10 @@
     },
     "packages/eth-connect-sdk": {
       "name": "@bosonprotocol/eth-connect-sdk",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "1.1.0"
+        "@bosonprotocol/common": "1.1.1"
       },
       "devDependencies": {
         "eslint": "^8.10.0",
@@ -22351,10 +22180,10 @@
     },
     "packages/ethers-sdk": {
       "name": "@bosonprotocol/ethers-sdk",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "1.1.0"
+        "@bosonprotocol/common": "1.1.1"
       },
       "devDependencies": {
         "@typechain/ethers-v5": "^9.0.0",
@@ -22371,10 +22200,10 @@
     },
     "packages/example-parent-app": {
       "name": "@bosonprotocol/example-parent-app",
-      "version": "1.1.1-alpha.2",
+      "version": "1.1.1",
       "dependencies": {
-        "@bosonprotocol/ipfs-storage": "1.1.1-alpha.2",
-        "@bosonprotocol/widgets-sdk": "1.1.0",
+        "@bosonprotocol/ipfs-storage": "1.1.1",
+        "@bosonprotocol/widgets-sdk": "1.1.1",
         "@ethersproject/address": "^5.6.0",
         "@ethersproject/units": "^5.6.0",
         "@testing-library/jest-dom": "^5.16.2",
@@ -22403,10 +22232,10 @@
     },
     "packages/ipfs-storage": {
       "name": "@bosonprotocol/ipfs-storage",
-      "version": "1.1.1-alpha.2",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "1.1.0",
+        "@bosonprotocol/common": "1.1.1",
         "ipfs-http-client": "^56.0.1",
         "multiformats": "^9.6.4",
         "uint8arrays": "^3.0.0"
@@ -22535,7 +22364,7 @@
     },
     "packages/subgraph": {
       "name": "@bosonprotocol/subgraph",
-      "version": "1.1.1-alpha.3",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphprotocol/graph-cli": "0.26.0",
@@ -22549,12 +22378,12 @@
     },
     "packages/widgets": {
       "name": "@bosonprotocol/widgets",
-      "version": "1.1.1-alpha.2",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/core-sdk": "1.1.0",
-        "@bosonprotocol/ethers-sdk": "1.1.0",
-        "@bosonprotocol/ipfs-storage": "1.1.1-alpha.2",
+        "@bosonprotocol/core-sdk": "1.1.1",
+        "@bosonprotocol/ethers-sdk": "1.1.1",
+        "@bosonprotocol/ipfs-storage": "1.1.1",
         "@ethersproject/units": "^5.6.0",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
@@ -22587,15 +22416,18 @@
     },
     "packages/widgets-sdk": {
       "name": "@bosonprotocol/widgets-sdk",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "react-use": "^17.3.2",
         "styled-components": "^5.3.3"
       },
       "devDependencies": {
         "rimraf": "^3.0.2",
         "typescript": "^4.5.3"
+      },
+      "peerDependencies": {
+        "react": "17 - 18",
+        "react-dom": "17 - 18"
       }
     }
   },
@@ -23640,7 +23472,7 @@
     "@bosonprotocol/core-sdk": {
       "version": "file:packages/core-sdk",
       "requires": {
-        "@bosonprotocol/common": "1.1.0",
+        "@bosonprotocol/common": "1.1.1",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -23658,7 +23490,7 @@
     "@bosonprotocol/eth-connect-sdk": {
       "version": "file:packages/eth-connect-sdk",
       "requires": {
-        "@bosonprotocol/common": "1.1.0",
+        "@bosonprotocol/common": "1.1.1",
         "eslint": "^8.10.0",
         "eth-connect": "^6.0.2",
         "jest": "^27.5.1",
@@ -23670,7 +23502,7 @@
     "@bosonprotocol/ethers-sdk": {
       "version": "file:packages/ethers-sdk",
       "requires": {
-        "@bosonprotocol/common": "1.1.0",
+        "@bosonprotocol/common": "1.1.1",
         "@typechain/ethers-v5": "^9.0.0",
         "eslint": "^8.10.0",
         "jest": "^27.5.1",
@@ -23683,8 +23515,8 @@
     "@bosonprotocol/example-parent-app": {
       "version": "file:packages/example-parent-app",
       "requires": {
-        "@bosonprotocol/ipfs-storage": "1.1.1-alpha.2",
-        "@bosonprotocol/widgets-sdk": "1.1.0",
+        "@bosonprotocol/ipfs-storage": "1.1.1",
+        "@bosonprotocol/widgets-sdk": "1.1.1",
         "@ethersproject/address": "^5.6.0",
         "@ethersproject/units": "^5.6.0",
         "@testing-library/jest-dom": "^5.16.2",
@@ -23714,7 +23546,7 @@
     "@bosonprotocol/ipfs-storage": {
       "version": "file:packages/ipfs-storage",
       "requires": {
-        "@bosonprotocol/common": "1.1.0",
+        "@bosonprotocol/common": "1.1.1",
         "eslint": "^8.10.0",
         "ipfs-http-client": "^56.0.1",
         "jest": "^27.5.1",
@@ -23827,9 +23659,9 @@
     "@bosonprotocol/widgets": {
       "version": "file:packages/widgets",
       "requires": {
-        "@bosonprotocol/core-sdk": "1.1.0",
-        "@bosonprotocol/ethers-sdk": "1.1.0",
-        "@bosonprotocol/ipfs-storage": "1.1.1-alpha.2",
+        "@bosonprotocol/core-sdk": "1.1.1",
+        "@bosonprotocol/ethers-sdk": "1.1.1",
+        "@bosonprotocol/ipfs-storage": "1.1.1",
         "@ethersproject/units": "^5.6.0",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
@@ -23863,7 +23695,6 @@
     "@bosonprotocol/widgets-sdk": {
       "version": "file:packages/widgets-sdk",
       "requires": {
-        "react-use": "^17.3.2",
         "rimraf": "^3.0.2",
         "styled-components": "^5.3.3",
         "typescript": "^4.5.3"
@@ -25812,9 +25643,6 @@
         "pretty-format": "^27.0.0"
       }
     },
-    "@types/js-cookie": {
-      "version": "2.2.7"
-    },
     "@types/json-schema": {
       "version": "7.0.9"
     },
@@ -26184,9 +26012,6 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "@xobotyi/scrollbar-width": {
-      "version": "1.9.5"
     },
     "@xtuc/ieee754": {
       "version": "1.2.0"
@@ -27696,12 +27521,6 @@
     "cookie-signature": {
       "version": "1.0.6"
     },
-    "copy-to-clipboard": {
-      "version": "3.3.1",
-      "requires": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "core-js": {
       "version": "3.21.1"
     },
@@ -27802,13 +27621,6 @@
       "version": "3.0.4",
       "requires": {
         "postcss-selector-parser": "^6.0.9"
-      }
-    },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
       }
     },
     "css-loader": {
@@ -29173,12 +28985,6 @@
     "fast-levenshtein": {
       "version": "2.0.6"
     },
-    "fast-shallow-equal": {
-      "version": "1.0.0"
-    },
-    "fastest-stable-stringify": {
-      "version": "2.0.2"
-    },
     "fastq": {
       "version": "1.13.0",
       "requires": {
@@ -30079,9 +29885,6 @@
         "ms": "^2.0.0"
       }
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4"
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "requires": {
@@ -30165,12 +29968,6 @@
     },
     "ini": {
       "version": "1.3.8"
-    },
-    "inline-style-prefixer": {
-      "version": "6.0.1",
-      "requires": {
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "inquirer": {
       "version": "8.2.2",
@@ -30940,7 +30737,8 @@
       "version": "0.4.7"
     },
     "isobject": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "isomorphic-ws": {
       "version": "4.0.1",
@@ -31602,9 +31400,6 @@
           }
         }
       }
-    },
-    "js-cookie": {
-      "version": "2.2.1"
     },
     "js-sha3": {
       "version": "0.8.0"
@@ -32702,19 +32497,6 @@
     },
     "nan": {
       "version": "2.15.0"
-    },
-    "nano-css": {
-      "version": "5.3.4",
-      "requires": {
-        "css-tree": "^1.1.2",
-        "csstype": "^3.0.6",
-        "fastest-stable-stringify": "^2.0.2",
-        "inline-style-prefixer": "^6.0.0",
-        "rtl-css-js": "^1.14.0",
-        "sourcemap-codec": "^1.4.8",
-        "stacktrace-js": "^2.0.2",
-        "stylis": "^4.0.6"
-      }
     },
     "nanoclone": {
       "version": "0.2.1",
@@ -34744,29 +34526,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-universal-interface": {
-      "version": "0.6.2",
-      "requires": {}
-    },
-    "react-use": {
-      "version": "17.3.2",
-      "requires": {
-        "@types/js-cookie": "^2.2.6",
-        "@xobotyi/scrollbar-width": "^1.9.5",
-        "copy-to-clipboard": "^3.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
-        "nano-css": "^5.3.1",
-        "react-universal-interface": "^0.6.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.1.0",
-        "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^3.0.1",
-        "ts-easing": "^0.2.0",
-        "tslib": "^2.1.0"
-      }
-    },
     "read-package-json": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-5.0.1.tgz",
@@ -35146,9 +34905,6 @@
     "requires-port": {
       "version": "1.0.0"
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1"
-    },
     "resolve": {
       "version": "1.22.0",
       "requires": {
@@ -35277,12 +35033,6 @@
         "optimist": "~0.3.5"
       }
     },
-    "rtl-css-js": {
-      "version": "1.15.0",
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -35358,9 +35108,6 @@
           "requires": {}
         }
       }
-    },
-    "screenfull": {
-      "version": "5.2.0"
     },
     "scrypt-js": {
       "version": "3.0.1",
@@ -35484,9 +35231,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "set-harmonic-interval": {
-      "version": "1.0.1"
     },
     "setprototypeof": {
       "version": "1.2.0"
@@ -35770,12 +35514,6 @@
     "stable": {
       "version": "0.1.8"
     },
-    "stack-generator": {
-      "version": "2.0.5",
-      "requires": {
-        "stackframe": "^1.1.1"
-      }
-    },
     "stack-utils": {
       "version": "2.0.5",
       "requires": {
@@ -35789,26 +35527,6 @@
     },
     "stackframe": {
       "version": "1.2.1"
-    },
-    "stacktrace-gps": {
-      "version": "3.0.4",
-      "requires": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.1.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.6"
-        }
-      }
-    },
-    "stacktrace-js": {
-      "version": "2.0.2",
-      "requires": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
-      }
     },
     "statuses": {
       "version": "1.5.0"
@@ -35978,9 +35696,6 @@
         "browserslist": "^4.16.6",
         "postcss-selector-parser": "^6.0.4"
       }
-    },
-    "stylis": {
-      "version": "4.0.13"
     },
     "supports-color": {
       "version": "7.2.0",
@@ -36304,9 +36019,6 @@
     "throat": {
       "version": "6.0.1"
     },
-    "throttle-debounce": {
-      "version": "3.0.1"
-    },
     "through": {
       "version": "2.3.8"
     },
@@ -36374,9 +36086,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "toggle-selection": {
-      "version": "1.0.6"
-    },
     "toidentifier": {
       "version": "1.0.1"
     },
@@ -36421,9 +36130,6 @@
         "command-line-usage": "^6.1.0",
         "string-format": "^2.0.0"
       }
-    },
-    "ts-easing": {
-      "version": "0.2.0"
     },
     "ts-essentials": {
       "version": "7.0.3",

--- a/packages/widgets-sdk/package.json
+++ b/packages/widgets-sdk/package.json
@@ -26,7 +26,6 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "react-use": "^17.3.2",
     "styled-components": "^5.3.3"
   }
 }

--- a/packages/widgets-sdk/src/lib/Modal.tsx
+++ b/packages/widgets-sdk/src/lib/Modal.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from "react";
 import styled from "styled-components";
-import useLockBodyScroll from "react-use/lib/useLockBodyScroll";
 
 const Root = styled.div`
   display: flex;
@@ -20,7 +19,5 @@ interface Props {
 }
 
 export function Modal({ children }: Props) {
-  useLockBodyScroll();
-
   return <Root>{children}</Root>;
 }


### PR DESCRIPTION
## Description

remove react-use as it does not support react v18 yet (https://github.com/streamich/react-use/pull/2313)

- by doing this we will not lock the body scroll anymore, which is a tiny issue compared to the issue of not being able to use this widgets-sdk in another repo that uses react v18


