### PR TITLE
feat(subgraph): enrich metadata schemas with fields from offer

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -18,6 +18,14 @@ interface MetadataInterface {
   offer: Offer!
   "Reference to related Seller entity"
   seller: Seller!
+  "Reference to related ExchangeToken entity"
+  exchangeToken: ExchangeToken!
+  """
+  Enriched fields from offer entity to allow nested query workaround
+  """
+  voided: Boolean!
+  validFromDate: BigInt!
+  validUntilDate: BigInt!
 }
 
 type BaseMetadataEntity implements MetadataInterface @entity {
@@ -29,6 +37,10 @@ type BaseMetadataEntity implements MetadataInterface @entity {
   type: MetadataType! # MetadataType.BASE
   offer: Offer!
   seller: Seller!
+  exchangeToken: ExchangeToken!
+  voided: Boolean!
+  validFromDate: BigInt!
+  validUntilDate: BigInt!
 }
 
 type ProductV1MetadataEntity implements MetadataInterface @entity {
@@ -40,12 +52,23 @@ type ProductV1MetadataEntity implements MetadataInterface @entity {
   type: MetadataType! # MetadataType.PRODUCT
   offer: Offer!
   seller: Seller!
+  exchangeToken: ExchangeToken!
+  voided: Boolean!
+  validFromDate: BigInt!
+  validUntilDate: BigInt!
   """
   ProductV1MetadataEntity specific fields
   """
   images: [String!]
   tags: [String!]
   brandName: String
+  brand: ProductV1Brand!
+}
+
+type ProductV1Brand @entity {
+  id: ID!
+  name: String!
+  products: [ProductV1MetadataEntity!]! @derivedFrom(field: "brand")
 }
 
 """

--- a/packages/subgraph/src/entities/metadata/base.ts
+++ b/packages/subgraph/src/entities/metadata/base.ts
@@ -1,22 +1,33 @@
 import { JSONValue, TypedMap } from "@graphprotocol/graph-ts";
+import { IBosonOfferHandler__getOfferResultOfferStruct } from "../../../generated/OfferHandler/IBosonOfferHandler";
 import { BaseMetadataEntity } from "../../../generated/schema";
 
 import { convertToString } from "../../utils/json";
 
 export function saveBaseMetadata(
-  offerId: string,
-  seller: string,
+  offerFromContract: IBosonOfferHandler__getOfferResultOfferStruct,
   metadataObj: TypedMap<string, JSONValue>
 ): string {
+  const offerId = offerFromContract.id.toString();
   const metadataId = offerId + "-metadata";
   const name = convertToString(metadataObj.get("name"));
   const description = convertToString(metadataObj.get("description"));
   const externalUrl = convertToString(metadataObj.get("external_url"));
   const schemaUrl = convertToString(metadataObj.get("schema_url"));
 
-  const baseMetadataEntity = new BaseMetadataEntity(metadataId);
+  let baseMetadataEntity = BaseMetadataEntity.load(metadataId);
+
+  if (baseMetadataEntity == null) {
+    baseMetadataEntity = new BaseMetadataEntity(metadataId);
+  }
+
   baseMetadataEntity.offer = offerId;
-  baseMetadataEntity.seller = seller;
+  baseMetadataEntity.seller = offerFromContract.seller.toHexString();
+  baseMetadataEntity.exchangeToken =
+    offerFromContract.exchangeToken.toHexString();
+  baseMetadataEntity.voided = offerFromContract.voided;
+  baseMetadataEntity.validFromDate = offerFromContract.validFromDate;
+  baseMetadataEntity.validUntilDate = offerFromContract.validUntilDate;
   baseMetadataEntity.type = "BASE";
   baseMetadataEntity.name = name;
   baseMetadataEntity.description = description;

--- a/packages/subgraph/src/entities/metadata/handler.ts
+++ b/packages/subgraph/src/entities/metadata/handler.ts
@@ -1,19 +1,19 @@
 import { log } from "@graphprotocol/graph-ts";
+import { IBosonOfferHandler__getOfferResultOfferStruct } from "../../../generated/OfferHandler/IBosonOfferHandler";
 import { saveProductV1Metadata } from "./product-v1";
 import { saveBaseMetadata } from "./base";
 import { getIpfsMetadataObject } from "../../utils/ipfs";
 import { convertToString } from "../../utils/json";
 
 export function saveMetadata(
-  ipfsHash: string,
-  offerId: string,
-  seller: string
+  offerFromContract: IBosonOfferHandler__getOfferResultOfferStruct
 ): string | null {
+  const ipfsHash = offerFromContract.metadataHash;
   const metadataObj = getIpfsMetadataObject(ipfsHash);
 
   if (metadataObj === null) {
     log.warning("Could not load metadata for offer with id: {}, ipfsHash: {}", [
-      offerId,
+      offerFromContract.id.toString(),
       ipfsHash
     ]);
     return null;
@@ -22,11 +22,11 @@ export function saveMetadata(
   const metadataType = convertToString(metadataObj.get("type"));
 
   if (metadataType == "BASE") {
-    return saveBaseMetadata(offerId, seller, metadataObj);
+    return saveBaseMetadata(offerFromContract, metadataObj);
   }
 
   if (metadataType == "PRODUCT_V1") {
-    return saveProductV1Metadata(offerId, seller, metadataObj);
+    return saveProductV1Metadata(offerFromContract, metadataObj);
   }
 
   return null;

--- a/packages/subgraph/src/entities/metadata/product-v1.ts
+++ b/packages/subgraph/src/entities/metadata/product-v1.ts
@@ -1,13 +1,17 @@
 import { JSONValue, TypedMap } from "@graphprotocol/graph-ts";
-import { ProductV1MetadataEntity } from "../../../generated/schema";
+import { IBosonOfferHandler__getOfferResultOfferStruct } from "../../../generated/OfferHandler/IBosonOfferHandler";
+import {
+  ProductV1MetadataEntity,
+  ProductV1Brand
+} from "../../../generated/schema";
 
 import { convertToString, convertToStringArray } from "../../utils/json";
 
 export function saveProductV1Metadata(
-  offerId: string,
-  seller: string,
+  offerFromContract: IBosonOfferHandler__getOfferResultOfferStruct,
   metadataObj: TypedMap<string, JSONValue>
 ): string {
+  const offerId = offerFromContract.id.toString();
   const metadataId = offerId + "-metadata";
   const name = convertToString(metadataObj.get("name"));
   const description = convertToString(metadataObj.get("description"));
@@ -18,10 +22,22 @@ export function saveProductV1Metadata(
   const tags = convertToStringArray(metadataObj.get("tags"));
   const brandName = convertToString(metadataObj.get("brandName"));
 
-  const productV1MetadataEntity = new ProductV1MetadataEntity(metadataId);
+  saveProductV1Brand(brandName);
+
+  let productV1MetadataEntity = ProductV1MetadataEntity.load(metadataId);
+
+  if (productV1MetadataEntity == null) {
+    productV1MetadataEntity = new ProductV1MetadataEntity(metadataId);
+  }
+
   productV1MetadataEntity.type = "PRODUCT_V1";
   productV1MetadataEntity.offer = offerId;
-  productV1MetadataEntity.seller = seller;
+  productV1MetadataEntity.seller = offerFromContract.seller.toHexString();
+  productV1MetadataEntity.exchangeToken =
+    offerFromContract.exchangeToken.toHexString();
+  productV1MetadataEntity.voided = offerFromContract.voided;
+  productV1MetadataEntity.validFromDate = offerFromContract.validFromDate;
+  productV1MetadataEntity.validUntilDate = offerFromContract.validUntilDate;
   productV1MetadataEntity.name = name;
   productV1MetadataEntity.description = description;
   productV1MetadataEntity.externalUrl = externalUrl;
@@ -29,6 +45,18 @@ export function saveProductV1Metadata(
   productV1MetadataEntity.images = images;
   productV1MetadataEntity.tags = tags;
   productV1MetadataEntity.brandName = brandName;
+  productV1MetadataEntity.brand = brandName.toLowerCase();
   productV1MetadataEntity.save();
   return metadataId;
+}
+
+function saveProductV1Brand(brandName: string): void {
+  const brandId = brandName.toLowerCase();
+  let brand = ProductV1Brand.load(brandId);
+
+  if (brand == null) {
+    brand = new ProductV1Brand(brandId);
+    brand.name = brandName;
+    brand.save();
+  }
 }

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -22,12 +22,8 @@ export function handleOfferCreatedEvent(event: OfferCreated): void {
       const offerFromContract = result.value.value1;
 
       saveSeller(offerFromContract.seller);
-      saveMetadata(
-        offerFromContract.metadataHash,
-        offerId.toString(),
-        offerFromContract.seller.toHexString()
-      );
       saveExchangeToken(offerFromContract.exchangeToken);
+      saveMetadata(offerFromContract);
 
       offer = new Offer(offerId.toString());
       offer.createdAt = event.block.timestamp;

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -20,6 +20,7 @@ dataSources:
         - Metadata
         - Seller
         - ExchangeToken
+        - ProductV1Brand
       abis:
         - name: IBosonOfferHandler
           file: ../common/src/abis/IBosonOfferHandler.json


### PR DESCRIPTION
The Graph currently does not support nested queries.
As a workaround, we enrich the `MetadataInterface` with respective fields
from the related offer entity for improved filtering.
