### PR TITLE
ci: change widgets deploy workflows to support staging

### DIFF
--- a/.github/workflows/deploy-prod-widgets.yaml
+++ b/.github/workflows/deploy-prod-widgets.yaml
@@ -1,12 +1,11 @@
-name: Deploy widgets to IPFS
+name: Deploy production widgets to IPFS
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    branches: [main]
 
 jobs:
   deploy:
-    if: startsWith(github.event.release.tag_name, '@bosonprotocol/widgets@')
     runs-on: ubuntu-latest
     name: Deploy widgets to IPFS
     steps:

--- a/.github/workflows/deploy-staging-widgets.yaml
+++ b/.github/workflows/deploy-staging-widgets.yaml
@@ -1,0 +1,29 @@
+name: Deploy staging widgets
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    if: startsWith(github.event.release.tag_name, '@bosonprotocol/widgets@')
+    runs-on: ubuntu-latest
+    name: Deploy widgets
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "npm"
+      - name: Turbo Cache
+        id: turbo-cache
+        uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}
+      - run: npm install -g surge
+      - run: npm ci
+      - run: npm run build -- --cache-dir=".turbo"
+      - run: surge ./packages/widgets/build https://boson-widgets-staging.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/deploy-testing-widgets.yaml
+++ b/.github/workflows/deploy-testing-widgets.yaml
@@ -1,4 +1,4 @@
-name: Deploy to surge
+name: Deploy testing widgets
 
 on:
   workflow_dispatch:
@@ -10,12 +10,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: Deploy widgets and example parent
-    env:
-      REACT_APP_WIDGETS_URL: https://boson-widgets-test.surge.sh
-      REACT_APP_CHAIN_ID: 3
-      REACT_APP_IPFS_METADATA_URL: https://ipfs.infura.io:5001
-      REACT_APP_METADATA_BASE_URL: https://ipfs.io/ipfs
+    name: Deploy widgets
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -33,4 +28,4 @@ jobs:
       - run: npm install -g surge
       - run: npm ci
       - run: npm run build -- --cache-dir=".turbo"
-      - run: surge ./packages/widgets/build ${{ env.REACT_APP_WIDGETS_URL }} --token ${{ secrets.SURGE_TOKEN }}
+      - run: surge ./packages/widgets/build https://boson-widgets-testing.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
## Description

This adds a new workflow to support staging env widgets.

- Push to main -> deploy testing env widgets
- Created release -> deploy staging env widgets
- Manual workflow trigger -> deploy prod env widgets to IPFS
