### PR TITLE
build: remove exact flag from lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,6 @@
       "ignoreChanges": ["*.md"],
       "message": "chore(release): publish latest [skip ci]",
       "conventionalCommits": true,
-      "exact": true,
       "verifyAccess": false
     }
   },


### PR DESCRIPTION
For some reason, the lockfile gets updated wrongly when setting the
`--exact` flag to `true`. See for example https://github.com/bosonprotocol/core-components/commit/48a876f57226b2eb9fcf93f225918dd251850dcf#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L22145
Turning it off mitigates the wrong lockfile update.