### PR TITLE
feat(core-sdk): get seller by address method

### DIFF
--- a/packages/core-sdk/src/accounts/subgraph.ts
+++ b/packages/core-sdk/src/accounts/subgraph.ts
@@ -35,3 +35,64 @@ export async function getSellerByOperator(
 
   return sellers[0];
 }
+
+export const getSellerByAdminQuery = `
+query GetSellersByAdmin($admin: String!) {
+  sellers(where: {
+    admin: $admin
+  }) {
+    ...sellerFields
+  }
+}
+${sellerFieldsFragment}
+`;
+
+export async function getSellerByAdmin(
+  subgraphUrl: string,
+  adminAddress: string
+): Promise<RawSellerFromSubgraph> {
+  const { sellers } = await fetchSubgraph<{ sellers: RawSellerFromSubgraph }>(
+    subgraphUrl,
+    getSellerByOperatorQuery,
+    { admin: adminAddress }
+  );
+
+  return sellers[0];
+}
+
+export const getSellerByClerkQuery = `
+query GetSellersByOperator($clerk: String!) {
+  sellers(where: {
+    clerk: $clerk
+  }) {
+    ...sellerFields
+  }
+}
+${sellerFieldsFragment}
+`;
+
+export async function getSellerByClerk(
+  subgraphUrl: string,
+  clerkAddress: string
+): Promise<RawSellerFromSubgraph> {
+  const { sellers } = await fetchSubgraph<{ sellers: RawSellerFromSubgraph }>(
+    subgraphUrl,
+    getSellerByOperatorQuery,
+    { clerk: clerkAddress }
+  );
+
+  return sellers[0];
+}
+
+export async function getSellerByAddress(
+  subgraphUrl: string,
+  address: string
+): Promise<RawSellerFromSubgraph> {
+  const [operator, admin, clerk] = await Promise.all([
+    getSellerByOperator(subgraphUrl, address),
+    getSellerByAdmin(subgraphUrl, address),
+    getSellerByClerk(subgraphUrl, address)
+  ]);
+
+  return operator || admin || clerk;
+}

--- a/packages/core-sdk/src/core-sdk.ts
+++ b/packages/core-sdk/src/core-sdk.ts
@@ -80,6 +80,12 @@ export class CoreSDK {
     return accounts.subgraph.getSellerByOperator(this._subgraphUrl, operator);
   }
 
+  public async getSellerByAddress(
+    address: string
+  ): Promise<accounts.RawSellerFromSubgraph> {
+    return accounts.subgraph.getSellerByAddress(this._subgraphUrl, address);
+  }
+
   public async createSellerAndOffer(
     sellerToCreate: accounts.CreateSellerArgs,
     offerToCreate: offers.CreateOfferArgs,

--- a/packages/core-sdk/tests/accounts/subgraph.test.ts
+++ b/packages/core-sdk/tests/accounts/subgraph.test.ts
@@ -1,0 +1,115 @@
+import { getSellerByAddress } from "../../src/accounts/subgraph";
+import { ADDRESS } from "@bosonprotocol/common/tests/mocks";
+import {
+  SUBGRAPH_URL,
+  interceptSubgraph,
+  mockRawSellerFromSubgraph
+} from "../mocks";
+
+describe("#getSellerByAddress()", () => {
+  test("return falsy if address no seller", async () => {
+    interceptSubgraph()
+      .times(3)
+      .reply(200, {
+        data: {
+          sellers: []
+        }
+      });
+
+    const rawSeller = await getSellerByAddress(SUBGRAPH_URL, ADDRESS);
+
+    expect(rawSeller).toBeFalsy();
+  });
+  test("return seller if address is operator", async () => {
+    const mockedRawSellerFromSubgraph = mockRawSellerFromSubgraph({
+      operator: ADDRESS
+    });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: [mockedRawSellerFromSubgraph]
+        }
+      });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: []
+        }
+      });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: []
+        }
+      });
+
+    const rawSeller = await getSellerByAddress(SUBGRAPH_URL, ADDRESS);
+
+    expect(rawSeller).toMatchObject(mockedRawSellerFromSubgraph);
+  });
+
+  test("return seller if address is admin", async () => {
+    const mockedRawSellerFromSubgraph = mockRawSellerFromSubgraph({
+      admin: ADDRESS
+    });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: []
+        }
+      });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: [mockedRawSellerFromSubgraph]
+        }
+      });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: []
+        }
+      });
+
+    const rawSeller = await getSellerByAddress(SUBGRAPH_URL, ADDRESS);
+
+    expect(rawSeller).toMatchObject(mockedRawSellerFromSubgraph);
+  });
+
+  test("return seller if address is clerk", async () => {
+    const mockedRawSellerFromSubgraph = mockRawSellerFromSubgraph({
+      clerk: ADDRESS
+    });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: []
+        }
+      });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: []
+        }
+      });
+    interceptSubgraph()
+      .times(1)
+      .reply(200, {
+        data: {
+          sellers: [mockedRawSellerFromSubgraph]
+        }
+      });
+
+    const rawSeller = await getSellerByAddress(SUBGRAPH_URL, ADDRESS);
+
+    expect(rawSeller).toMatchObject(mockedRawSellerFromSubgraph);
+  });
+});

--- a/packages/core-sdk/tests/mocks.ts
+++ b/packages/core-sdk/tests/mocks.ts
@@ -1,15 +1,30 @@
 import { RawOfferFromSubgraph } from "../src/offers/types";
+import { RawSellerFromSubgraph } from "../src/accounts/types";
 import { MetadataType, utils } from "@bosonprotocol/common";
 import nock from "nock";
 
 export const SUBGRAPH_URL = "https://subgraph.com/subgraphs";
-
 export const DAY_IN_MS = 24 * 60 * 60 * 1000;
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export function interceptSubgraph() {
   return nock(SUBGRAPH_URL).post("", (body) => {
     return body.query && body.variables;
   });
+}
+
+export function mockRawSellerFromSubgraph(
+  overrides: Partial<RawSellerFromSubgraph> = {}
+): RawSellerFromSubgraph {
+  return {
+    id: "1",
+    admin: ZERO_ADDRESS,
+    clerk: ZERO_ADDRESS,
+    operator: ZERO_ADDRESS,
+    treasury: ZERO_ADDRESS,
+    active: true,
+    ...overrides
+  };
 }
 
 export function mockRawOfferFromSubgraph(
@@ -39,15 +54,15 @@ export function mockRawOfferFromSubgraph(
     voidedAt: null,
     seller: {
       id: "1",
-      operator: "0x0000000000000000000000000000000000000000",
-      admin: "0x0000000000000000000000000000000000000000",
-      clerk: "0x0000000000000000000000000000000000000000",
-      treasury: "0x0000000000000000000000000000000000000000",
+      operator: ZERO_ADDRESS,
+      admin: ZERO_ADDRESS,
+      clerk: ZERO_ADDRESS,
+      treasury: ZERO_ADDRESS,
       active: true,
       ...seller
     },
     exchangeToken: {
-      address: "0x0000000000000000000000000000000000000000",
+      address: ZERO_ADDRESS,
       decimals: "18",
       name: "Ether",
       symbol: "ETH",


### PR DESCRIPTION
## Description

Add method to core-sdk which queries the subgraph for a seller by account.

## How to test


```js
const seller = await coreSDK.getSellerByAddress(address)
// falsy if no seller entity on subgraph
```
