### PR TITLE
fix(subgraph): correctly store sellerId in offer entity

### DIFF
--- a/packages/subgraph/src/mappings/offer-handler.ts
+++ b/packages/subgraph/src/mappings/offer-handler.ts
@@ -27,6 +27,7 @@ export function handleOfferCreatedEvent(event: OfferCreated): void {
     offer.redeemableFromDate = offerStruct.redeemableFromDate;
     offer.fulfillmentPeriodDuration = offerStruct.fulfillmentPeriodDuration;
     offer.voucherValidDuration = offerStruct.voucherValidDuration;
+    offer.sellerId = offerStruct.sellerId;
     offer.seller = offerStruct.sellerId.toString();
     offer.exchangeToken = offerStruct.exchangeToken.toHexString();
     offer.metadataUri = offerStruct.metadataUri;


### PR DESCRIPTION
## Description

The `sellerId` was not correctly stored in the `offer` entity, which led to some misbehaving subgraph queries.

