### PR TITLE
fix: ipfs service in docker-compose

### DIFF
--- a/utils/graph/docker-compose.yml
+++ b/utils/graph/docker-compose.yml
@@ -1,13 +1,13 @@
-version: '3'
+version: "3"
 services:
   graph-node:
     image: graphprotocol/graph-node
     ports:
-      - '8000:8000'
-      - '8001:8001'
-      - '8020:8020'
-      - '8030:8030'
-      - '8040:8040'
+      - "8000:8000"
+      - "8001:8001"
+      - "8020:8020"
+      - "8030:8030"
+      - "8040:8040"
     depends_on:
       - ipfs
       - postgres
@@ -18,26 +18,24 @@ services:
       postgres_user: graph-node
       postgres_pass: let-me-in
       postgres_db: graph-node
-      ipfs: 'ipfs:5001'
-      ethereum: 'mainnet:https://geth.bsn-development-potassium.bosonportal.io/ac012be65837ebc3134e/rpc'
+      ipfs: "ipfs:5001"
+      ethereum: "mainnet:https://geth.bsn-development-potassium.bosonportal.io/ac012be65837ebc3134e/rpc"
       GRAPH_LOG: info
       GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: "true"
 
   ipfs:
-    image: ipfs/go-ipfs:v0.4.23
+    image: ipfs/go-ipfs:master-2022-05-25-e8f1ce0
     ports:
-      - '5001:5001'
+      - "5001:5001"
     volumes:
       - ./data/ipfs:/data/ipfs
+      - ./ipfs-config.sh:/container-init.d/ipfs-config.sh
+
   postgres:
     image: postgres
     ports:
-      - '5432:5432'
-    command:
-      [
-        "postgres",
-        "-cshared_preload_libraries=pg_stat_statements"
-      ]
+      - "5432:5432"
+    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
     environment:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in

--- a/utils/graph/ipfs-config.sh
+++ b/utils/graph/ipfs-config.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "Setting IPFS config..."
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'


### PR DESCRIPTION
## Description

The IPFS service was throwing `403: Forbidden` when trying to hit the API.
We fix this by adding a script to the`container-init.d` folder which is
part of v0.13 (not released yet).
See https://github.com/ipfs/go-ipfs/issues/8640
