### PR TITLE
fix: add exchangeId query param in the manage-offer widget if it's truthy only

### DIFF
--- a/packages/widgets-sdk/src/widgets/manage-offer/index.tsx
+++ b/packages/widgets-sdk/src/widgets/manage-offer/index.tsx
@@ -54,10 +54,10 @@ function ManageOfferWidget({
 
   const urlParams = new URLSearchParams({
     offerId,
-    exchangeId,
     chainId,
     ipfsMetadataUrl,
-    ...(forceBuyerView && { forceBuyerView })
+    ...(forceBuyerView && { forceBuyerView }),
+    ...(exchangeId && { exchangeId })
   } as unknown as Record<string, string>).toString();
 
   return (


### PR DESCRIPTION
## Description

fix: add exchangeId query param in the manage-offer widget if it's truthy only
