### PR TITLE
feat: remove valid from/until fields in manage-exchange widget

### DIFF
--- a/packages/widgets/src/lib/components/details/ExchangeDetails.tsx
+++ b/packages/widgets/src/lib/components/details/ExchangeDetails.tsx
@@ -1,0 +1,185 @@
+import { utils, BigNumberish, BigNumber } from "ethers";
+import {
+  Row,
+  Entry,
+  Label,
+  Value,
+  Spacer,
+  Money,
+  Currency
+} from "./shared-styles";
+import { formatDate } from "./shared-utils";
+
+interface Props {
+  currencySymbol: string;
+  currencyDecimals?: number;
+  quantityAvailable?: BigNumberish;
+  quantityInitial?: BigNumberish;
+  priceInWei: BigNumberish;
+  buyerCancelPenaltyInWei: BigNumberish;
+  sellerDepositInWei: BigNumberish;
+  voucherRedeemableFromDateInMS: BigNumberish;
+  voucherRedeemableUntilDateInMS: BigNumberish;
+  voucherValidDurationInMS?: BigNumberish;
+  metadataUri: string;
+  offerChecksum?: string;
+  protocolFeeInWei: BigNumberish;
+  fulfillmentPeriodInMS: BigNumberish;
+  resolutionPeriodInMS: BigNumberish;
+}
+
+export function ExchangeDetails({
+  currencySymbol,
+  currencyDecimals = 18,
+  quantityInitial,
+  quantityAvailable,
+  priceInWei,
+  buyerCancelPenaltyInWei,
+  sellerDepositInWei,
+  voucherRedeemableFromDateInMS,
+  voucherRedeemableUntilDateInMS,
+  voucherValidDurationInMS,
+  metadataUri,
+  offerChecksum,
+  protocolFeeInWei,
+  fulfillmentPeriodInMS,
+  resolutionPeriodInMS
+}: Props) {
+  return (
+    <>
+      <Row>
+        {quantityAvailable && (
+          <Entry>
+            <Label>Available (Qty.)</Label>
+            <Value title={quantityAvailable.toString()}>
+              {quantityAvailable}
+            </Value>
+          </Entry>
+        )}
+        {quantityInitial && (
+          <Entry>
+            <Label>Initial (Qty.)</Label>
+            <Value title={quantityInitial.toString()}>{quantityInitial}</Value>
+          </Entry>
+        )}
+      </Row>
+      <Row>
+        <Entry>
+          <Label>Price</Label>
+          <Money>
+            <Value title={utils.formatUnits(priceInWei, currencyDecimals)}>
+              {utils.formatUnits(priceInWei, currencyDecimals)}
+            </Value>
+            <Currency>{currencySymbol}</Currency>
+          </Money>
+        </Entry>
+        <Entry>
+          <Label>Cancellation Penalty</Label>
+          <Money>
+            <Value
+              title={utils.formatUnits(
+                buyerCancelPenaltyInWei,
+                currencyDecimals
+              )}
+            >
+              {utils.formatUnits(buyerCancelPenaltyInWei, currencyDecimals)}
+            </Value>
+            <Currency>{currencySymbol}</Currency>
+          </Money>
+        </Entry>
+      </Row>
+      <Row>
+        <Entry>
+          <Label>Seller Deposit</Label>
+          <Money>
+            <Value
+              title={utils.formatUnits(sellerDepositInWei, currencyDecimals)}
+            >
+              {utils.formatUnits(sellerDepositInWei, currencyDecimals)}
+            </Value>
+            <Currency>{currencySymbol}</Currency>
+          </Money>
+        </Entry>
+        <Entry>
+          <Label>Protocol Fee</Label>
+          <Money>
+            <Value
+              title={utils.formatUnits(protocolFeeInWei, currencyDecimals)}
+            >
+              {utils.formatUnits(protocolFeeInWei, currencyDecimals)}
+            </Value>
+            <Currency>{currencySymbol}</Currency>
+          </Money>
+        </Entry>
+      </Row>
+      <Spacer />
+      <Row>
+        <Entry>
+          <Label>Redeemable From</Label>
+          <Value title={formatDate(voucherRedeemableFromDateInMS.toString())}>
+            {formatDate(voucherRedeemableFromDateInMS.toString())}
+          </Value>
+        </Entry>
+        <Entry>
+          <Label>Redeemable Until</Label>
+          <Value
+            title={getRedeemableUntilDate({
+              voucherRedeemableFromDateInMS,
+              voucherRedeemableUntilDateInMS,
+              voucherValidDurationInMS
+            })}
+          >
+            {getRedeemableUntilDate({
+              voucherRedeemableFromDateInMS,
+              voucherRedeemableUntilDateInMS,
+              voucherValidDurationInMS
+            })}
+          </Value>
+        </Entry>
+      </Row>
+      <Row>
+        <Entry>
+          <Label>Fulfillment Period</Label>
+          <Value title={fulfillmentPeriodInMS.toString()}>
+            {fulfillmentPeriodInMS}
+          </Value>
+        </Entry>
+        <Entry>
+          <Label>Resolution Period</Label>
+          <Value title={resolutionPeriodInMS.toString()}>
+            {resolutionPeriodInMS.toString()}
+          </Value>
+        </Entry>
+      </Row>
+      <Spacer />
+      <Row>
+        <Entry>
+          <Label>Metadata URI</Label>
+          <Value title={metadataUri}>{metadataUri}</Value>
+        </Entry>
+        {offerChecksum && (
+          <Entry>
+            <Label>Offer Checksum</Label>
+            <Value title={offerChecksum}>{offerChecksum}</Value>
+          </Entry>
+        )}
+      </Row>
+    </>
+  );
+}
+
+function getRedeemableUntilDate(args: {
+  voucherRedeemableFromDateInMS: BigNumberish;
+  voucherRedeemableUntilDateInMS: BigNumberish;
+  voucherValidDurationInMS?: BigNumberish;
+}) {
+  if (BigNumber.from(args.voucherRedeemableUntilDateInMS).gt(0)) {
+    return formatDate(args.voucherRedeemableUntilDateInMS.toString());
+  }
+
+  return formatDate(
+    BigNumber.from(args.voucherRedeemableFromDateInMS)
+      .add(BigNumber.from(args.voucherValidDurationInMS))
+      .toString()
+  );
+}

--- a/packages/widgets/src/views/manage-exchange/index.tsx
+++ b/packages/widgets/src/views/manage-exchange/index.tsx
@@ -11,7 +11,7 @@ import { SellerActions } from "./SellerActions";
 import { useManageExchangeData } from "./useManageExchangeData";
 import { hooks } from "../../lib/connectors/metamask";
 import { BuyerActions } from "./BuyerActions";
-import { OfferDetails } from "../../lib/components/details/OfferDetails";
+import { ExchangeDetails } from "../../lib/components/details/ExchangeDetails";
 import { isAccountSeller } from "../../lib/seller";
 import { ActionsWrapper } from "../../lib/components/actions/ActionsWrapper";
 import { getExchangeState } from "../../lib/exchanges";
@@ -54,14 +54,12 @@ export default function ManageExchange() {
           <Value>{exchangeState}</Value>
         </Entry>
       </Row>
-      <OfferDetails
+      <ExchangeDetails
         protocolFeeInWei={offer.protocolFee}
         currencySymbol={offer.exchangeToken.symbol}
         priceInWei={offer.price}
         buyerCancelPenaltyInWei={offer.buyerCancelPenalty}
         sellerDepositInWei={offer.sellerDeposit}
-        validFromDateInMS={Number(offer.validFromDate) * 1000}
-        validUntilDateInMS={Number(offer.validUntilDate) * 1000}
         voucherRedeemableFromDateInMS={
           Number(offer.voucherRedeemableFromDate) * 1000
         }


### PR DESCRIPTION
## Description

feat: remove valid from/until fields in manage-exchange widget

- I duplicated the OfferDetails and then remove those 2 fields