### PR TITLE
build: extend local deploy script

### DIFF
--- a/contracts/scripts/deploy.js
+++ b/contracts/scripts/deploy.js
@@ -234,7 +234,13 @@ async function main() {
     wallet: deployer,
     active: true
   });
-  console.log(`✅ Dispute resolver deployed. \n`);
+  console.log(`✅ Dispute resolver deployed.`);
+
+  // Deploy ERC20-compliant mock token for testing
+  if (hre.network.name === "localhost" || !config[0].tokenAddress) {
+    const [foreign20Token] = await deployMockTokens(gasLimit, ["Foreign20"]);
+    deploymentComplete("Foreign20", foreign20Token.address, [], contracts);
+  }
 
   // Bail now if deploying locally
   if (hre.network.name === "localhost") {
@@ -243,7 +249,7 @@ async function main() {
 
   // Wait a minute after deployment completes and then verify contracts on etherscan
   console.log(
-    "⏲ Pause one minute, allowing deployments to propagate to Etherscan backend..."
+    "\n⏲ Pause one minute, allowing deployments to propagate to Etherscan backend..."
   );
   await delay(60_000).then(async () => {
     console.log("🔍 Verifying contracts on Etherscan...");

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -54,6 +54,12 @@ dataSources:
       abis:
         - name: IBosonAccountHandler
           file: ../common/src/abis/IBosonAccountHandler.json
+        - name: ERC20
+          file: ../common/src/abis/ERC20.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
       eventHandlers:
         - event: SellerCreated(indexed uint256,(uint256,address,address,address,address,bool),indexed address)
           handler: handleSellerCreatedEvent
@@ -81,6 +87,12 @@ dataSources:
       abis:
         - name: IBosonExchangeHandler
           file: ../common/src/abis/IBosonExchangeHandler.json
+        - name: ERC20
+          file: ../common/src/abis/ERC20.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
       eventHandlers:
         - event: BuyerCommitted(indexed uint256,indexed uint256,indexed uint256,(uint256,uint256,uint256,uint256,(uint256,uint256,uint256,bool),uint8),address)
           handler: handleBuyerCommittedEvent
@@ -110,6 +122,12 @@ dataSources:
       abis:
         - name: IBosonFundsHandler
           file: ../common/src/abis/IBosonFundsHandler.json
+        - name: ERC20
+          file: ../common/src/abis/ERC20.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
       eventHandlers:
         - event: FundsDeposited(indexed uint256,indexed address,indexed address,uint256)
           handler: handleFundsDepositedEvent


### PR DESCRIPTION
## Description

In order to fully test non-native currency support, we need a
ERC20-compliant exchange token.
Unfortunately, the mocked BosonToken, is not.
Therefore, we have to use the mock `Foreign20` token, which
gets now deployed as part of the deploy script.

The address on local e2e setup is:
0x95401dc811bb5740090279Ba06cfA8fcF6113778

