### PR TITLE
feat(subgraph): enrich metadata with `quantityAvailable` field

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -27,6 +27,7 @@ interface MetadataInterface {
   voided: Boolean!
   validFromDate: BigInt!
   validUntilDate: BigInt!
+  quantityAvailable: BigInt!
 }
 
 type BaseMetadataEntity implements MetadataInterface @entity {
@@ -39,10 +40,14 @@ type BaseMetadataEntity implements MetadataInterface @entity {
   offer: Offer!
   seller: Seller!
   exchangeToken: ExchangeToken!
+  """
+  Enriched fields from offer entity to allow nested query workaround
+  """
   createdAt: BigInt!
   voided: Boolean!
   validFromDate: BigInt!
   validUntilDate: BigInt!
+  quantityAvailable: BigInt!
 }
 
 type ProductV1MetadataEntity implements MetadataInterface @entity {
@@ -55,10 +60,14 @@ type ProductV1MetadataEntity implements MetadataInterface @entity {
   offer: Offer!
   seller: Seller!
   exchangeToken: ExchangeToken!
+  """
+  Enriched fields from offer entity to allow nested query workaround
+  """
   createdAt: BigInt!
   voided: Boolean!
   validFromDate: BigInt!
   validUntilDate: BigInt!
+  quantityAvailable: BigInt!
   """
   ProductV1MetadataEntity specific fields
   """

--- a/packages/subgraph/src/entities/metadata/base.ts
+++ b/packages/subgraph/src/entities/metadata/base.ts
@@ -28,6 +28,7 @@ export function saveBaseMetadata(
   baseMetadataEntity.createdAt = timestamp;
   baseMetadataEntity.validFromDate = offer.validFromDate;
   baseMetadataEntity.validUntilDate = offer.validUntilDate;
+  baseMetadataEntity.quantityAvailable = offer.quantityAvailable;
   baseMetadataEntity.type = "BASE";
   baseMetadataEntity.name = name;
   baseMetadataEntity.description = description;

--- a/packages/subgraph/src/entities/metadata/product-v1.ts
+++ b/packages/subgraph/src/entities/metadata/product-v1.ts
@@ -39,6 +39,7 @@ export function saveProductV1Metadata(
   productV1MetadataEntity.voided = offer.voided;
   productV1MetadataEntity.validFromDate = offer.validFromDate;
   productV1MetadataEntity.validUntilDate = offer.validUntilDate;
+  productV1MetadataEntity.quantityAvailable = offer.quantityAvailable;
   productV1MetadataEntity.name = name;
   productV1MetadataEntity.description = description;
   productV1MetadataEntity.externalUrl = externalUrl;


### PR DESCRIPTION
## Description

Allows filtering for `quantityAvailable` when querying metadata entities.

NOTE: I think enriching the metadata entities with these fields is a bit suboptimal and hard to maintain. Every time a requirement for filtering changes, we need to hoist this field up. This defeats the purpose of GraphQL IMO. I would therefore suggest querying and filtering generic `Offer` entities when filtering for on-chain data. Only if we need to filter for metadata (e.g. name, description, etc.), then we should query `Metadata` entities. 