### PR TITLE
fix: remove duplicates from search result set

### DIFF
--- a/packages/react-kit/src/components/searchBar/SearchBar.tsx
+++ b/packages/react-kit/src/components/searchBar/SearchBar.tsx
@@ -33,7 +33,7 @@ export const SearchBar = ({
       if (e.key === "Enter") {
         e.preventDefault();
 
-        let searchResults: BaseMetadataEntityFieldsFragment[] = [];
+        let searchResults: subgraph.BaseMetadataEntityFieldsFragment[] = [];
 
         const searchResultsDescPromise = coreSdk.getBaseMetadataEntities({
           metadataFilter: {


### PR DESCRIPTION
## Description

The previous approach with using `new Set` doesn't work. All objects have different references therefore they are considered unique when only using `Set`. We can truly remove duplicates by using a `Map` approach as introduced in this PR.

