### PR TITLE
docs(react-kit): add rudimentary api docs

### DIFF
--- a/packages/react-kit/src/components/cta/common/types.ts
+++ b/packages/react-kit/src/components/cta/common/types.ts
@@ -3,13 +3,38 @@ import { CoreSdkConfig } from "../../../hooks/useCoreSdk";
 import { ButtonSize } from "../../buttons/Button";
 
 export type CtaButtonProps<T> = CoreSdkConfig & {
+  /**
+   * Optional Biconomy meta transactions API key. If set, then meta transactions will be
+   * enabled.
+   */
   metaTransactionsApiKey?: string;
   disabled?: boolean;
+  /**
+   * Optional number of block confirmations to wait for after transaction is sent.
+   * Defaults to 1.
+   */
   waitBlocks?: number;
+  /**
+   * Optional additional information to show as a button label.
+   */
   extraInfo?: string;
+  /**
+   * Optional callback to invoke before user signs the transaction.
+   */
   onPendingSignature?: () => void;
+  /**
+   * Optional callback to invoke after user signed the transaction and before the respective
+   * number of blocks (`waitBlock`) were mined.
+   */
   onPendingTransaction?: (txHash: string) => void;
+  /**
+   * Optional callback to invoke after the respective number of block (`waitBlocks`) were
+   * mined.
+   */
   onSuccess?: (receipt: providers.TransactionReceipt, payload: T) => void;
+  /**
+   * Optional callback to invoke if an error happened.
+   */
   onError?: (error: Error) => void;
   children?: React.ReactNode;
   size?: ButtonSize;

--- a/packages/react-kit/src/components/cta/exchange/CancelButton.tsx
+++ b/packages/react-kit/src/components/cta/exchange/CancelButton.tsx
@@ -9,7 +9,12 @@ import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 
-type Props = { exchangeId: BigNumberish } & CtaButtonProps<{
+type Props = {
+  /**
+   * ID of voucher/exchange to cancel.
+   */
+  exchangeId: BigNumberish;
+} & CtaButtonProps<{
   exchangeId: BigNumberish;
 }>;
 

--- a/packages/react-kit/src/components/cta/exchange/RedeemButton.tsx
+++ b/packages/react-kit/src/components/cta/exchange/RedeemButton.tsx
@@ -9,7 +9,12 @@ import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 
-type Props = { exchangeId: BigNumberish } & CtaButtonProps<{
+type Props = {
+  /**
+   * ID of voucher/exchange to redeem.
+   */
+  exchangeId: BigNumberish;
+} & CtaButtonProps<{
   exchangeId: BigNumberish;
 }>;
 

--- a/packages/react-kit/src/components/cta/exchange/RevokeButton.tsx
+++ b/packages/react-kit/src/components/cta/exchange/RevokeButton.tsx
@@ -7,9 +7,15 @@ import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 
-type Props = { exchangeId: BigNumberish } & CtaButtonProps<{
+type Props = {
+  /**
+   * ID of voucher/exchange to revoke.
+   */
+  exchangeId: BigNumberish;
+} & CtaButtonProps<{
   exchangeId: BigNumberish;
 }>;
+
 export const RevokeButton = ({
   exchangeId,
   disabled = false,

--- a/packages/react-kit/src/components/cta/offer/CommitButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/CommitButton.tsx
@@ -9,7 +9,12 @@ import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 
-type Props = { offerId: BigNumberish } & CtaButtonProps<{
+type Props = {
+  /**
+   * ID of offer to commit to.
+   */
+  offerId: BigNumberish;
+} & CtaButtonProps<{
   exchangeId: BigNumberish;
 }>;
 

--- a/packages/react-kit/src/components/cta/offer/VoidButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/VoidButton.tsx
@@ -7,7 +7,12 @@ import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 
-type Props = { offerId: BigNumberish } & CtaButtonProps<{
+type Props = {
+  /**
+   * ID of offer to void.
+   */
+  offerId: BigNumberish;
+} & CtaButtonProps<{
   offerId: BigNumberish;
 }>;
 

--- a/packages/react-kit/src/components/searchBar/SearchBar.tsx
+++ b/packages/react-kit/src/components/searchBar/SearchBar.tsx
@@ -5,17 +5,26 @@ import { InputField, InputWrapper } from "./SearchBar.styles";
 import { subgraph } from "@bosonprotocol/core-sdk";
 
 interface SearchBarProps {
+  /**
+   * Target chain.
+   */
+  chainId: number;
   placeholder?: string;
   disabled?: boolean;
-  chainId?: number;
+  /**
+   * Optional callback to invoke with search results.
+   */
   onSuccess?: (results: subgraph.BaseMetadataEntityFieldsFragment[]) => void;
+  /**
+   * Optional callback to invoke if an error happened.
+   */
   onError?: (error: Error) => void;
 }
 
 export const SearchBar = ({
   placeholder = "Search...",
   disabled = false,
-  chainId = 1234,
+  chainId,
   onSuccess,
   onError
 }: SearchBarProps) => {

--- a/packages/react-kit/src/hooks/meta-tx/useBiconomy.tsx
+++ b/packages/react-kit/src/hooks/meta-tx/useBiconomy.tsx
@@ -10,6 +10,12 @@ export type BiconomyConfig = {
   jsonRpcUrl?: string;
 };
 
+/**
+ * Hook that initializes an instance of `Biconomy`.
+ * This instance is used to enable Biconomy meta transactions.
+ * @param config - Configuration arguments of `Biconomy` instance.
+ * @returns Initialized `Biconomy` instance.
+ */
 export function useBiconomy(config: BiconomyConfig) {
   const defaultConfig = getDefaultConfig({ chainId: config.chainId });
   const [biconomyState, setBiconomyState] = useState<

--- a/packages/react-kit/src/hooks/meta-tx/useMetaTxHandlerContract.ts
+++ b/packages/react-kit/src/hooks/meta-tx/useMetaTxHandlerContract.ts
@@ -10,6 +10,12 @@ type MetaTxHandlerConfig = BiconomyConfig & {
   web3Provider?: Provider;
 };
 
+/**
+ * Hook that initializes a `MetaTransactionHandler` contract instance and connects it to
+ * a Biconomy relayer. Allows the usage of meta transactions via Biconomy.
+ * @param config - Configuration arguments.
+ * @returns Biconomy-connected contract instance.
+ */
 export function useMetaTxHandlerContract(config: MetaTxHandlerConfig) {
   const defaultConfig = getDefaultConfig({ chainId: config.chainId });
   const [metaTxHandlerContract, setMetaTxHandlerContract] = useState<

--- a/packages/react-kit/src/hooks/useCoreSdk.tsx
+++ b/packages/react-kit/src/hooks/useCoreSdk.tsx
@@ -5,15 +5,44 @@ import { IpfsMetadataStorage } from "@bosonprotocol/ipfs-storage";
 import { providers } from "ethers";
 
 export type CoreSdkConfig = {
-  web3Provider?: Provider;
+  /**
+   * Target chain.
+   */
   chainId: number;
+  /**
+   * Ethers provider that will be passed to `CoreSDK`. Defaults to `JsonRpcProvider`
+   * connected via default URL of respective chain ID.
+   */
+  web3Provider?: Provider;
+  /**
+   * Optional override for default `JsonRpcProvider` to use.
+   */
   jsonRpcUrl?: string;
+  /**
+   * Optional override for subgraph API url to use.
+   */
   subgraphUrl?: string;
+  /**
+   * Optional override for Diamond contract address to use.
+   */
   protocolDiamond?: string;
+  /**
+   * Optional override for IPFS metadata storage to use.
+   */
   ipfsMetadataStorageUrl?: string;
+  /**
+   * Optional override for Thr Graph IPFS storage to use.
+   */
   theGraphIpfsUrl?: string;
 };
 
+/**
+ * Hook that initializes an instance of `CoreSDK` from the `@bosonprotocol/core-sdk`
+ * package. The instance will be reinitialized when the passed in `web3Provider`
+ * changes.
+ * @param config - Configuration arguments.
+ * @returns Instance of `CoreSDK`.
+ */
 export function useCoreSdk(config: CoreSdkConfig) {
   const [coreSdk, setCoreSdk] = useState<CoreSDK>(initCoreSdk(config));
 

--- a/packages/react-kit/src/stories/searchBar/SearchBar.stories.tsx
+++ b/packages/react-kit/src/stories/searchBar/SearchBar.stories.tsx
@@ -15,5 +15,6 @@ const Template: ComponentStory<typeof SearchBar> = (args) => (
 export const Primary: ComponentStory<typeof SearchBar> = Template.bind({});
 
 Primary.args = {
-  disabled: false
+  disabled: false,
+  chainId: 1234
 };


### PR DESCRIPTION
## Description

This adds some rudimentary docs for the hooks and CTA components of the react-kit. We should think about how we can improve the component documentation in storybook though. I think using MDX https://storybook.js.org/docs/react/writing-docs/docs-page#with-mdx-documentation gives us more control over what we exactly want to show and highlight. 

## How to test

Start storybook and switch to the `Docs` tab of a story. 
