### PR TITLE
feat(react-kit): add hook to use ipfs metadata storage

### DIFF
--- a/packages/react-kit/src/hooks/index.ts
+++ b/packages/react-kit/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useBiconomy } from "./meta-tx/useBiconomy";
 export { useMetaTxHandlerContract } from "./meta-tx/useMetaTxHandlerContract";
 
 export { useCoreSdk } from "./useCoreSdk";
+export { useIpfsMetadataStorage } from "./useIpfsMetadataStorage";

--- a/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
+++ b/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { getDefaultConfig } from "@bosonprotocol/core-sdk";
+import { IpfsMetadataStorage } from "@bosonprotocol/ipfs-storage";
+
+/**
+ * Hook that initializes an instance of `IpfsMetadataStorage` from the `@bosonprotocol/ipfs-storage`
+ * package.
+ * @param chainIdOrUrl - Chain ID to use default IPFS url or custom url.
+ * @returns Instance of `IpfsMetadataStorage`.
+ */
+export function useIpfsMetadataStorage(chainIdOrUrl: number | string) {
+  const [ipfsMetadataStorage, setIpfsMetadataStorage] =
+    useState<IpfsMetadataStorage>(initIpfsMetadataStorage(chainIdOrUrl));
+
+  useEffect(() => {
+    setIpfsMetadataStorage(initIpfsMetadataStorage(chainIdOrUrl));
+  }, [chainIdOrUrl]);
+
+  return ipfsMetadataStorage;
+}
+
+function initIpfsMetadataStorage(chainIdOrUrl: number | string) {
+  const url =
+    typeof chainIdOrUrl === "number"
+      ? getDefaultConfig({ chainId: chainIdOrUrl }).ipfsMetadataUrl
+      : chainIdOrUrl;
+
+  return new IpfsMetadataStorage({ url });
+}


### PR DESCRIPTION
## Description

Allows the usage of ipfs metadata storage as a standalone.
