### PR TITLE
feat: create dispute resolver script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@lerna-lite/cli": "^1.0.5",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
         "@typescript-eslint/parser": "^5.12.1",
+        "commander": "^9.4.0",
         "eslint-config-prettier": "^8.4.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-tsdoc": "^0.2.16",
@@ -17946,11 +17947,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "dev": true,
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/common-path-prefix": {
@@ -24629,6 +24631,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/html-tags": {
@@ -56314,9 +56324,10 @@
       }
     },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "dev": true
     },
     "common-path-prefix": {
       "version": "3.0.0",
@@ -61553,6 +61564,13 @@
         "param-case": "^3.0.4",
         "relateurl": "^0.2.7",
         "terser": "^5.10.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        }
       }
     },
     "html-tags": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "e2e:services:default": "./e2e/run-e2e-services.sh",
     "e2e:services:win32": "cmd /c .\\e2e\\run-e2e-services.cmd",
     "subgraph:deploy:local": "cd ./packages/subgraph && npm run deploy:local",
-    "export-abis": "ts-node ./scripts/export-abis.ts"
+    "export-abis": "ts-node ./scripts/export-abis.ts",
+    "dr:create": "ts-node -P tsconfig.base.json ./scripts/create-dispute-resolver.ts"
   },
   "repository": {
     "type": "git",
@@ -47,6 +48,7 @@
     "@lerna-lite/cli": "^1.0.5",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
+    "commander": "^9.4.0",
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-tsdoc": "^0.2.16",

--- a/scripts/create-dispute-resolver.ts
+++ b/scripts/create-dispute-resolver.ts
@@ -1,0 +1,109 @@
+import { Wallet, providers } from "ethers";
+import { program } from "commander";
+import { getDefaultConfig } from "../packages/common/src";
+import { CoreSDK } from "../packages/core-sdk/src";
+import { EthersAdapter } from "../packages/ethers-sdk/src";
+
+program
+  .description("Creates and activates a dispute resolver.")
+  .argument("<PROTOCOL_ADMIN_PK>", "Private key of account with ADMIN role.")
+  .argument(
+    "<DR_ADMIN_ADDRESS>",
+    "Admin address of dispute resolver. Same address will be used for clerk, treasury and operator if no overrides set."
+  )
+  .option("-c, --chain <CHAIN_ID>", "Target chain id", "1234")
+  .option(
+    "-e, --escalation-period <PERIOD_IN_MS>",
+    "Escalation response period in milliseconds."
+  )
+  .option(
+    "-m, --metadata <METADATA_URI>",
+    "Metadata URI of dispute resolver.",
+    "ipfs://dispute-resolver-uri"
+  )
+  .option(
+    "-f, --fees <...FEES>",
+    "Comma-separated list of dispute resolution fee tuples with the format: <TOKEN_ADDRESS>/<TOKEN_NAME>/<FEE_AMOUNT>"
+  )
+  .option(
+    "-s, --sellers <...SELLERS>",
+    "Comma-separated list of allowed seller IDs."
+  )
+  .option(
+    "-o, --operator <OPERATOR_ADDRESS>",
+    "Operator address to set for dispute resolver."
+  )
+  .option(
+    "-cl, --clerk <CLERK_ADDRESS>",
+    "Clerk address to set for dispute resolver."
+  )
+  .option(
+    "-t, --treasury <TREASURY_ADDRESS>",
+    "Treasury address to set for dispute resolver."
+  )
+  .parse(process.argv);
+
+async function main() {
+  const [protocolAdminPrivateKey, disputeResolverAdminAddress] = program.args;
+
+  const opts = program.opts();
+  const escalationResponsePeriodInMS =
+    opts.escalationResponsePeriod || 60_000_000_000;
+  const operator = opts.operator || disputeResolverAdminAddress;
+  const clerk = opts.clerk || disputeResolverAdminAddress;
+  const treasury = opts.treasury || disputeResolverAdminAddress;
+  const chainId = Number(opts.chain || "1234");
+  const defaultConfig = getDefaultConfig({ chainId });
+  const metadataUri = opts.metadata;
+  const fees = opts.fees
+    ? (opts.fees as string)
+        .split(",")
+        .map((tupleString) => tupleString.split("/"))
+        .map((tuple) => ({
+          tokenAddress: tuple[0],
+          tokenName: tuple[1],
+          feeAmount: tuple[2]
+        }))
+    : [];
+  const sellers = opts.sellers ? (opts.sellers as string).split(",") : [];
+
+  const protocolAdminWallet = new Wallet(protocolAdminPrivateKey);
+  const coreSDK = CoreSDK.fromDefaultConfig({
+    web3Lib: new EthersAdapter(
+      new providers.JsonRpcProvider(defaultConfig.jsonRpcUrl),
+      protocolAdminWallet
+    ),
+    chainId
+  });
+
+  console.log(`Creating dispute resolver on chain ${chainId}...`);
+  const txResponse1 = await coreSDK.createDisputeResolver({
+    escalationResponsePeriodInMS,
+    admin: disputeResolverAdminAddress,
+    operator,
+    clerk,
+    treasury,
+    metadataUri,
+    fees,
+    sellerAllowList: sellers
+  });
+  console.log(`Tx hash: ${txResponse1.hash}`);
+  const receipt = await txResponse1.wait();
+  const disputeResolverId = coreSDK.getDisputeResolverIdFromLogs(receipt.logs);
+  console.log(`Dispute resolver with id ${disputeResolverId} created.`);
+
+  console.log(`Activating dispute resolver...`);
+  const txResponse2 = await coreSDK.activateDisputeResolver(
+    disputeResolverId as string
+  );
+  console.log(`Tx hash: ${txResponse2.hash}`);
+  await txResponse2.wait();
+  console.log(`Dispute resolver with id ${disputeResolverId} activated.`);
+}
+
+main()
+  .then(() => console.log("success"))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description

Utility script to create and activate a DR from the CLI. Example:
```bash
npm run dr:create -- 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 0x57faFe1fB7C682216FCe44e50946C5249192b9D5 -f 0x0000000000000000000000000000000000000000/ETH/0 -c 31337
```

Note, that this currently only works with the local e2e setup. For the test env, we need to update the contracts submodule first.

## How to test
To see the help documentation run:
```bash
npm run dr:create -- --help
```
