### PR TITLE
feat(react-kit): allow custom ipfs http client headers

### DIFF
--- a/packages/react-kit/src/hooks/useCoreSdk.tsx
+++ b/packages/react-kit/src/hooks/useCoreSdk.tsx
@@ -31,6 +31,10 @@ export type CoreSdkConfig = {
    */
   ipfsMetadataStorageUrl?: string;
   /**
+   * Optional override for IPFS metadata storage headers.
+   */
+  ipfsMetadataStorageHeaders?: Headers | Record<string, string>;
+  /**
    * Optional override for Thr Graph IPFS storage to use.
    */
   theGraphIpfsUrl?: string;
@@ -70,7 +74,8 @@ function initCoreSdk(config: CoreSdkConfig) {
       config.theGraphIpfsUrl || defaultConfig.theGraphIpfsUrl
     ),
     metadataStorage: new IpfsMetadataStorage({
-      url: config.ipfsMetadataStorageUrl || defaultConfig.ipfsMetadataUrl
+      url: config.ipfsMetadataStorageUrl || defaultConfig.ipfsMetadataUrl,
+      headers: config.ipfsMetadataStorageHeaders
     })
   });
 }

--- a/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
+++ b/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
@@ -6,24 +6,33 @@ import { IpfsMetadataStorage } from "@bosonprotocol/ipfs-storage";
  * Hook that initializes an instance of `IpfsMetadataStorage` from the `@bosonprotocol/ipfs-storage`
  * package.
  * @param chainIdOrUrl - Chain ID to use default IPFS url or custom url.
+ * @param headers - Optional IPFS http client headers.
  * @returns Instance of `IpfsMetadataStorage`.
  */
-export function useIpfsMetadataStorage(chainIdOrUrl: number | string) {
+export function useIpfsMetadataStorage(
+  chainIdOrUrl: number | string,
+  headers?: Headers | Record<string, string>
+) {
   const [ipfsMetadataStorage, setIpfsMetadataStorage] =
-    useState<IpfsMetadataStorage>(initIpfsMetadataStorage(chainIdOrUrl));
+    useState<IpfsMetadataStorage>(
+      initIpfsMetadataStorage(chainIdOrUrl, headers)
+    );
 
   useEffect(() => {
-    setIpfsMetadataStorage(initIpfsMetadataStorage(chainIdOrUrl));
-  }, [chainIdOrUrl]);
+    setIpfsMetadataStorage(initIpfsMetadataStorage(chainIdOrUrl, headers));
+  }, [chainIdOrUrl, headers]);
 
   return ipfsMetadataStorage;
 }
 
-function initIpfsMetadataStorage(chainIdOrUrl: number | string) {
+function initIpfsMetadataStorage(
+  chainIdOrUrl: number | string,
+  headers?: Headers | Record<string, string>
+) {
   const url =
     typeof chainIdOrUrl === "number"
       ? getDefaultConfig({ chainId: chainIdOrUrl }).ipfsMetadataUrl
       : chainIdOrUrl;
 
-  return new IpfsMetadataStorage({ url });
+  return new IpfsMetadataStorage({ url, headers });
 }


### PR DESCRIPTION
## Description

We need auth headers for our dedicated ipfs gateway. This allows us to set them in the react-kit hooks.

