### PR TITLE
feat: allow IPFS get to return string (not only JSON)

### DIFF
--- a/packages/ipfs-storage/src/ipfs/metadata.ts
+++ b/packages/ipfs-storage/src/ipfs/metadata.ts
@@ -28,7 +28,9 @@ export class IpfsMetadataStorage
   }
 
   public async getMetadata(metadataUriOrHash: string): Promise<AnyMetadata> {
-    const metadata = await this.get<ERC721Metadata>(metadataUriOrHash);
+    const metadata = (await this.get<ERC721Metadata>(
+      metadataUriOrHash
+    )) as ERC721Metadata;
     validateMetadata(metadata);
 
     return metadata;


### PR DESCRIPTION
## Description

Card [[BP315](https://app.asana.com/0/1200803815983047/1202829324431167)]
The change in the IPFS-STORAGE package code allows fetching string data (currently only JSON is supported), so that it's possible to use this layer to fetch images (avoid using browser default IPFS gateway, that doesn't respond correctly)

## How to test


