### PR TITLE
fix: default the graph storage url

### DIFF
--- a/packages/react-kit/src/hooks/useCoreSdk.tsx
+++ b/packages/react-kit/src/hooks/useCoreSdk.tsx
@@ -70,6 +70,10 @@ function initCoreSdk(config: CoreSdkConfig) {
   const connectedProvider = config.web3Provider || defaultProvider;
   const metadataStorageUrl =
     config.ipfsMetadataStorageUrl || defaultConfig.ipfsMetadataUrl;
+  const theGraphStorageUrl =
+    config.theGraphIpfsUrl ||
+    defaultConfig.theGraphIpfsUrl ||
+    metadataStorageUrl;
 
   return new CoreSDK({
     web3Lib: new EthersAdapter(connectedProvider),
@@ -77,12 +81,12 @@ function initCoreSdk(config: CoreSdkConfig) {
       config.protocolDiamond || defaultConfig.contracts.protocolDiamond,
     subgraphUrl: config.subgraphUrl || defaultConfig.subgraphUrl,
     theGraphStorage: new IpfsMetadataStorage({
-      url:
-        config.theGraphIpfsUrl ||
-        defaultConfig.theGraphIpfsUrl ||
-        metadataStorageUrl,
+      url: theGraphStorageUrl,
       headers:
-        config.theGraphIpfsStorageHeaders || config.ipfsMetadataStorageHeaders
+        config.theGraphIpfsStorageHeaders ||
+        theGraphStorageUrl === metadataStorageUrl
+          ? config.ipfsMetadataStorageHeaders
+          : undefined
     }),
     metadataStorage: new IpfsMetadataStorage({
       url: metadataStorageUrl,

--- a/packages/subgraph/src/entities/token.ts
+++ b/packages/subgraph/src/entities/token.ts
@@ -17,14 +17,13 @@ export function saveExchangeToken(exchangeTokenAddress: Address): void {
       const networkName = dataSource.network();
 
       exchangeToken.decimals = BigInt.fromI32(18);
-      if(['mumbai', 'polygon'].includes(networkName)){
+      if (["mumbai", "polygon"].includes(networkName)) {
         exchangeToken.name = "Matic";
         exchangeToken.symbol = "MATIC";
-      }else{
+      } else {
         exchangeToken.name = "Ether";
         exchangeToken.symbol = "ETH";
       }
-      
     } else {
       exchangeToken.decimals = fetchTokenDecimals(exchangeTokenAddress);
       exchangeToken.name = fetchTokenName(exchangeTokenAddress);


### PR DESCRIPTION
## Description

Only reuse IPFS headers for The Graph if same url.

