### PR TITLE
fix: return image data from IPFS without string conversion

### DIFF
--- a/packages/ipfs-storage/src/ipfs/base.ts
+++ b/packages/ipfs-storage/src/ipfs/base.ts
@@ -42,10 +42,10 @@ export class BaseIpfsStorage {
       chunks.push(chunk);
     }
     const data = concat(chunks);
-    const dataStr = toString(data);
     if (!asJson) {
-      return dataStr;
+      return data as unknown as T;
     }
+    const dataStr = toString(data);
     return JSON.parse(dataStr);
   }
 


### PR DESCRIPTION
## Description

When an image is got from IPFS, we shall return the binary stream, instead of converting it to string

## How to test

N/A
