### PR TITLE
fix: fix hook useIpfsMetadataStorage

### DIFF
--- a/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
+++ b/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
@@ -6,41 +6,35 @@ import { EnvironmentType } from "@bosonprotocol/common/src/types";
 /**
  * Hook that initializes an instance of `IpfsMetadataStorage` from the `@bosonprotocol/ipfs-storage`
  * package.
- * @param config - envName to use default IPFS url or custom url.
+ * @param envName - envName to use default IPFS url.
+ * @param url - optional custom url.
  * @param headers - Optional IPFS http client headers.
  * @returns Instance of `IpfsMetadataStorage`.
  */
 export function useIpfsMetadataStorage(
-  config: {
-    envName?: EnvironmentType;
-    url?: string;
-  },
+  envName: EnvironmentType,
+  url?: string,
   headers?: Headers | Record<string, string>
 ) {
-  const [ipfsMetadataStorage, setIpfsMetadataStorage] = useState<
-    IpfsMetadataStorage | undefined
-  >(initIpfsMetadataStorage(config, headers));
+  const [ipfsMetadataStorage, setIpfsMetadataStorage] =
+    useState<IpfsMetadataStorage>(
+      initIpfsMetadataStorage(envName, url, headers)
+    );
 
   useEffect(() => {
-    setIpfsMetadataStorage(initIpfsMetadataStorage(config, headers));
-  }, [config, headers]);
+    setIpfsMetadataStorage(initIpfsMetadataStorage(envName, url, headers));
+  }, [envName, url, headers]);
 
   return ipfsMetadataStorage;
 }
 
 function initIpfsMetadataStorage(
-  config: {
-    envName?: EnvironmentType;
-    url?: string;
-  },
+  envName: EnvironmentType,
+  url?: string,
   headers?: Headers | Record<string, string>
 ) {
-  if (!config.envName && !config.url) {
-    return undefined;
-  }
-  const url = config.envName
-    ? getDefaultConfig(config.envName).ipfsMetadataUrl
-    : config.url;
-
-  return new IpfsMetadataStorage({ url, headers });
+  return new IpfsMetadataStorage({
+    url: url || getDefaultConfig(envName).ipfsMetadataUrl,
+    headers
+  });
 }


### PR DESCRIPTION
## Description

Using a nested `config` parameter for the hook was a very bad idea.
I presume recreating a new structure with identical content (eg `{ envName: "testing" }`) is considered **as a new value** by React (as it IS a new object).
That leads to loop over the initialisation... blocking the webpage logic.

New implementation uses 2 single parameters envName and url. The second one is optional.
Updates will only be done if these values change (that should never happen as it comes from static config).
Anyway, that fixes the problem
