### PR TITLE
ci: fix graph node image version to 0.27.0

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "8545:8545"
 
   graph-node:
-    image: graphprotocol/graph-node
+    image: graphprotocol/graph-node:v0.27.0
     ports:
       - "8000:8000"
       - "8001:8001"


### PR DESCRIPTION
## Description

For some reason, the latest `0.28.0` image of the graph-node doesn't correctly start to index. This PR is a quick fix and the real reason will be investigated.
