### PR TITLE
feat: commit button pas ref add

### DIFF
--- a/packages/react-kit/src/components/buttons/Button.tsx
+++ b/packages/react-kit/src/components/buttons/Button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { Loading } from "../Loading";
 
 import { ButtonStyle } from "./Button.styles";
@@ -29,27 +29,33 @@ export interface ButtonProps {
   children?: React.ReactNode;
 }
 
-export const Button = ({
-  children,
-  onClick,
-  className,
-  size = ButtonSize.Medium,
-  variant = "primary",
-  ...props
-}: ButtonProps) => {
-  return (
-    <ButtonStyle
-      variant={variant}
-      className={className}
-      onClick={onClick}
-      size={size}
-      {...props}
-    >
-      {props.loading ? (
-        <Loading data-loading />
-      ) : (
-        <span id="buttonText">{children}</span>
-      )}
-    </ButtonStyle>
-  );
-};
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      children,
+      onClick,
+      className,
+      size = ButtonSize.Medium,
+      variant = "primary",
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <ButtonStyle
+        variant={variant}
+        className={className}
+        onClick={onClick}
+        size={size}
+        ref={ref}
+        {...props}
+      >
+        {props.loading ? (
+          <Loading data-loading />
+        ) : (
+          <span id="buttonText">{children}</span>
+        )}
+      </ButtonStyle>
+    );
+  }
+);

--- a/packages/react-kit/src/components/cta/offer/CommitButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/CommitButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { RefObject, useState } from "react";
 import { BigNumberish, providers } from "ethers";
 
 import { Button, ButtonSize } from "../../buttons/Button";
@@ -13,6 +13,8 @@ type Props = {
    * ID of offer to commit to.
    */
   offerId: BigNumberish;
+  isPauseCommitting?: boolean;
+  buttonRef?: RefObject<HTMLButtonElement>;
 } & CtaButtonProps<{
   exchangeId: BigNumberish;
 }>;
@@ -29,6 +31,8 @@ export const CommitButton = ({
   onError,
   waitBlocks = 1,
   size = ButtonSize.Large,
+  isPauseCommitting = false,
+  buttonRef,
   variant = "primary",
   ...coreSdkConfig
 }: Props) => {
@@ -39,11 +43,12 @@ export const CommitButton = ({
 
   return (
     <Button
+      ref={buttonRef}
       variant={variant}
       size={size}
       disabled={disabled}
       onClick={async () => {
-        if (!isLoading) {
+        if (!isLoading && !isPauseCommitting) {
           try {
             setIsLoading(true);
             onPendingSignature?.();

--- a/packages/react-kit/src/stories/cta/offer/CommitButton.stories.tsx
+++ b/packages/react-kit/src/stories/cta/offer/CommitButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { CommitButton } from "../../../components/cta/offer/CommitButton";
@@ -12,11 +12,12 @@ export default {
 } as ComponentMeta<typeof CommitButton>;
 
 const Template: ComponentStory<typeof CommitButton> = (args) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const provider = hooks.useProvider();
 
   return (
     <CtaButtonWrapper>
-      <CommitButton web3Provider={provider} {...args} />
+      <CommitButton web3Provider={provider} {...args} buttonRef={buttonRef} />
     </CtaButtonWrapper>
   );
 };


### PR DESCRIPTION
## Description

- `isPauseCommitting` props has been added to CommitButton to pause execution of committing
- `buttonRef` props has been added to pass ref to Button component
- implementation of Button component has been changed by forwardRef
## How to test

run on storybook
