### PR TITLE
feat: expose `metaTxHandler.getResubmitted`

### DIFF
--- a/packages/core-sdk/src/meta-tx/biconomy.ts
+++ b/packages/core-sdk/src/meta-tx/biconomy.ts
@@ -21,19 +21,21 @@ export type RelayOverrides = {
   apiId: string;
 };
 
+export type GetRetriedHashesData = {
+  oldHash: string;
+  newHash: string;
+  oldGasPrice: string;
+  newGasPrice: string;
+  timestamp: number;
+  retryCount: number;
+  relayerAddress: string;
+  newStatus: string;
+};
+
 export type GetRetriedHashesResponse = {
   code: number;
   message: string;
-  data: {
-    oldHash: string;
-    newHash: string;
-    oldGasPrice: string;
-    newGasPrice: string;
-    timestamp: number;
-    retryCount: number;
-    relayerAddress: string;
-    newStatus: string;
-  };
+  data: GetRetriedHashesData;
   events?: unknown[];
 };
 

--- a/packages/core-sdk/src/meta-tx/handler.ts
+++ b/packages/core-sdk/src/meta-tx/handler.ts
@@ -16,7 +16,7 @@ import {
   encodeCreateOfferBatch
 } from "../offers/interface";
 import { prepareDataSignatureParameters } from "../utils/signature";
-import { Biconomy } from "./biconomy";
+import { Biconomy, GetRetriedHashesData } from "./biconomy";
 
 type BaseMetaTxArgs = {
   web3Lib: Web3LibAdapter;
@@ -553,4 +553,27 @@ export async function relayMetaTransaction(args: {
     value: BigNumber.from(0),
     chainId: chainId
   };
+}
+
+export async function getResubmitted(args: {
+  chainId: number;
+  metaTx: {
+    config: MetaTxConfig;
+    originalHash: string;
+  };
+}): Promise<GetRetriedHashesData> {
+  const { chainId, metaTx } = args;
+
+  const biconomy = new Biconomy(
+    metaTx.config.relayerUrl,
+    metaTx.config.apiKey,
+    metaTx.config.apiId
+  );
+
+  const retriedHashesResponse = await biconomy.getResubmitted({
+    networkId: chainId,
+    transactionHash: metaTx.originalHash
+  });
+
+  return retriedHashesResponse.data;
 }


### PR DESCRIPTION


## Description

This method is needed in the dApp to determine whether a meta transaction is mined or not.
