### PR TITLE
feat: add `isMetaTx` to `onPendingTransaction` hook

### DIFF
--- a/packages/react-kit/src/components/cta/common/types.ts
+++ b/packages/react-kit/src/components/cta/common/types.ts
@@ -22,7 +22,7 @@ export type CtaButtonProps<T> = CoreSdkConfig & {
    * Optional callback to invoke after user signed the transaction and before the respective
    * number of blocks (`waitBlock`) were mined.
    */
-  onPendingTransaction?: (txHash: string) => void;
+  onPendingTransaction?: (txHash: string, isMetaTx?: boolean) => void;
   /**
    * Optional callback to invoke after the respective number of block (`waitBlocks`) were
    * mined.

--- a/packages/react-kit/src/components/cta/exchange/CancelButton.tsx
+++ b/packages/react-kit/src/components/cta/exchange/CancelButton.tsx
@@ -50,8 +50,11 @@ export const CancelButton = ({
             onPendingSignature?.();
 
             let txResponse;
+            const isMetaTx = Boolean(
+              coreSdk.isMetaTxConfigSet && signerAddress
+            );
 
-            if (coreSdk.isMetaTxConfigSet && signerAddress) {
+            if (isMetaTx) {
               const nonce = Date.now();
 
               const { r, s, v, functionName, functionSignature } =
@@ -72,7 +75,7 @@ export const CancelButton = ({
               txResponse = await coreSdk.cancelVoucher(exchangeId);
             }
 
-            onPendingTransaction?.(txResponse.hash);
+            onPendingTransaction?.(txResponse.hash, isMetaTx);
             const receipt = await txResponse.wait(waitBlocks);
 
             onSuccess?.(receipt as providers.TransactionReceipt, {

--- a/packages/react-kit/src/components/cta/exchange/RedeemButton.tsx
+++ b/packages/react-kit/src/components/cta/exchange/RedeemButton.tsx
@@ -50,8 +50,11 @@ export const RedeemButton = ({
             onPendingSignature?.();
 
             let txResponse;
+            const isMetaTx = Boolean(
+              coreSdk.isMetaTxConfigSet && signerAddress
+            );
 
-            if (coreSdk.isMetaTxConfigSet && signerAddress) {
+            if (isMetaTx) {
               const nonce = Date.now();
 
               const { r, s, v, functionName, functionSignature } =
@@ -72,7 +75,7 @@ export const RedeemButton = ({
               txResponse = await coreSdk.redeemVoucher(exchangeId);
             }
 
-            onPendingTransaction?.(txResponse.hash);
+            onPendingTransaction?.(txResponse.hash, isMetaTx);
             const receipt = await txResponse.wait(waitBlocks);
 
             onSuccess?.(receipt as providers.TransactionReceipt, {

--- a/packages/react-kit/src/components/cta/offer/CommitButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/CommitButton.tsx
@@ -64,8 +64,11 @@ export const CommitButton = ({
             onPendingSignature?.();
 
             let txResponse;
+            const isMetaTx = Boolean(
+              coreSdk.isMetaTxConfigSet && signerAddress
+            );
 
-            if (coreSdk.isMetaTxConfigSet && signerAddress) {
+            if (isMetaTx) {
               const nonce = Date.now();
               const { r, s, v, functionName, functionSignature } =
                 await coreSdk.signMetaTxCommitToOffer({
@@ -84,7 +87,7 @@ export const CommitButton = ({
               txResponse = await coreSdk.commitToOffer(offerId);
             }
 
-            onPendingTransaction?.(txResponse.hash);
+            onPendingTransaction?.(txResponse.hash, isMetaTx);
             const receipt = await txResponse.wait(waitBlocks);
             const exchangeId = coreSdk.getCommittedExchangeIdFromLogs(
               receipt.logs


### PR DESCRIPTION
## Description

This information is needed in the interface to keep track of pending meta transactions. We eventually need to add this to each CTA that supports meta transactions. 

