### PR TITLE
fix: set metadataStorage and theGraphStorage for createOffer meta-tx

### DIFF
--- a/packages/core-sdk/src/core-sdk.ts
+++ b/packages/core-sdk/src/core-sdk.ts
@@ -1499,6 +1499,8 @@ export class CoreSDK {
   ) {
     return metaTx.handler.signMetaTxCreateOffer({
       web3Lib: this._web3Lib,
+      theGraphStorage: this._theGraphStorage,
+      metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
       ...args
@@ -1518,6 +1520,8 @@ export class CoreSDK {
   ) {
     return metaTx.handler.signMetaTxCreateOfferBatch({
       web3Lib: this._web3Lib,
+      theGraphStorage: this._theGraphStorage,
+      metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
       ...args


### PR DESCRIPTION
## Description

in the changes merged this morning, metadataStorage and theGraphStorage arguments were missing when calling signMetaTxCreateOffer() or signMetaTxCreateOfferBatch()

