### PR TITLE
feat: add support for replaced transactions

### DIFF
--- a/packages/react-kit/src/components/cta/common/types.ts
+++ b/packages/react-kit/src/components/cta/common/types.ts
@@ -25,6 +25,23 @@ export type CtaButtonProps<T> = CoreSdkConfig & {
    */
   onPendingTransaction?: (txHash: string, isMetaTx?: boolean) => void;
   /**
+   * Optional callback to invoke after a transaction was replaced or canceled.
+   */
+  onCancelledTransaction?: (
+    oldTxHash: string,
+    nexTxResponse: providers.TransactionResponse,
+    isMetaTx?: boolean
+  ) => void;
+  /**
+   * Optional callback to invoke after a transaction was repriced, i.e. speed up.
+   */
+  onRepricedTransaction?: (
+    oldTxHash: string,
+    newTxResponse: providers.TransactionResponse,
+    newTxReceipt: providers.TransactionReceipt,
+    isMetaTx?: boolean
+  ) => void;
+  /**
    * Optional callback to invoke after the respective number of block (`waitBlocks`) were
    * mined.
    */

--- a/packages/react-kit/src/stories/cta/offer/CommitButton.stories.tsx
+++ b/packages/react-kit/src/stories/cta/offer/CommitButton.stories.tsx
@@ -42,6 +42,14 @@ Simple.args = {
     console.log("----------ON PENDING TRANSACTION-------------");
     console.log("txHash", txHash);
   },
+  onCancelledTransaction: (oldTxHash, newTxResponse) => {
+    console.log("----------ON CANCELLED TRANSACTION-------------");
+    console.log({ oldTxHash, newTxResponse });
+  },
+  onRepricedTransaction: (oldTxHash, newTxResponse, newTxReceipt) => {
+    console.log("----------ON REPRICED TRANSACTION-------------");
+    console.log({ oldTxHash, newTxResponse, newTxReceipt });
+  },
   onSuccess: (receipt, payload) => {
     console.log("----------ON SUCCESS-------------");
     console.log("receipt", receipt);


### PR DESCRIPTION
## Description

This introduces two new optional callbacks for CTAs that use the generic `<CtaButton />` component.

## How to test

I couldn't fully test because on the Mumbai testnet with a very low fee it would still mine the transaction.
