### PR TITLE
fix: images cutting off text below

### DIFF
--- a/packages/react-kit/src/components/productCard/ProductCard.styles.ts
+++ b/packages/react-kit/src/components/productCard/ProductCard.styles.ts
@@ -140,6 +140,7 @@ export const BottomText = styled.p`
 
 export const ProductCardImageWrapper = styled.div`
   width: 100%;
-  height: 100%;
-  max-height: 75%;
+  flex: 1 1 100%;
+  min-height: 0;
+  height: auto;
 `;

--- a/packages/react-kit/src/stories/ExchangeCard.stories.tsx
+++ b/packages/react-kit/src/stories/ExchangeCard.stories.tsx
@@ -35,12 +35,12 @@ const wrapper = (Story: Story) => (
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Redeemed.args = {
   id: "4852",
-  title: "ABI #4852",
+  title: "Super Shoe King of Hell King of HellKing of HellKing of Hell",
   avatarName: "Abi",
   avatar:
     "https://images.unsplash.com/photo-1613771404721-1f92d799e49f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8cG9rZW1vbnxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=500&q=60",
   imageProps: {
-    src: "https://images.unsplash.com/photo-1576618148400-f54bed99fcfd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NDV8fHByb2R1Y3R8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60",
+    src: "https://images.unsplash.com/photo-1576618148400-f54bed99fcfd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NDV8fHByb2R1Y3R8ZW58MHx8MHx8&auto=format&fit=crop&w=500&h=700&q=60",
     preloadConfig: {
       status: "loading",
       errorIcon: <></>,

--- a/packages/react-kit/src/stories/ProductCard.stories.tsx
+++ b/packages/react-kit/src/stories/ProductCard.stories.tsx
@@ -19,7 +19,9 @@ const Template: ComponentStory<typeof ProductCard> = (args) => (
 );
 
 const wrapper = (Story: Story) => (
-  <div style={{ width: "20.188rem" }}>
+  <div
+    style={{ height: "500px", display: "grid", gridTemplateColumns: "18rem" }}
+  >
     <Story />
   </div>
 );
@@ -30,7 +32,7 @@ export const ProductCardPrimary: ComponentStory<typeof ProductCard> =
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 ProductCardPrimary.args = {
   productId: "123",
-  title: "Super Shoe",
+  title: "Super Shoe King of HellKing of HellKing of HellKing of Hell",
   avatar:
     "https://images.unsplash.com/flagged/photo-1570612861542-284f4c12e75f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1740&q=80",
   avatarName: (


### PR DESCRIPTION
whenever there is a long text below, the product card image should shrink

![image](https://user-images.githubusercontent.com/102516373/200273264-d2cc85ef-b34e-4fa6-acdd-3401a054fb67.png)