### PR TITLE
fix: urls in metadata need to be reset with the new UUID

### DIFF
--- a/packages/metadata/src/product-v1/index.ts
+++ b/packages/metadata/src/product-v1/index.ts
@@ -186,9 +186,19 @@ function buildVariantProductMetadata(
         value: variation.option
       };
     });
+    const uuid = buildUuid();
+    // externalUrl and licenseUrl needs to be patched with the new UUID
+    const [externalUrl, licenseUrl] = replaceUUID(
+      productMetadata.uuid,
+      uuid,
+      productMetadata,
+      ["externalUrl", "licenseUrl"]
+    );
     return {
       ...productMetadata,
-      uuid: buildUuid(),
+      uuid,
+      externalUrl,
+      licenseUrl,
       variations: variant,
       attributes: [...productMetadata.attributes, ...variantAttributes]
     };
@@ -220,4 +230,22 @@ function serializeVariant(variant: ProductV1Variant): string {
     a.type.localeCompare(b.type)
   );
   return JSON.stringify(orderedTable);
+}
+
+function replaceUUID(
+  oldUUID: string,
+  newUUID: string,
+  metadata: Record<string, unknown>,
+  fields: string[]
+): string[] {
+  const ret = [];
+  for (const field of fields) {
+    // Note: in case metadata[field] does not exist or can not be converted into a string, the value is returned as is
+    ret.push(
+      String(metadata[field])
+        ? String(metadata[field]).replaceAll(oldUUID, newUUID)
+        : metadata[field]
+    );
+  }
+  return ret;
 }

--- a/packages/metadata/tests/product-v1/valid/fullOffer.json
+++ b/packages/metadata/tests/product-v1/valid/fullOffer.json
@@ -4,7 +4,7 @@
   "uuid": "ecf2a6dc-555b-41b5-aca8-b7e29eebbb30",
   "name": "Boson X MetaFactory Hoodie",
   "description": "The future is here and it starts with a limited edition MetaFactory X Boson Protocol Hoodie... This unisex hoodie, in a metablack coloureway with reflective stripes, is made from a heavyweight French terry cotton. It has an adjustable hood and full colour interior, elasticated trims, reflective lining, and reflective back panels... Nothing says open metaverse more than this collab between MetaFactory and Boson Protocol. Limited Edition: Only 75 ever made.",
-  "externalUrl": "https://app.bosonportal.io",
+  "externalUrl": "https://app.bosonportal.io/#/offer-uuid/ecf2a6dc-555b-41b5-aca8-b7e29eebbb30",
   "animationUrl": "https://app.bosonportal.io/animationUrl",
   "licenseUrl": "https://app.bosonportal.io/#/license/ecf2a6dc-555b-41b5-aca8-b7e29eebbb30",
   "condition": "this offer requires to own at least one NFT of Makersplace collection: https://opensea.io/collection/makersplace",

--- a/packages/metadata/tests/product-v1/valid/minimalOffer.json
+++ b/packages/metadata/tests/product-v1/valid/minimalOffer.json
@@ -4,7 +4,7 @@
   "uuid": "ecf2a6dc-555b-41b5-aca8-b7e29eebbb30",
   "name": "Boson X MetaFactory Hoodie",
   "description": "The future is here and it starts with a limited edition MetaFactory X Boson Protocol Hoodie... This unisex hoodie, in a metablack coloureway with reflective stripes, is made from a heavyweight French terry cotton. It has an adjustable hood and full colour interior, elasticated trims, reflective lining, and reflective back panels... Nothing says open metaverse more than this collab between MetaFactory and Boson Protocol. Limited Edition: Only 75 ever made.",
-  "externalUrl": "https://app.bosonportal.io",
+  "externalUrl": "https://app.bosonportal.io/#/offer-uuid/ecf2a6dc-555b-41b5-aca8-b7e29eebbb30",
   "licenseUrl": "https://app.bosonportal.io/#/license/ecf2a6dc-555b-41b5-aca8-b7e29eebbb30",
   "image": "https://bsn-portal-production-image-upload-storage.s3.amazonaws.com/fc11acc4-e27b-4ede-b7d3-f16735fab406",
   "attributes": [

--- a/packages/metadata/tests/productV1.test.ts
+++ b/packages/metadata/tests/productV1.test.ts
@@ -333,6 +333,33 @@ describe("#productV1 tests", () => {
       expect(metadatas[0].uuid).not.toEqual(metadatas[1].uuid);
     });
 
+    test("each metadata should have externalUrl and licenseUrl replaced with the new offer uuid", async () => {
+      const productMetadata =
+        productV1ValidMinimalOffer as unknown as ProductV1Metadata;
+      const oldUUID = productMetadata.uuid;
+      const oldExternalUrl = productMetadata.externalUrl;
+      const oldLicenseUrl = productMetadata.licenseUrl;
+      const metadatas = createVariantProductMetadata(
+        productMetadata,
+        variantsOK
+      );
+
+      expect(metadatas.length).toEqual(variantsOK.length);
+
+      // We want each metadata to have its own offer uuid
+      for (let i = 0; i < variantsOK.length; i++) {
+        expect(metadatas[i].uuid).not.toEqual(oldUUID);
+        expect(metadatas[i].externalUrl).not.toEqual(oldExternalUrl);
+        expect(metadatas[i].externalUrl).toEqual(
+          oldExternalUrl.replace(oldUUID, metadatas[i].uuid)
+        );
+        expect(metadatas[i].licenseUrl).not.toEqual(oldLicenseUrl);
+        expect(metadatas[i].licenseUrl).toEqual(
+          oldLicenseUrl.replace(oldUUID, metadatas[i].uuid)
+        );
+      }
+    });
+
     test("each metadata should be based on the product metadata", async () => {
       const productMetadata =
         productV1ValidMinimalOffer as unknown as ProductV1Metadata;
@@ -342,31 +369,22 @@ describe("#productV1 tests", () => {
       );
 
       expect(metadatas.length).toEqual(variantsOK.length);
-      expect(metadatas[0]).toEqual({
-        ...productMetadata,
-        uuid: metadatas[0].uuid,
-        variations: variantsOK[0].productVariant,
-        attributes: [
-          ...productMetadata.attributes,
-          ...variantsOK[0].productVariant.map((variant) => ({
-            trait_type: variant.type,
-            value: variant.option
-          }))
-        ]
-      });
-
-      expect(metadatas[1]).toEqual({
-        ...productMetadata,
-        uuid: metadatas[1].uuid,
-        variations: variantsOK[1].productVariant,
-        attributes: [
-          ...productMetadata.attributes,
-          ...variantsOK[1].productVariant.map((variant) => ({
-            trait_type: variant.type,
-            value: variant.option
-          }))
-        ]
-      });
+      for (let i = 0; i < variantsOK.length; i++) {
+        expect(metadatas[i]).toEqual({
+          ...productMetadata,
+          uuid: metadatas[i].uuid,
+          variations: variantsOK[i].productVariant,
+          externalUrl: metadatas[i].externalUrl,
+          licenseUrl: metadatas[i].licenseUrl,
+          attributes: [
+            ...productMetadata.attributes,
+            ...variantsOK[i].productVariant.map((variant) => ({
+              trait_type: variant.type,
+              value: variant.option
+            }))
+          ]
+        });
+      }
     });
     test("add productOverrides to the metadata", async () => {
       const productOverrides = [
@@ -398,6 +416,8 @@ describe("#productV1 tests", () => {
           ...productMetadata,
           uuid: metadatas[index].uuid,
           variations: variantsOK[index].productVariant,
+          externalUrl: metadatas[index].externalUrl,
+          licenseUrl: metadatas[index].licenseUrl,
           productOverrides: productOverrides[index],
           attributes: [
             ...productMetadata.attributes,
@@ -428,32 +448,23 @@ describe("#productV1 tests", () => {
 
       expect(metadatas.length).toEqual(variantsOK.length);
 
-      expect(metadatas[0]).toEqual({
-        ...productMetadata,
-        uuid: metadatas[0].uuid,
-        variations: variantsOK[0].productVariant,
-        attributes: [
-          ...productMetadata.attributes,
-          ...variantsOK[0].productVariant.map((variant) => ({
-            trait_type: variant.type,
-            value: variant.option
-          }))
-        ]
-      });
-
-      expect(metadatas[1]).toEqual({
-        ...productMetadata,
-        uuid: metadatas[1].uuid,
-        variations: variantsOK[1].productVariant,
-        productOverrides: productOverrides[1],
-        attributes: [
-          ...productMetadata.attributes,
-          ...variantsOK[1].productVariant.map((variant) => ({
-            trait_type: variant.type,
-            value: variant.option
-          }))
-        ]
-      });
+      for (let i = 0; i < variantsOK.length; i++) {
+        expect(metadatas[i]).toEqual({
+          ...productMetadata,
+          uuid: metadatas[i].uuid,
+          variations: variantsOK[i].productVariant,
+          externalUrl: metadatas[i].externalUrl,
+          licenseUrl: metadatas[i].licenseUrl,
+          productOverrides: productOverrides[i],
+          attributes: [
+            ...productMetadata.attributes,
+            ...variantsOK[i].productVariant.map((variant) => ({
+              trait_type: variant.type,
+              value: variant.option
+            }))
+          ]
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
## Description

fixes https://app.asana.com/0/1200803815983047/1203447505735972
"Link to offer terms in OpenSea doesn't work"

## How to test

Create a multi-variant offer and check the externalUrl and licenseUrl in the metadata are valid links