### PR TITLE
feat: adapt biconomy relaying with forwarder

### DIFF
--- a/packages/core-sdk/src/forwarder/handler.ts
+++ b/packages/core-sdk/src/forwarder/handler.ts
@@ -7,13 +7,13 @@ export async function getNonce(args: {
   contractAddress: string;
   user: string;
   web3Lib: Web3LibAdapter;
-  batchId: BigNumberish;
+  batchId?: BigNumberish;
   forwarderAbi: typeof abis.MockForwarderABI | typeof abis.BiconomyForwarderABI;
 }): Promise<string> {
   const isMock = args.forwarderAbi === mockInterface.abi;
   const data = isMock
     ? mockInterface.encodeGetNonce(args.user)
-    : biconomyInterface.encodeGetNonce(args.user, args.batchId);
+    : biconomyInterface.encodeGetNonce(args.user, args.batchId || "0");
 
   const result = await args.web3Lib.call({
     to: args.contractAddress,
@@ -45,12 +45,10 @@ export async function verifyEIP712(args: {
     args.signature
   );
   try {
-    const result = await args.web3Lib.call({
+    await args.web3Lib.call({
       to: args.contractAddress,
       data
     });
-    const ret = biconomyInterface.decodeVerifyEIP712(result);
-    console.log({ ret });
     return true;
   } catch (e) {
     return false;

--- a/packages/core-sdk/src/meta-tx/biconomy.ts
+++ b/packages/core-sdk/src/meta-tx/biconomy.ts
@@ -44,12 +44,45 @@ export type GetRetriedHashesArgs = {
   transactionHash: string;
 };
 
+export type ForwarderDomainData = {
+  name: string;
+  version: string;
+  verifyingContract: string;
+  salt: string;
+};
+
 export class Biconomy {
   public constructor(
     private _relayerUrl: string,
-    private _apiKey: string,
-    private _apiId: string
+    private _apiKey?: string,
+    private _apiId?: string
   ) {}
+
+  public async getForwarderDomainDetails(
+    args: { chainId: number },
+    overrides: Partial<{
+      relayerUrl: string;
+      forwarderAddress: string;
+    }> = {}
+  ): Promise<{ [key: string]: ForwarderDomainData }> {
+    const url = `${
+      overrides.relayerUrl || this._relayerUrl
+    }/api/v2/meta-tx/systemInfo?networkId=${args.chainId}`;
+    const response = await fetch(url, { method: "GET" });
+
+    if (!response.ok) {
+      let message;
+      try {
+        const jsonResponse = await response.json();
+        message = JSON.stringify(jsonResponse);
+      } catch {
+        message = response.statusText;
+      }
+      throw new ApiError(response.status, `Failed to relay tx: ${message}`);
+    }
+    const txResponse = await response.json();
+    return txResponse?.forwarderDomainDetails;
+  }
 
   public async relayTransaction(
     args: RelayTransactionArgs,

--- a/packages/core-sdk/src/meta-tx/mixin.ts
+++ b/packages/core-sdk/src/meta-tx/mixin.ts
@@ -165,25 +165,17 @@ export class MetaTxMixin extends BaseCoreSDK {
       | "web3Lib"
       | "bosonVoucherAddress"
       | "chainId"
-      | "nonce"
       | "forwarderAddress"
       | "batchId"
       | "forwarderAbi"
+      | "relayerUrl"
     >,
     overrides: Partial<{
       batchId: BigNumberish;
     }> = {}
   ) {
-    const signerAddress = await this._web3Lib.getSignerAddress();
     const forwarderAddress = this._contracts.forwarder;
     const batchId = overrides.batchId || 0;
-    const nonce = await getNonce({
-      contractAddress: forwarderAddress,
-      user: signerAddress,
-      web3Lib: this._web3Lib,
-      batchId,
-      forwarderAbi: this._metaTxConfig.forwarderAbi
-    });
     const offerFromSubgraph = await getOfferById(
       this._subgraphUrl,
       args.offerId
@@ -192,10 +184,10 @@ export class MetaTxMixin extends BaseCoreSDK {
       web3Lib: this._web3Lib,
       bosonVoucherAddress: offerFromSubgraph.seller.voucherCloneAddress,
       chainId: this._chainId,
-      nonce,
       forwarderAddress,
       batchId,
       forwarderAbi: this._metaTxConfig.forwarderAbi,
+      relayerUrl: this._metaTxConfig.relayerUrl,
       ...args
     });
   }
@@ -210,6 +202,7 @@ export class MetaTxMixin extends BaseCoreSDK {
       | "forwarderAddress"
       | "batchId"
       | "forwarderAbi"
+      | "relayerUrl"
     >,
     overrides: Partial<{
       batchId: BigNumberish;
@@ -222,22 +215,15 @@ export class MetaTxMixin extends BaseCoreSDK {
     );
     const forwarderAddress = this._contracts.forwarder;
     const batchId = overrides.batchId || 0;
-    const nonce = await getNonce({
-      contractAddress: forwarderAddress,
-      user: sellerAddress,
-      web3Lib: this._web3Lib,
-      batchId,
-      forwarderAbi: this._metaTxConfig.forwarderAbi
-    });
 
     return handler.signMetaTxSetApprovalForAll({
       web3Lib: this._web3Lib,
       bosonVoucherAddress: seller.voucherCloneAddress,
       chainId: this._chainId,
-      nonce,
       forwarderAddress,
       batchId,
       forwarderAbi: this._metaTxConfig.forwarderAbi,
+      relayerUrl: this._metaTxConfig.relayerUrl,
       ...args
     });
   }
@@ -252,6 +238,7 @@ export class MetaTxMixin extends BaseCoreSDK {
       | "forwarderAddress"
       | "batchId"
       | "forwarderAbi"
+      | "relayerUrl"
     >,
     overrides: Partial<{
       batchId?: BigNumberish;
@@ -265,23 +252,16 @@ export class MetaTxMixin extends BaseCoreSDK {
     );
     const forwarderAddress = this._contracts.forwarder;
     const batchId = overrides.batchId || 0;
-    const nonce = await getNonce({
-      contractAddress: forwarderAddress,
-      user: sellerAddress,
-      web3Lib: this._web3Lib,
-      batchId,
-      forwarderAbi: this._metaTxConfig.forwarderAbi
-    });
 
     return handler.signMetaTxSetApprovalForAllToContract(
       {
         web3Lib: this._web3Lib,
         bosonVoucherAddress: seller.voucherCloneAddress,
         chainId: this._chainId,
-        nonce,
         forwarderAddress,
         batchId,
         forwarderAbi: this._metaTxConfig.forwarderAbi,
+        relayerUrl: this._metaTxConfig.relayerUrl,
         ...args
       },
       {
@@ -300,6 +280,7 @@ export class MetaTxMixin extends BaseCoreSDK {
       | "forwarderAddress"
       | "batchId"
       | "forwarderAbi"
+      | "relayerUrl"
     >,
     overrides: Partial<{
       batchId?: BigNumberish;
@@ -313,23 +294,16 @@ export class MetaTxMixin extends BaseCoreSDK {
     );
     const forwarderAddress = this._contracts.forwarder;
     const batchId = overrides.batchId || 0;
-    const nonce = await getNonce({
-      contractAddress: forwarderAddress,
-      user: sellerAddress,
-      web3Lib: this._web3Lib,
-      batchId,
-      forwarderAbi: this._metaTxConfig.forwarderAbi
-    });
 
     return handler.signMetaTxCallExternalContract(
       {
         web3Lib: this._web3Lib,
         bosonVoucherAddress: seller.voucherCloneAddress,
         chainId: this._chainId,
-        nonce,
         forwarderAddress,
         batchId,
         forwarderAbi: this._metaTxConfig.forwarderAbi,
+        relayerUrl: this._metaTxConfig.relayerUrl,
         ...args
       },
       {

--- a/packages/core-sdk/src/voucher/handler.ts
+++ b/packages/core-sdk/src/voucher/handler.ts
@@ -5,11 +5,15 @@ import {
   decodeGetAvailablePreMints,
   decodeGetRangeByOfferId,
   decodeIsApprovedForAll,
+  decodeIsTrustedForwarder,
+  decodeOwner,
   encodeBurnPremintedVouchers,
   encodeCallExternalContract,
   encodeGetAvailablePreMints,
   encodeGetRangeByOfferId,
   encodeIsApprovedForAll,
+  encodeIsTrustedForwarder,
+  encodeOwner,
   encodePreMint,
   encodeSetApprovalForAllToContract,
   encodeTransferFrom,
@@ -25,6 +29,29 @@ export async function burnPremintedVouchers(args: {
     to: args.contractAddress,
     data: encodeBurnPremintedVouchers(args.offerId)
   });
+}
+
+export async function owner(args: {
+  contractAddress: string;
+  web3Lib: Web3LibAdapter;
+}): Promise<string> {
+  const result = await args.web3Lib.call({
+    to: args.contractAddress,
+    data: encodeOwner()
+  });
+  return decodeOwner(result);
+}
+
+export async function isTrustedForwarder(args: {
+  forwarder: string;
+  contractAddress: string;
+  web3Lib: Web3LibAdapter;
+}): Promise<boolean> {
+  const result = await args.web3Lib.call({
+    to: args.contractAddress,
+    data: encodeIsTrustedForwarder(args.forwarder)
+  });
+  return decodeIsTrustedForwarder(result);
 }
 
 export async function getAvailablePreMints(args: {

--- a/packages/core-sdk/src/voucher/interface.ts
+++ b/packages/core-sdk/src/voucher/interface.ts
@@ -84,3 +84,64 @@ export function encodeWithdrawToProtocol(tokenList: string[]) {
     tokenList
   ]);
 }
+
+const ownableIface = new Interface([
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address"
+      }
+    ],
+    stateMutability: "view",
+    type: "function"
+  }
+]);
+
+export function encodeOwner() {
+  return ownableIface.encodeFunctionData("owner");
+}
+
+export function decodeOwner(result: string): string {
+  const [owner] = ownableIface.decodeFunctionResult("owner", result);
+  return owner;
+}
+
+const eRC2771ContextIface = new Interface([
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "forwarder",
+        type: "address"
+      }
+    ],
+    name: "isTrustedForwarder",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool"
+      }
+    ],
+    stateMutability: "view",
+    type: "function"
+  }
+]);
+
+export function encodeIsTrustedForwarder(forwarder: string) {
+  return eRC2771ContextIface.encodeFunctionData("isTrustedForwarder", [
+    forwarder
+  ]);
+}
+
+export function decodeIsTrustedForwarder(result: string): boolean {
+  const [isTrustedForwarder] = eRC2771ContextIface.decodeFunctionResult(
+    "isTrustedForwarder",
+    result
+  );
+  return isTrustedForwarder;
+}


### PR DESCRIPTION
## Description

- following the issue with Biconomy forwarder, the coreSDK now gets the Biconomy config (via HTTP API) to list all forwarder addresses, then check the voucher contract which one it supports. If none is found, an exception is raised.
- Once the forwarder to use has been identified, the meta-tranasaction is built and signed (with the appropriate forwarder address), then relayed through Biconomy

## How to test

N/A - e2e tests only use local forwarder and relayer