### PR TITLE
chore: allow to run pin-to-pinata workflow manually on a branch

### DIFF
--- a/.github/workflows/pin-to-pinata.yaml
+++ b/.github/workflows/pin-to-pinata.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   schedule:
     - cron: "0 * * * *" # run every hour
+  workflow_dispatch:
+    branches: [main]
 
 jobs:
   pin-to-pinata:


### PR DESCRIPTION
## Description

{{what was done}}

## How to test

{{how can it be tested}}
