### PR TITLE
fix: usdc approve fails from dcl

### DIFF
--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bosonprotocol/core-sdk",
-  "version": "1.25.0-alpha.10",
+  "version": "1.25.0-mvfw23.1",
   "description": "Facilitates interaction with the contracts and subgraphs of the Boson Protocol",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/core-sdk/src/native-meta-tx/handler.ts
+++ b/packages/core-sdk/src/native-meta-tx/handler.ts
@@ -36,24 +36,19 @@ export async function getNonce(args: {
     );
     return String(nonce);
   } catch (e) {
-    // Check if the error means the 'getNonce()' function does not exists in the contract
-    if (
-      (e.message as string)?.match(
-        /Transaction reverted without a reason string/
-      )
-    ) {
-      // If so, call 'nonces()' instead (USDC case, for instance)
-      const result = await args.web3Lib.call({
-        to: args.contractAddress,
-        data: alternativeNonceIface.encodeFunctionData("nonces", [args.user])
-      });
-      const [nonce] = alternativeNonceIface.decodeFunctionResult(
-        "nonces",
-        result
-      );
-      return String(nonce);
-    }
-    throw e;
+    console.warn(
+      `Calling getNonce() for contract ${args.contractAddress} has failed. Try with 'nonces' instead`
+    );
+    // If so, call 'nonces()' instead (USDC case, for instance)
+    const result = await args.web3Lib.call({
+      to: args.contractAddress,
+      data: alternativeNonceIface.encodeFunctionData("nonces", [args.user])
+    });
+    const [nonce] = alternativeNonceIface.decodeFunctionResult(
+      "nonces",
+      result
+    );
+    return String(nonce);
   }
 }
 


### PR DESCRIPTION
## Description

USDC approval meta-tx signing fails only when called from DCL
This was coming from getNonce() implementation that retries with "nonces" instead of "getNonce" only when failing and the error message matches the one returned by Metamask. However on DCL, we are using an HTTP provider instead of Metamask and the error message is not the same.

## How to test

N/A