### PR TITLE
feat: allow checking an offer is compliant with the fair exchange policy

### DIFF
--- a/data/exchangePolicies/exchangePolicyRules.template.json
+++ b/data/exchangePolicies/exchangePolicyRules.template.json
@@ -14,7 +14,7 @@
       "disputeResolverId": {
         "description": "Dispute Resolver",
         "type": "string",
-        "matches": "^(1)$",
+        "matches": "^(<DEFAULT_DISPUTE_RESOLVER_ID>)$",
         "required": true
       },
       "exchangeToken": {
@@ -24,7 +24,7 @@
             "description": "Exchange Token",
             "type": "string",
             "flags": "i",
-            "pattern": "^(0x0000000000000000000000000000000000000000)$",
+            "pattern": "^(<TOKENS_LIST>)$",
             "required": true
           }
         },
@@ -52,7 +52,7 @@
                 "description": "Buyer/Seller Agreement Template",
                 "type": "string",
                 "flags": "i",
-                "pattern": "^(fairExchangePolicy|ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz)$",
+                "pattern": "^(fairExchangePolicy|ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz|ipfs://QmZEYfG31PR1SgStg1wCFawQPxtbY9N44vDK9fjj3J9oz2|ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz|ipfs://QmXfDShmggHm7BzMbkzv2rRowwPyJ55mypGp32qKSPGto4|ipfs://QmXxRznUVMkQMb6hLiojbiv9uDw22RcEpVk6Gr3YywihcJ)$",
                 "required": true
               }
             },

--- a/data/exchangePolicies/fairExchangePolicy-testing.json
+++ b/data/exchangePolicies/fairExchangePolicy-testing.json
@@ -1,8 +1,0 @@
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/person.schema.json",
-  "title": "Person",
-  "description": "A person",
-  "type": "object",
-  "properties": {}
-}

--- a/data/exchangePolicies/fairExchangePolicy-testing.json
+++ b/data/exchangePolicies/fairExchangePolicy-testing.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/person.schema.json",
+  "title": "Person",
+  "description": "A person",
+  "type": "object",
+  "properties": {}
+}

--- a/data/ipfs.txt
+++ b/data/ipfs.txt
@@ -3,3 +3,4 @@ HERE AFTER THE IPFS HASH OF THE UPLOADED FILES (FOR RECORDING AND TRACEABILITY)
 
 contractualAgreement.template.md QmZEYfG31PR1SgStg1wCFawQPxtbY9N44vDK9fjj3J9oz2
 rNFTLicense.template.md QmeVkdpKbfHKrPb9tXDXUoPEResEanGpcGANfAjb8bUQYT
+exchangePolicyRules.template.json QmV3Wy2wmrFdEXzhyhvvaW25Q8w2wTd2UypFVyhwsdBE8T

--- a/e2e/tests/core-sdk-extend-offer.test.ts
+++ b/e2e/tests/core-sdk-extend-offer.test.ts
@@ -1,5 +1,4 @@
-import { BigNumber, Wallet } from "ethers";
-import { CoreSDK } from "../../packages/core-sdk/src";
+import { BigNumber } from "ethers";
 
 import {
   createOffer,
@@ -7,14 +6,12 @@ import {
   ensureCreatedSeller,
   initCoreSDKWithFundedWallet,
   seedWallet16,
-  seedWallet17,
   waitForGraphNodeIndexing
 } from "./utils";
 
 jest.setTimeout(60_000);
 
 const seedWallet = seedWallet16; // be sure the seedWallet is not used by another test (to allow concurrent run)
-const buyerWallet = seedWallet17;
 
 describe("core-sdk-extend-offer", () => {
   test("Extend an offer", async () => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "abi-signatures:export": "ts-node -P tsconfig.base.json ./scripts/abi-signatures.ts --csv scripts/abi-signatures.csv",
     "pin-to-pinata": "ts-node -P tsconfig.base.json ./scripts/pin-to-pinata.ts",
     "complete-exchange": "ts-node -P tsconfig.base.json ./scripts/complete-exchange.ts",
-    "update-contract-uri": "ts-node -P tsconfig.base.json ./scripts/change-contract-uri.ts"
+    "update-contract-uri": "ts-node -P tsconfig.base.json ./scripts/change-contract-uri.ts",
+    "check-offer-exchange-policy": "ts-node -P tsconfig.base.json ./scripts/checkOfferExchangePolicy.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -44,6 +44,7 @@
     "graphql": "^16.5.0",
     "graphql-request": "^4.3.0",
     "mustache": "^4.2.0",
+    "schema-to-yup": "^1.11.11",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/packages/core-sdk/src/offers/checkExchangePolicy.ts
+++ b/packages/core-sdk/src/offers/checkExchangePolicy.ts
@@ -28,10 +28,10 @@ export type YupPropertyDef = {
 
 export type CheckExchangePolicyRules = {
   yupSchema: {
-    $schema: string;
-    $id: string;
-    title: string;
-    description: string;
+    $schema?: string;
+    $id?: string;
+    title?: string;
+    description?: string;
     type: string;
     properties: {
       [key: string]: YupPropertyDef;

--- a/packages/core-sdk/src/offers/checkExchangePolicy.ts
+++ b/packages/core-sdk/src/offers/checkExchangePolicy.ts
@@ -1,0 +1,77 @@
+import { buildYup } from "schema-to-yup";
+import { SchemaOf } from "yup";
+import { OfferFieldsFragment } from "../subgraph";
+
+export type CheckExchangePolicyResult = {
+  isValid: boolean;
+  errors: {
+    message: string;
+    path: string;
+    value: unknown;
+  }[];
+};
+
+export type YupPropertyDef = {
+  title?: string;
+  description?: string;
+  type: string;
+  properties?: {
+    [key: string]: YupPropertyDef;
+  };
+  required?: boolean;
+  min?: string | number;
+  max?: string | number;
+  flags?: string;
+  pattern?: string;
+  matches?: string;
+};
+
+export type CheckExchangePolicyRules = {
+  yupSchema: {
+    $schema: string;
+    $id: string;
+    title: string;
+    description: string;
+    type: string;
+    properties: {
+      [key: string]: YupPropertyDef;
+    };
+  };
+  yupConfig: {
+    errMessages?: {
+      [key: string]: {
+        required?: string;
+        min?: string;
+        max?: string;
+        flags?: string;
+        pattern?: string;
+        matches?: string;
+      };
+    };
+  };
+};
+
+export function checkExchangePolicy(
+  offerData: OfferFieldsFragment,
+  rules: CheckExchangePolicyRules
+): CheckExchangePolicyResult {
+  const baseSchema: SchemaOf<unknown> = buildYup(
+    rules.yupSchema,
+    rules.yupConfig
+  );
+  try {
+    baseSchema.validateSync(offerData, { abortEarly: false });
+  } catch (e) {
+    return {
+      isValid: false,
+      errors:
+        e.inner?.map((error) => {
+          return { ...error };
+        }) || []
+    };
+  }
+  return {
+    isValid: true,
+    errors: []
+  };
+}

--- a/packages/core-sdk/src/offers/index.ts
+++ b/packages/core-sdk/src/offers/index.ts
@@ -7,6 +7,7 @@ export * as storage from "./storage";
 export * from "./types";
 export * from "./getOfferStatus";
 export * from "./renderContractualAgreement";
+export * from "./checkExchangePolicy";
 
 export const validation: {
   createOfferArgsSchema: typeof utils.validation.createOfferArgsSchema;

--- a/packages/core-sdk/src/offers/mixin.ts
+++ b/packages/core-sdk/src/offers/mixin.ts
@@ -450,4 +450,20 @@ export class OfferMixin extends BaseCoreSDK {
     }
     throw new Error(`Unsupported tokenType=${tokenType}`);
   }
+
+  /**
+   * Check a given offer meets ExchangePolicy rules.
+   * @param offerId - Id of offer to render agreement for.
+   * @returns Contractual agreement as string.
+   */
+  public async checkExchangePolicy(
+    offerId: BigNumberish,
+    rules: offers.CheckExchangePolicyRules
+  ): Promise<offers.CheckExchangePolicyResult> {
+    const offerData = await offers.subgraph.getOfferById(
+      this._subgraphUrl,
+      offerId
+    );
+    return offers.checkExchangePolicy(offerData, rules);
+  }
 }

--- a/packages/core-sdk/tests/check-exchange-policy.test.ts
+++ b/packages/core-sdk/tests/check-exchange-policy.test.ts
@@ -1,0 +1,115 @@
+import { offers } from "../src";
+import invalidOffer1 from "./exchangePolicy/examples/invalidOffer1.json";
+import invalidOffer2 from "./exchangePolicy/examples/invalidOffer2.json";
+import invalidOffer3 from "./exchangePolicy/examples/invalidOffer3.json";
+import invalidOffer4 from "./exchangePolicy/examples/invalidOffer4.json";
+import invalidOffer5 from "./exchangePolicy/examples/invalidOffer5.json";
+import validOffer from "./exchangePolicy/examples/validOffer.json";
+import exchangePolicyRules from "./exchangePolicy/exchangePolicyRules.testing.json";
+import { OfferFieldsFragment } from "../src/subgraph";
+
+describe("test check exchange policy", () => {
+  test("test check exchange policy with validOffer data", () => {
+    const result = offers.checkExchangePolicy(
+      validOffer as OfferFieldsFragment,
+      exchangePolicyRules
+    );
+    expect(result.isValid).toBe(true);
+  });
+  test("test check exchange policy with invalidOffer data (1 error)", () => {
+    const result = offers.checkExchangePolicy(
+      invalidOffer1 as OfferFieldsFragment,
+      exchangePolicyRules
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.errors.length).toEqual(1);
+    expect(result.errors[0].message).toEqual(
+      "Dispute Period Duration is less than 30 days"
+    );
+  });
+  test("test check exchange policy with invalidOffer data (all errors)", () => {
+    const result = offers.checkExchangePolicy(
+      invalidOffer2 as OfferFieldsFragment,
+      exchangePolicyRules
+    );
+    expect(result.isValid).toBe(false);
+    const messagePerPath = {
+      disputePeriodDuration: "Dispute Period Duration is less than 30 days",
+      disputeResolverId: "Dispute Resolver is not whitelisted",
+      "exchangeToken.address": "Currency Token is not whitelisted",
+      resolutionPeriodDuration:
+        "Resolution Period Duration is less than 15 days",
+      "metadata.type": "Metadata Type is not PRODUCT_V1 standard",
+      "metadata.exchangePolicy.template":
+        "Buyer/Seller Agreement Template is not standard",
+      "metadata.shipping.returnPeriodInDays":
+        "Return Period is less than 15 days"
+    };
+    expect(result.errors.length).toEqual(Object.keys(messagePerPath).length);
+    for (const path in messagePerPath) {
+      expect(result.errors.find((error) => error.path === path)).toBeTruthy();
+      expect(
+        result.errors.find((error) => error.path === path)?.message
+      ).toEqual(messagePerPath[path]);
+    }
+  });
+  test("test check exchange policy with invalidOffer data (missing data 1/3)", () => {
+    const result = offers.checkExchangePolicy(
+      invalidOffer3 as unknown as OfferFieldsFragment,
+      exchangePolicyRules
+    );
+    expect(result.isValid).toBe(false);
+    const messagePerPath = {
+      "metadata.type": "Metadata Type is not specified",
+      "metadata.exchangePolicy.template":
+        "Buyer/Seller Agreement Template is not specified",
+      "metadata.shipping.returnPeriodInDays": "Return Period is not specified"
+    };
+    expect(result.errors.length).toEqual(Object.keys(messagePerPath).length);
+    for (const path in messagePerPath) {
+      expect(result.errors.find((error) => error.path === path)).toBeTruthy();
+      expect(
+        result.errors.find((error) => error.path === path)?.message
+      ).toEqual(messagePerPath[path]);
+    }
+  });
+  test("test check exchange policy with invalidOffer data (missing data 2/3)", () => {
+    const result = offers.checkExchangePolicy(
+      invalidOffer4 as unknown as OfferFieldsFragment,
+      exchangePolicyRules
+    );
+    expect(result.isValid).toBe(false);
+    const messagePerPath = {
+      "metadata.type": "Metadata Type is not specified",
+      "metadata.exchangePolicy.template":
+        "Buyer/Seller Agreement Template is not specified",
+      "metadata.shipping.returnPeriodInDays": "Return Period is not specified"
+    };
+    expect(result.errors.length).toEqual(Object.keys(messagePerPath).length);
+    for (const path in messagePerPath) {
+      expect(result.errors.find((error) => error.path === path)).toBeTruthy();
+      expect(
+        result.errors.find((error) => error.path === path)?.message
+      ).toEqual(messagePerPath[path]);
+    }
+  });
+  test("test check exchange policy with invalidOffer data (missing data 3/3)", () => {
+    const result = offers.checkExchangePolicy(
+      invalidOffer5 as unknown as OfferFieldsFragment,
+      exchangePolicyRules
+    );
+    expect(result.isValid).toBe(false);
+    const messagePerPath = {
+      "metadata.exchangePolicy.template":
+        "Buyer/Seller Agreement Template is not specified",
+      "metadata.shipping.returnPeriodInDays": "Return Period is not specified"
+    };
+    expect(result.errors.length).toEqual(Object.keys(messagePerPath).length);
+    for (const path in messagePerPath) {
+      expect(result.errors.find((error) => error.path === path)).toBeTruthy();
+      expect(
+        result.errors.find((error) => error.path === path)?.message
+      ).toEqual(messagePerPath[path]);
+    }
+  });
+});

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer1.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer1.json
@@ -1,0 +1,596 @@
+{
+  "id": "10",
+  "createdAt": "1683819387",
+  "price": "100000000000000",
+  "sellerDeposit": "0",
+  "protocolFee": "500000000000",
+  "agentFee": "0",
+  "agentId": "0",
+  "buyerCancelPenalty": "0",
+  "quantityAvailable": "97",
+  "quantityInitial": "100",
+  "validFromDate": "1683819900",
+  "validUntilDate": "1685570340",
+  "voucherRedeemableFromDate": "1683819600",
+  "voucherRedeemableUntilDate": "1685570340",
+  "disputePeriodDuration": "2591999",
+  "voucherValidDuration": "0",
+  "resolutionPeriodDuration": "1296000",
+  "metadataUri": "ipfs://QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "metadataHash": "QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "voided": false,
+  "voidedAt": null,
+  "disputeResolverId": "13",
+  "numberOfCommits": "3",
+  "numberOfRedemptions": "3",
+  "condition": null,
+  "seller": {
+    "id": "30",
+    "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "authTokenId": "0",
+    "authTokenType": 0,
+    "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+    "active": true,
+    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+    "royaltyPercentage": "200",
+    "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+    "metadata": {
+      "id": "30-seller-metadata",
+      "createdAt": "1687943706",
+      "name": "reg",
+      "description": "reg",
+      "legalTradingName": "legal reg",
+      "type": "SELLER",
+      "kind": "regular",
+      "website": "www.reg2.com",
+      "images": [
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+          "tag": "profile",
+          "type": "image/png",
+          "width": 200,
+          "height": 200,
+          "fit": null,
+          "position": null
+        },
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+          "tag": "cover",
+          "type": "image/jpeg",
+          "width": 1531,
+          "height": 190,
+          "fit": null,
+          "position": null
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email-contact-link",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "socialLinks": [],
+      "salesChannels": [
+        {
+          "id": "30-custom storefront-customstore1-sale-channel",
+          "tag": "Custom storefront",
+          "name": "customstore1",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+              "lastUpdated": "1687773517"
+            }
+          ]
+        },
+        {
+          "id": "30-custom storefront-hola-sale-channel",
+          "tag": "Custom storefront",
+          "name": "hola",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+              "lastUpdated": "1687862702"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "exchangeToken": {
+    "id": "0x0000000000000000000000000000000000000000",
+    "address": "0x0000000000000000000000000000000000000000",
+    "decimals": "18",
+    "symbol": "MATIC",
+    "name": "Matic"
+  },
+  "disputeResolver": {
+    "id": "13",
+    "escalationResponsePeriod": "7775999",
+    "admin": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "clerk": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "treasury": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "assistant": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "metadataUri": "ipfs://dispute-resolver-uri",
+    "active": true,
+    "sellerAllowList": [],
+    "fees": [
+      {
+        "id": "13-0x0000000000000000000000000000000000000000-fee",
+        "tokenAddress": "0x0000000000000000000000000000000000000000",
+        "tokenName": "ETH",
+        "token": {
+          "id": "0x0000000000000000000000000000000000000000",
+          "address": "0x0000000000000000000000000000000000000000",
+          "decimals": "18",
+          "symbol": "MATIC",
+          "name": "Matic"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f-fee",
+        "tokenAddress": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+        "tokenName": "DAI",
+        "token": {
+          "id": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "address": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "decimals": "18",
+          "symbol": "DAI",
+          "name": "DAI"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0-fee",
+        "tokenAddress": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+        "tokenName": "BOSON",
+        "token": {
+          "id": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "address": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "decimals": "18",
+          "symbol": "BOSON",
+          "name": "Boson Token (PoS)"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832-fee",
+        "tokenAddress": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+        "tokenName": "USDT",
+        "token": {
+          "id": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "address": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "decimals": "6",
+          "symbol": "USDT",
+          "name": "Tether USD"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa-fee",
+        "tokenAddress": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+        "tokenName": "WETH",
+        "token": {
+          "id": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "address": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "decimals": "18",
+          "symbol": "WETH",
+          "name": "Wrapped Ether"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xe6b8a5cf854791412c1f6efc7caf629f5df1c747-fee",
+        "tokenAddress": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+        "tokenName": "USDC",
+        "token": {
+          "id": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "address": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "decimals": "6",
+          "symbol": "USDC",
+          "name": "Mumbai USD Coin"
+        },
+        "feeAmount": "0"
+      }
+    ]
+  },
+  "disputeResolutionTerms": {
+    "id": "13-10-terms",
+    "disputeResolverId": "13",
+    "escalationResponsePeriod": "7775999",
+    "feeAmount": "0",
+    "buyerEscalationDeposit": "0"
+  },
+  "metadata": {
+    "name": "a",
+    "description": "desc\n\nTerms for the Boson rNFT Voucher: http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "externalUrl": "http://localhost:3000/#/offer-uuid/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "animationUrl": null,
+    "animationMetadata": null,
+    "licenseUrl": "http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "condition": null,
+    "schemaUrl": "https://schema.org/",
+    "type": "PRODUCT_V1",
+    "image": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+    "attributes": [
+      {
+        "traitType": "Redeemable At",
+        "value": "http://localhost:3000",
+        "displayType": ""
+      },
+      {
+        "traitType": "Redeemable Until",
+        "value": "1685570340000",
+        "displayType": "date"
+      },
+      {
+        "traitType": "Seller",
+        "value": "reg name",
+        "displayType": ""
+      },
+      {
+        "traitType": "Token Type",
+        "value": "BOSON rNFT",
+        "displayType": ""
+      }
+    ],
+    "createdAt": "1683819387",
+    "voided": false,
+    "validFromDate": "1683819900",
+    "validUntilDate": "1685570340",
+    "quantityAvailable": "97",
+    "uuid": "0eaefa-3f54-72ce-0c5a-65a6c201",
+    "product": {
+      "id": "2d62d7-7346-b74-b227-56dbf668dfbb-1",
+      "uuid": "2d62d7-7346-b74-b227-56dbf668dfbb",
+      "version": 1,
+      "title": "a",
+      "description": "desc",
+      "identification_sKU": null,
+      "identification_productId": null,
+      "identification_productIdType": null,
+      "productionInformation_brandName": "reg name",
+      "brand": {
+        "id": "reg name",
+        "name": "reg name"
+      },
+      "productionInformation_manufacturer": null,
+      "productionInformation_manufacturerPartNumber": null,
+      "productionInformation_modelNumber": null,
+      "productionInformation_materials": [],
+      "details_category": "apparel-accessories",
+      "category": {
+        "id": "apparel-accessories",
+        "name": "apparel-accessories"
+      },
+      "details_subCategory": null,
+      "subCategory": null,
+      "details_subCategory2": null,
+      "subCategory2": null,
+      "details_offerCategory": "PHYSICAL",
+      "offerCategory": "PHYSICAL",
+      "details_tags": [
+        "taa"
+      ],
+      "tags": [
+        {
+          "id": "taa",
+          "name": "taa"
+        }
+      ],
+      "details_sections": [],
+      "sections": [],
+      "details_personalisation": [],
+      "personalisation": [],
+      "visuals_images": [
+        {
+          "id": "ipfs://qmqh2jgehkqfke4o8ldvypcnwdqipurvh55jcczuwz96kx-product_image",
+          "url": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+          "tag": "product_image",
+          "type": "IMAGE",
+          "width": 1111,
+          "height": 642
+        }
+      ],
+      "visuals_videos": [],
+      "packaging_packageQuantity": null,
+      "packaging_dimensions_length": null,
+      "packaging_dimensions_width": null,
+      "packaging_dimensions_height": null,
+      "packaging_dimensions_unit": "m",
+      "packaging_weight_value": null,
+      "packaging_weight_unit": "kg",
+      "productV1Seller": {
+        "id": "30-product-v1",
+        "defaultVersion": 1,
+        "name": "my_name",
+        "description": "my_bio",
+        "externalUrl": "www.reg2.com",
+        "tokenId": null,
+        "sellerId": "30",
+        "images": [
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+            "tag": "profile",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          },
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+            "tag": "cover",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          }
+        ],
+        "contactLinks": [
+          {
+            "id": "reg@email.com-email",
+            "url": "reg@email.com",
+            "tag": "email"
+          }
+        ],
+        "contactPreference": "xmtp_and_email",
+        "seller": {
+          "id": "30",
+          "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "authTokenId": "0",
+          "authTokenType": 0,
+          "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+          "active": true,
+          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+          "royaltyPercentage": "200",
+          "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+          "metadata": {
+            "id": "30-seller-metadata",
+            "createdAt": "1687943706",
+            "name": "reg",
+            "description": "reg",
+            "legalTradingName": "legal reg",
+            "type": "SELLER",
+            "kind": "regular",
+            "website": "www.reg2.com",
+            "images": [
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+                "tag": "profile",
+                "type": "image/png",
+                "width": 200,
+                "height": 200,
+                "fit": null,
+                "position": null
+              },
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+                "tag": "cover",
+                "type": "image/jpeg",
+                "width": 1531,
+                "height": 190,
+                "fit": null,
+                "position": null
+              }
+            ],
+            "contactLinks": [
+              {
+                "id": "reg@email.com-email-contact-link",
+                "url": "reg@email.com",
+                "tag": "email"
+              }
+            ],
+            "contactPreference": "xmtp_and_email",
+            "socialLinks": [],
+            "salesChannels": [
+              {
+                "id": "30-custom storefront-customstore1-sale-channel",
+                "tag": "Custom storefront",
+                "name": "customstore1",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                    "lastUpdated": "1687773517"
+                  }
+                ]
+              },
+              {
+                "id": "30-custom storefront-hola-sale-channel",
+                "tag": "Custom storefront",
+                "name": "hola",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                    "lastUpdated": "1687862702"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "salesChannels": []
+    },
+    "variations": [],
+    "productV1Seller": {
+      "id": "30-product-v1",
+      "defaultVersion": 1,
+      "name": "my_name",
+      "description": "my_bio",
+      "externalUrl": "www.reg2.com",
+      "tokenId": null,
+      "sellerId": "30",
+      "images": [
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+          "tag": "profile",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        },
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+          "tag": "cover",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "seller": {
+        "id": "30",
+        "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "authTokenId": "0",
+        "authTokenType": 0,
+        "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+        "active": true,
+        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+        "royaltyPercentage": "200",
+        "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+        "metadata": {
+          "id": "30-seller-metadata",
+          "createdAt": "1687943706",
+          "name": "reg",
+          "description": "reg",
+          "legalTradingName": "legal reg",
+          "type": "SELLER",
+          "kind": "regular",
+          "website": "www.reg2.com",
+          "images": [
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+              "tag": "profile",
+              "type": "image/png",
+              "width": 200,
+              "height": 200,
+              "fit": null,
+              "position": null
+            },
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+              "tag": "cover",
+              "type": "image/jpeg",
+              "width": 1531,
+              "height": 190,
+              "fit": null,
+              "position": null
+            }
+          ],
+          "contactLinks": [
+            {
+              "id": "reg@email.com-email-contact-link",
+              "url": "reg@email.com",
+              "tag": "email"
+            }
+          ],
+          "contactPreference": "xmtp_and_email",
+          "socialLinks": [],
+          "salesChannels": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel",
+              "tag": "Custom storefront",
+              "name": "customstore1",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                  "lastUpdated": "1687773517"
+                }
+              ]
+            },
+            {
+              "id": "30-custom storefront-hola-sale-channel",
+              "tag": "Custom storefront",
+              "name": "hola",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                  "lastUpdated": "1687862702"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "exchangePolicy": {
+      "id": "10-metadata-exchange-policy",
+      "uuid": "1683819377084",
+      "version": 1,
+      "label": "Fair Exchange Policy",
+      "template": "fairExchangePolicy",
+      "sellerContactMethod": "Chat App in the dApp",
+      "disputeResolverContactMethod": "email to: disputes-test@redeemeum.com"
+    },
+    "shipping": {
+      "id": "10-metadata-shipping",
+      "defaultVersion": 1,
+      "countryOfOrigin": null,
+      "supportedJurisdictions": [],
+      "redemptionPoint": null,
+      "returnPeriodInDays": 15
+    }
+  },
+  "range": null
+}

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer2.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer2.json
@@ -1,0 +1,596 @@
+{
+  "id": "10",
+  "createdAt": "1683819387",
+  "price": "100000000000000",
+  "sellerDeposit": "0",
+  "protocolFee": "500000000000",
+  "agentFee": "0",
+  "agentId": "0",
+  "buyerCancelPenalty": "0",
+  "quantityAvailable": "97",
+  "quantityInitial": "100",
+  "validFromDate": "1683819900",
+  "validUntilDate": "1685570340",
+  "voucherRedeemableFromDate": "1683819600",
+  "voucherRedeemableUntilDate": "1685570340",
+  "disputePeriodDuration": "2591999",
+  "voucherValidDuration": "0",
+  "resolutionPeriodDuration": "1295999",
+  "metadataUri": "ipfs://QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "metadataHash": "QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "voided": false,
+  "voidedAt": null,
+  "disputeResolverId": "12",
+  "numberOfCommits": "3",
+  "numberOfRedemptions": "3",
+  "condition": null,
+  "seller": {
+    "id": "30",
+    "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "authTokenId": "0",
+    "authTokenType": 0,
+    "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+    "active": true,
+    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+    "royaltyPercentage": "200",
+    "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+    "metadata": {
+      "id": "30-seller-metadata",
+      "createdAt": "1687943706",
+      "name": "reg",
+      "description": "reg",
+      "legalTradingName": "legal reg",
+      "type": "SELLER",
+      "kind": "regular",
+      "website": "www.reg2.com",
+      "images": [
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+          "tag": "profile",
+          "type": "image/png",
+          "width": 200,
+          "height": 200,
+          "fit": null,
+          "position": null
+        },
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+          "tag": "cover",
+          "type": "image/jpeg",
+          "width": 1531,
+          "height": 190,
+          "fit": null,
+          "position": null
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email-contact-link",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "socialLinks": [],
+      "salesChannels": [
+        {
+          "id": "30-custom storefront-customstore1-sale-channel",
+          "tag": "Custom storefront",
+          "name": "customstore1",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+              "lastUpdated": "1687773517"
+            }
+          ]
+        },
+        {
+          "id": "30-custom storefront-hola-sale-channel",
+          "tag": "Custom storefront",
+          "name": "hola",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+              "lastUpdated": "1687862702"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "exchangeToken": {
+    "id": "0x6982508145454Ce325dDbE47a25d4ec3d2311934",
+    "address": "0x6982508145454Ce325dDbE47a25d4ec3d2311934",
+    "decimals": "18",
+    "symbol": "FAKE",
+    "name": "Fake"
+  },
+  "disputeResolver": {
+    "id": "13",
+    "escalationResponsePeriod": "7775999",
+    "admin": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "clerk": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "treasury": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "assistant": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "metadataUri": "ipfs://dispute-resolver-uri",
+    "active": true,
+    "sellerAllowList": [],
+    "fees": [
+      {
+        "id": "13-0x0000000000000000000000000000000000000000-fee",
+        "tokenAddress": "0x0000000000000000000000000000000000000000",
+        "tokenName": "ETH",
+        "token": {
+          "id": "0x0000000000000000000000000000000000000000",
+          "address": "0x0000000000000000000000000000000000000000",
+          "decimals": "18",
+          "symbol": "MATIC",
+          "name": "Matic"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f-fee",
+        "tokenAddress": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+        "tokenName": "DAI",
+        "token": {
+          "id": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "address": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "decimals": "18",
+          "symbol": "DAI",
+          "name": "DAI"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0-fee",
+        "tokenAddress": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+        "tokenName": "BOSON",
+        "token": {
+          "id": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "address": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "decimals": "18",
+          "symbol": "BOSON",
+          "name": "Boson Token (PoS)"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832-fee",
+        "tokenAddress": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+        "tokenName": "USDT",
+        "token": {
+          "id": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "address": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "decimals": "6",
+          "symbol": "USDT",
+          "name": "Tether USD"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa-fee",
+        "tokenAddress": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+        "tokenName": "WETH",
+        "token": {
+          "id": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "address": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "decimals": "18",
+          "symbol": "WETH",
+          "name": "Wrapped Ether"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xe6b8a5cf854791412c1f6efc7caf629f5df1c747-fee",
+        "tokenAddress": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+        "tokenName": "USDC",
+        "token": {
+          "id": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "address": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "decimals": "6",
+          "symbol": "USDC",
+          "name": "Mumbai USD Coin"
+        },
+        "feeAmount": "0"
+      }
+    ]
+  },
+  "disputeResolutionTerms": {
+    "id": "13-10-terms",
+    "disputeResolverId": "13",
+    "escalationResponsePeriod": "7775999",
+    "feeAmount": "0",
+    "buyerEscalationDeposit": "0"
+  },
+  "metadata": {
+    "name": "a",
+    "description": "desc\n\nTerms for the Boson rNFT Voucher: http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "externalUrl": "http://localhost:3000/#/offer-uuid/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "animationUrl": null,
+    "animationMetadata": null,
+    "licenseUrl": "http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "condition": null,
+    "schemaUrl": "https://schema.org/",
+    "type": "NON_STANDARD_TYPE",
+    "image": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+    "attributes": [
+      {
+        "traitType": "Redeemable At",
+        "value": "http://localhost:3000",
+        "displayType": ""
+      },
+      {
+        "traitType": "Redeemable Until",
+        "value": "1685570340000",
+        "displayType": "date"
+      },
+      {
+        "traitType": "Seller",
+        "value": "reg name",
+        "displayType": ""
+      },
+      {
+        "traitType": "Token Type",
+        "value": "BOSON rNFT",
+        "displayType": ""
+      }
+    ],
+    "createdAt": "1683819387",
+    "voided": false,
+    "validFromDate": "1683819900",
+    "validUntilDate": "1685570340",
+    "quantityAvailable": "97",
+    "uuid": "0eaefa-3f54-72ce-0c5a-65a6c201",
+    "product": {
+      "id": "2d62d7-7346-b74-b227-56dbf668dfbb-1",
+      "uuid": "2d62d7-7346-b74-b227-56dbf668dfbb",
+      "version": 1,
+      "title": "a",
+      "description": "desc",
+      "identification_sKU": null,
+      "identification_productId": null,
+      "identification_productIdType": null,
+      "productionInformation_brandName": "reg name",
+      "brand": {
+        "id": "reg name",
+        "name": "reg name"
+      },
+      "productionInformation_manufacturer": null,
+      "productionInformation_manufacturerPartNumber": null,
+      "productionInformation_modelNumber": null,
+      "productionInformation_materials": [],
+      "details_category": "apparel-accessories",
+      "category": {
+        "id": "apparel-accessories",
+        "name": "apparel-accessories"
+      },
+      "details_subCategory": null,
+      "subCategory": null,
+      "details_subCategory2": null,
+      "subCategory2": null,
+      "details_offerCategory": "PHYSICAL",
+      "offerCategory": "PHYSICAL",
+      "details_tags": [
+        "taa"
+      ],
+      "tags": [
+        {
+          "id": "taa",
+          "name": "taa"
+        }
+      ],
+      "details_sections": [],
+      "sections": [],
+      "details_personalisation": [],
+      "personalisation": [],
+      "visuals_images": [
+        {
+          "id": "ipfs://qmqh2jgehkqfke4o8ldvypcnwdqipurvh55jcczuwz96kx-product_image",
+          "url": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+          "tag": "product_image",
+          "type": "IMAGE",
+          "width": 1111,
+          "height": 642
+        }
+      ],
+      "visuals_videos": [],
+      "packaging_packageQuantity": null,
+      "packaging_dimensions_length": null,
+      "packaging_dimensions_width": null,
+      "packaging_dimensions_height": null,
+      "packaging_dimensions_unit": "m",
+      "packaging_weight_value": null,
+      "packaging_weight_unit": "kg",
+      "productV1Seller": {
+        "id": "30-product-v1",
+        "defaultVersion": 1,
+        "name": "my_name",
+        "description": "my_bio",
+        "externalUrl": "www.reg2.com",
+        "tokenId": null,
+        "sellerId": "30",
+        "images": [
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+            "tag": "profile",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          },
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+            "tag": "cover",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          }
+        ],
+        "contactLinks": [
+          {
+            "id": "reg@email.com-email",
+            "url": "reg@email.com",
+            "tag": "email"
+          }
+        ],
+        "contactPreference": "xmtp_and_email",
+        "seller": {
+          "id": "30",
+          "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "authTokenId": "0",
+          "authTokenType": 0,
+          "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+          "active": true,
+          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+          "royaltyPercentage": "200",
+          "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+          "metadata": {
+            "id": "30-seller-metadata",
+            "createdAt": "1687943706",
+            "name": "reg",
+            "description": "reg",
+            "legalTradingName": "legal reg",
+            "type": "SELLER",
+            "kind": "regular",
+            "website": "www.reg2.com",
+            "images": [
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+                "tag": "profile",
+                "type": "image/png",
+                "width": 200,
+                "height": 200,
+                "fit": null,
+                "position": null
+              },
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+                "tag": "cover",
+                "type": "image/jpeg",
+                "width": 1531,
+                "height": 190,
+                "fit": null,
+                "position": null
+              }
+            ],
+            "contactLinks": [
+              {
+                "id": "reg@email.com-email-contact-link",
+                "url": "reg@email.com",
+                "tag": "email"
+              }
+            ],
+            "contactPreference": "xmtp_and_email",
+            "socialLinks": [],
+            "salesChannels": [
+              {
+                "id": "30-custom storefront-customstore1-sale-channel",
+                "tag": "Custom storefront",
+                "name": "customstore1",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                    "lastUpdated": "1687773517"
+                  }
+                ]
+              },
+              {
+                "id": "30-custom storefront-hola-sale-channel",
+                "tag": "Custom storefront",
+                "name": "hola",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                    "lastUpdated": "1687862702"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "salesChannels": []
+    },
+    "variations": [],
+    "productV1Seller": {
+      "id": "30-product-v1",
+      "defaultVersion": 1,
+      "name": "my_name",
+      "description": "my_bio",
+      "externalUrl": "www.reg2.com",
+      "tokenId": null,
+      "sellerId": "30",
+      "images": [
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+          "tag": "profile",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        },
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+          "tag": "cover",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "seller": {
+        "id": "30",
+        "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "authTokenId": "0",
+        "authTokenType": 0,
+        "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+        "active": true,
+        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+        "royaltyPercentage": "200",
+        "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+        "metadata": {
+          "id": "30-seller-metadata",
+          "createdAt": "1687943706",
+          "name": "reg",
+          "description": "reg",
+          "legalTradingName": "legal reg",
+          "type": "SELLER",
+          "kind": "regular",
+          "website": "www.reg2.com",
+          "images": [
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+              "tag": "profile",
+              "type": "image/png",
+              "width": 200,
+              "height": 200,
+              "fit": null,
+              "position": null
+            },
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+              "tag": "cover",
+              "type": "image/jpeg",
+              "width": 1531,
+              "height": 190,
+              "fit": null,
+              "position": null
+            }
+          ],
+          "contactLinks": [
+            {
+              "id": "reg@email.com-email-contact-link",
+              "url": "reg@email.com",
+              "tag": "email"
+            }
+          ],
+          "contactPreference": "xmtp_and_email",
+          "socialLinks": [],
+          "salesChannels": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel",
+              "tag": "Custom storefront",
+              "name": "customstore1",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                  "lastUpdated": "1687773517"
+                }
+              ]
+            },
+            {
+              "id": "30-custom storefront-hola-sale-channel",
+              "tag": "Custom storefront",
+              "name": "hola",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                  "lastUpdated": "1687862702"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "exchangePolicy": {
+      "id": "10-metadata-exchange-policy",
+      "uuid": "1683819377084",
+      "version": 1,
+      "label": "Fair Exchange Policy",
+      "template": "unfairExchangePolicy",
+      "sellerContactMethod": "Chat App in the dApp",
+      "disputeResolverContactMethod": "email to: disputes-test@redeemeum.com"
+    },
+    "shipping": {
+      "id": "10-metadata-shipping",
+      "defaultVersion": 1,
+      "countryOfOrigin": null,
+      "supportedJurisdictions": [],
+      "redemptionPoint": null,
+      "returnPeriodInDays": 14
+    }
+  },
+  "range": null
+}

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer3.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer3.json
@@ -1,0 +1,593 @@
+{
+  "id": "10",
+  "createdAt": "1683819387",
+  "price": "100000000000000",
+  "sellerDeposit": "0",
+  "protocolFee": "500000000000",
+  "agentFee": "0",
+  "agentId": "0",
+  "buyerCancelPenalty": "0",
+  "quantityAvailable": "97",
+  "quantityInitial": "100",
+  "validFromDate": "1683819900",
+  "validUntilDate": "1685570340",
+  "voucherRedeemableFromDate": "1683819600",
+  "voucherRedeemableUntilDate": "1685570340",
+  "disputePeriodDuration": "2592000",
+  "voucherValidDuration": "0",
+  "resolutionPeriodDuration": "1296000",
+  "metadataUri": "ipfs://QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "metadataHash": "QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "voided": false,
+  "voidedAt": null,
+  "disputeResolverId": "13",
+  "numberOfCommits": "3",
+  "numberOfRedemptions": "3",
+  "condition": null,
+  "seller": {
+    "id": "30",
+    "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "authTokenId": "0",
+    "authTokenType": 0,
+    "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+    "active": true,
+    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+    "royaltyPercentage": "200",
+    "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+    "metadata": {
+      "id": "30-seller-metadata",
+      "createdAt": "1687943706",
+      "name": "reg",
+      "description": "reg",
+      "legalTradingName": "legal reg",
+      "type": "SELLER",
+      "kind": "regular",
+      "website": "www.reg2.com",
+      "images": [
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+          "tag": "profile",
+          "type": "image/png",
+          "width": 200,
+          "height": 200,
+          "fit": null,
+          "position": null
+        },
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+          "tag": "cover",
+          "type": "image/jpeg",
+          "width": 1531,
+          "height": 190,
+          "fit": null,
+          "position": null
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email-contact-link",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "socialLinks": [],
+      "salesChannels": [
+        {
+          "id": "30-custom storefront-customstore1-sale-channel",
+          "tag": "Custom storefront",
+          "name": "customstore1",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+              "lastUpdated": "1687773517"
+            }
+          ]
+        },
+        {
+          "id": "30-custom storefront-hola-sale-channel",
+          "tag": "Custom storefront",
+          "name": "hola",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+              "lastUpdated": "1687862702"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "exchangeToken": {
+    "id": "0x0000000000000000000000000000000000000000",
+    "address": "0x0000000000000000000000000000000000000000",
+    "decimals": "18",
+    "symbol": "MATIC",
+    "name": "Matic"
+  },
+  "disputeResolver": {
+    "id": "13",
+    "escalationResponsePeriod": "7775999",
+    "admin": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "clerk": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "treasury": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "assistant": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "metadataUri": "ipfs://dispute-resolver-uri",
+    "active": true,
+    "sellerAllowList": [],
+    "fees": [
+      {
+        "id": "13-0x0000000000000000000000000000000000000000-fee",
+        "tokenAddress": "0x0000000000000000000000000000000000000000",
+        "tokenName": "ETH",
+        "token": {
+          "id": "0x0000000000000000000000000000000000000000",
+          "address": "0x0000000000000000000000000000000000000000",
+          "decimals": "18",
+          "symbol": "MATIC",
+          "name": "Matic"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f-fee",
+        "tokenAddress": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+        "tokenName": "DAI",
+        "token": {
+          "id": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "address": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "decimals": "18",
+          "symbol": "DAI",
+          "name": "DAI"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0-fee",
+        "tokenAddress": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+        "tokenName": "BOSON",
+        "token": {
+          "id": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "address": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "decimals": "18",
+          "symbol": "BOSON",
+          "name": "Boson Token (PoS)"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832-fee",
+        "tokenAddress": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+        "tokenName": "USDT",
+        "token": {
+          "id": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "address": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "decimals": "6",
+          "symbol": "USDT",
+          "name": "Tether USD"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa-fee",
+        "tokenAddress": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+        "tokenName": "WETH",
+        "token": {
+          "id": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "address": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "decimals": "18",
+          "symbol": "WETH",
+          "name": "Wrapped Ether"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xe6b8a5cf854791412c1f6efc7caf629f5df1c747-fee",
+        "tokenAddress": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+        "tokenName": "USDC",
+        "token": {
+          "id": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "address": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "decimals": "6",
+          "symbol": "USDC",
+          "name": "Mumbai USD Coin"
+        },
+        "feeAmount": "0"
+      }
+    ]
+  },
+  "disputeResolutionTerms": {
+    "id": "13-10-terms",
+    "disputeResolverId": "13",
+    "escalationResponsePeriod": "7775999",
+    "feeAmount": "0",
+    "buyerEscalationDeposit": "0"
+  },
+  "metadata": {
+    "name": "a",
+    "description": "desc\n\nTerms for the Boson rNFT Voucher: http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "externalUrl": "http://localhost:3000/#/offer-uuid/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "animationUrl": null,
+    "animationMetadata": null,
+    "licenseUrl": "http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "condition": null,
+    "schemaUrl": "https://schema.org/",
+    "image": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+    "attributes": [
+      {
+        "traitType": "Redeemable At",
+        "value": "http://localhost:3000",
+        "displayType": ""
+      },
+      {
+        "traitType": "Redeemable Until",
+        "value": "1685570340000",
+        "displayType": "date"
+      },
+      {
+        "traitType": "Seller",
+        "value": "reg name",
+        "displayType": ""
+      },
+      {
+        "traitType": "Token Type",
+        "value": "BOSON rNFT",
+        "displayType": ""
+      }
+    ],
+    "createdAt": "1683819387",
+    "voided": false,
+    "validFromDate": "1683819900",
+    "validUntilDate": "1685570340",
+    "quantityAvailable": "97",
+    "uuid": "0eaefa-3f54-72ce-0c5a-65a6c201",
+    "product": {
+      "id": "2d62d7-7346-b74-b227-56dbf668dfbb-1",
+      "uuid": "2d62d7-7346-b74-b227-56dbf668dfbb",
+      "version": 1,
+      "title": "a",
+      "description": "desc",
+      "identification_sKU": null,
+      "identification_productId": null,
+      "identification_productIdType": null,
+      "productionInformation_brandName": "reg name",
+      "brand": {
+        "id": "reg name",
+        "name": "reg name"
+      },
+      "productionInformation_manufacturer": null,
+      "productionInformation_manufacturerPartNumber": null,
+      "productionInformation_modelNumber": null,
+      "productionInformation_materials": [],
+      "details_category": "apparel-accessories",
+      "category": {
+        "id": "apparel-accessories",
+        "name": "apparel-accessories"
+      },
+      "details_subCategory": null,
+      "subCategory": null,
+      "details_subCategory2": null,
+      "subCategory2": null,
+      "details_offerCategory": "PHYSICAL",
+      "offerCategory": "PHYSICAL",
+      "details_tags": [
+        "taa"
+      ],
+      "tags": [
+        {
+          "id": "taa",
+          "name": "taa"
+        }
+      ],
+      "details_sections": [],
+      "sections": [],
+      "details_personalisation": [],
+      "personalisation": [],
+      "visuals_images": [
+        {
+          "id": "ipfs://qmqh2jgehkqfke4o8ldvypcnwdqipurvh55jcczuwz96kx-product_image",
+          "url": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+          "tag": "product_image",
+          "type": "IMAGE",
+          "width": 1111,
+          "height": 642
+        }
+      ],
+      "visuals_videos": [],
+      "packaging_packageQuantity": null,
+      "packaging_dimensions_length": null,
+      "packaging_dimensions_width": null,
+      "packaging_dimensions_height": null,
+      "packaging_dimensions_unit": "m",
+      "packaging_weight_value": null,
+      "packaging_weight_unit": "kg",
+      "productV1Seller": {
+        "id": "30-product-v1",
+        "defaultVersion": 1,
+        "name": "my_name",
+        "description": "my_bio",
+        "externalUrl": "www.reg2.com",
+        "tokenId": null,
+        "sellerId": "30",
+        "images": [
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+            "tag": "profile",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          },
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+            "tag": "cover",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          }
+        ],
+        "contactLinks": [
+          {
+            "id": "reg@email.com-email",
+            "url": "reg@email.com",
+            "tag": "email"
+          }
+        ],
+        "contactPreference": "xmtp_and_email",
+        "seller": {
+          "id": "30",
+          "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "authTokenId": "0",
+          "authTokenType": 0,
+          "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+          "active": true,
+          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+          "royaltyPercentage": "200",
+          "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+          "metadata": {
+            "id": "30-seller-metadata",
+            "createdAt": "1687943706",
+            "name": "reg",
+            "description": "reg",
+            "legalTradingName": "legal reg",
+            "type": "SELLER",
+            "kind": "regular",
+            "website": "www.reg2.com",
+            "images": [
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+                "tag": "profile",
+                "type": "image/png",
+                "width": 200,
+                "height": 200,
+                "fit": null,
+                "position": null
+              },
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+                "tag": "cover",
+                "type": "image/jpeg",
+                "width": 1531,
+                "height": 190,
+                "fit": null,
+                "position": null
+              }
+            ],
+            "contactLinks": [
+              {
+                "id": "reg@email.com-email-contact-link",
+                "url": "reg@email.com",
+                "tag": "email"
+              }
+            ],
+            "contactPreference": "xmtp_and_email",
+            "socialLinks": [],
+            "salesChannels": [
+              {
+                "id": "30-custom storefront-customstore1-sale-channel",
+                "tag": "Custom storefront",
+                "name": "customstore1",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                    "lastUpdated": "1687773517"
+                  }
+                ]
+              },
+              {
+                "id": "30-custom storefront-hola-sale-channel",
+                "tag": "Custom storefront",
+                "name": "hola",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                    "lastUpdated": "1687862702"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "salesChannels": []
+    },
+    "variations": [],
+    "productV1Seller": {
+      "id": "30-product-v1",
+      "defaultVersion": 1,
+      "name": "my_name",
+      "description": "my_bio",
+      "externalUrl": "www.reg2.com",
+      "tokenId": null,
+      "sellerId": "30",
+      "images": [
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+          "tag": "profile",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        },
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+          "tag": "cover",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "seller": {
+        "id": "30",
+        "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "authTokenId": "0",
+        "authTokenType": 0,
+        "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+        "active": true,
+        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+        "royaltyPercentage": "200",
+        "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+        "metadata": {
+          "id": "30-seller-metadata",
+          "createdAt": "1687943706",
+          "name": "reg",
+          "description": "reg",
+          "legalTradingName": "legal reg",
+          "type": "SELLER",
+          "kind": "regular",
+          "website": "www.reg2.com",
+          "images": [
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+              "tag": "profile",
+              "type": "image/png",
+              "width": 200,
+              "height": 200,
+              "fit": null,
+              "position": null
+            },
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+              "tag": "cover",
+              "type": "image/jpeg",
+              "width": 1531,
+              "height": 190,
+              "fit": null,
+              "position": null
+            }
+          ],
+          "contactLinks": [
+            {
+              "id": "reg@email.com-email-contact-link",
+              "url": "reg@email.com",
+              "tag": "email"
+            }
+          ],
+          "contactPreference": "xmtp_and_email",
+          "socialLinks": [],
+          "salesChannels": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel",
+              "tag": "Custom storefront",
+              "name": "customstore1",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                  "lastUpdated": "1687773517"
+                }
+              ]
+            },
+            {
+              "id": "30-custom storefront-hola-sale-channel",
+              "tag": "Custom storefront",
+              "name": "hola",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                  "lastUpdated": "1687862702"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "exchangePolicy": {
+      "id": "10-metadata-exchange-policy",
+      "uuid": "1683819377084",
+      "version": 1,
+      "label": "Fair Exchange Policy",
+      "sellerContactMethod": "Chat App in the dApp",
+      "disputeResolverContactMethod": "email to: disputes-test@redeemeum.com"
+    },
+    "shipping": {
+      "id": "10-metadata-shipping",
+      "defaultVersion": 1,
+      "countryOfOrigin": null,
+      "supportedJurisdictions": [],
+      "redemptionPoint": null
+    }
+  },
+  "range": null
+}

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer4.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer4.json
@@ -1,0 +1,224 @@
+{
+  "id": "10",
+  "createdAt": "1683819387",
+  "price": "100000000000000",
+  "sellerDeposit": "0",
+  "protocolFee": "500000000000",
+  "agentFee": "0",
+  "agentId": "0",
+  "buyerCancelPenalty": "0",
+  "quantityAvailable": "97",
+  "quantityInitial": "100",
+  "validFromDate": "1683819900",
+  "validUntilDate": "1685570340",
+  "voucherRedeemableFromDate": "1683819600",
+  "voucherRedeemableUntilDate": "1685570340",
+  "disputePeriodDuration": "2592000",
+  "voucherValidDuration": "0",
+  "resolutionPeriodDuration": "1296000",
+  "metadataUri": "ipfs://QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "metadataHash": "QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "voided": false,
+  "voidedAt": null,
+  "disputeResolverId": "13",
+  "numberOfCommits": "3",
+  "numberOfRedemptions": "3",
+  "condition": null,
+  "seller": {
+    "id": "30",
+    "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "authTokenId": "0",
+    "authTokenType": 0,
+    "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+    "active": true,
+    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+    "royaltyPercentage": "200",
+    "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+    "metadata": {
+      "id": "30-seller-metadata",
+      "createdAt": "1687943706",
+      "name": "reg",
+      "description": "reg",
+      "legalTradingName": "legal reg",
+      "type": "SELLER",
+      "kind": "regular",
+      "website": "www.reg2.com",
+      "images": [
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+          "tag": "profile",
+          "type": "image/png",
+          "width": 200,
+          "height": 200,
+          "fit": null,
+          "position": null
+        },
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+          "tag": "cover",
+          "type": "image/jpeg",
+          "width": 1531,
+          "height": 190,
+          "fit": null,
+          "position": null
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email-contact-link",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "socialLinks": [],
+      "salesChannels": [
+        {
+          "id": "30-custom storefront-customstore1-sale-channel",
+          "tag": "Custom storefront",
+          "name": "customstore1",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+              "lastUpdated": "1687773517"
+            }
+          ]
+        },
+        {
+          "id": "30-custom storefront-hola-sale-channel",
+          "tag": "Custom storefront",
+          "name": "hola",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+              "lastUpdated": "1687862702"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "exchangeToken": {
+    "id": "0x0000000000000000000000000000000000000000",
+    "address": "0x0000000000000000000000000000000000000000",
+    "decimals": "18",
+    "symbol": "MATIC",
+    "name": "Matic"
+  },
+  "disputeResolver": {
+    "id": "13",
+    "escalationResponsePeriod": "7775999",
+    "admin": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "clerk": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "treasury": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "assistant": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "metadataUri": "ipfs://dispute-resolver-uri",
+    "active": true,
+    "sellerAllowList": [],
+    "fees": [
+      {
+        "id": "13-0x0000000000000000000000000000000000000000-fee",
+        "tokenAddress": "0x0000000000000000000000000000000000000000",
+        "tokenName": "ETH",
+        "token": {
+          "id": "0x0000000000000000000000000000000000000000",
+          "address": "0x0000000000000000000000000000000000000000",
+          "decimals": "18",
+          "symbol": "MATIC",
+          "name": "Matic"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f-fee",
+        "tokenAddress": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+        "tokenName": "DAI",
+        "token": {
+          "id": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "address": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "decimals": "18",
+          "symbol": "DAI",
+          "name": "DAI"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0-fee",
+        "tokenAddress": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+        "tokenName": "BOSON",
+        "token": {
+          "id": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "address": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "decimals": "18",
+          "symbol": "BOSON",
+          "name": "Boson Token (PoS)"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832-fee",
+        "tokenAddress": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+        "tokenName": "USDT",
+        "token": {
+          "id": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "address": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "decimals": "6",
+          "symbol": "USDT",
+          "name": "Tether USD"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa-fee",
+        "tokenAddress": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+        "tokenName": "WETH",
+        "token": {
+          "id": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "address": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "decimals": "18",
+          "symbol": "WETH",
+          "name": "Wrapped Ether"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xe6b8a5cf854791412c1f6efc7caf629f5df1c747-fee",
+        "tokenAddress": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+        "tokenName": "USDC",
+        "token": {
+          "id": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "address": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "decimals": "6",
+          "symbol": "USDC",
+          "name": "Mumbai USD Coin"
+        },
+        "feeAmount": "0"
+      }
+    ]
+  },
+  "disputeResolutionTerms": {
+    "id": "13-10-terms",
+    "disputeResolverId": "13",
+    "escalationResponsePeriod": "7775999",
+    "feeAmount": "0",
+    "buyerEscalationDeposit": "0"
+  },
+  "range": null
+}

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer5.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer5.json
@@ -1,0 +1,579 @@
+{
+  "id": "10",
+  "createdAt": "1683819387",
+  "price": "100000000000000",
+  "sellerDeposit": "0",
+  "protocolFee": "500000000000",
+  "agentFee": "0",
+  "agentId": "0",
+  "buyerCancelPenalty": "0",
+  "quantityAvailable": "97",
+  "quantityInitial": "100",
+  "validFromDate": "1683819900",
+  "validUntilDate": "1685570340",
+  "voucherRedeemableFromDate": "1683819600",
+  "voucherRedeemableUntilDate": "1685570340",
+  "disputePeriodDuration": "2592000",
+  "voucherValidDuration": "0",
+  "resolutionPeriodDuration": "1296000",
+  "metadataUri": "ipfs://QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "metadataHash": "QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "voided": false,
+  "voidedAt": null,
+  "disputeResolverId": "13",
+  "numberOfCommits": "3",
+  "numberOfRedemptions": "3",
+  "condition": null,
+  "seller": {
+    "id": "30",
+    "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "authTokenId": "0",
+    "authTokenType": 0,
+    "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+    "active": true,
+    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+    "royaltyPercentage": "200",
+    "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+    "metadata": {
+      "id": "30-seller-metadata",
+      "createdAt": "1687943706",
+      "name": "reg",
+      "description": "reg",
+      "legalTradingName": "legal reg",
+      "type": "SELLER",
+      "kind": "regular",
+      "website": "www.reg2.com",
+      "images": [
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+          "tag": "profile",
+          "type": "image/png",
+          "width": 200,
+          "height": 200,
+          "fit": null,
+          "position": null
+        },
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+          "tag": "cover",
+          "type": "image/jpeg",
+          "width": 1531,
+          "height": 190,
+          "fit": null,
+          "position": null
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email-contact-link",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "socialLinks": [],
+      "salesChannels": [
+        {
+          "id": "30-custom storefront-customstore1-sale-channel",
+          "tag": "Custom storefront",
+          "name": "customstore1",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+              "lastUpdated": "1687773517"
+            }
+          ]
+        },
+        {
+          "id": "30-custom storefront-hola-sale-channel",
+          "tag": "Custom storefront",
+          "name": "hola",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+              "lastUpdated": "1687862702"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "exchangeToken": {
+    "id": "0x0000000000000000000000000000000000000000",
+    "address": "0x0000000000000000000000000000000000000000",
+    "decimals": "18",
+    "symbol": "MATIC",
+    "name": "Matic"
+  },
+  "disputeResolver": {
+    "id": "13",
+    "escalationResponsePeriod": "7775999",
+    "admin": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "clerk": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "treasury": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "assistant": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "metadataUri": "ipfs://dispute-resolver-uri",
+    "active": true,
+    "sellerAllowList": [],
+    "fees": [
+      {
+        "id": "13-0x0000000000000000000000000000000000000000-fee",
+        "tokenAddress": "0x0000000000000000000000000000000000000000",
+        "tokenName": "ETH",
+        "token": {
+          "id": "0x0000000000000000000000000000000000000000",
+          "address": "0x0000000000000000000000000000000000000000",
+          "decimals": "18",
+          "symbol": "MATIC",
+          "name": "Matic"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f-fee",
+        "tokenAddress": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+        "tokenName": "DAI",
+        "token": {
+          "id": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "address": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "decimals": "18",
+          "symbol": "DAI",
+          "name": "DAI"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0-fee",
+        "tokenAddress": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+        "tokenName": "BOSON",
+        "token": {
+          "id": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "address": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "decimals": "18",
+          "symbol": "BOSON",
+          "name": "Boson Token (PoS)"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832-fee",
+        "tokenAddress": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+        "tokenName": "USDT",
+        "token": {
+          "id": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "address": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "decimals": "6",
+          "symbol": "USDT",
+          "name": "Tether USD"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa-fee",
+        "tokenAddress": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+        "tokenName": "WETH",
+        "token": {
+          "id": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "address": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "decimals": "18",
+          "symbol": "WETH",
+          "name": "Wrapped Ether"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xe6b8a5cf854791412c1f6efc7caf629f5df1c747-fee",
+        "tokenAddress": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+        "tokenName": "USDC",
+        "token": {
+          "id": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "address": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "decimals": "6",
+          "symbol": "USDC",
+          "name": "Mumbai USD Coin"
+        },
+        "feeAmount": "0"
+      }
+    ]
+  },
+  "disputeResolutionTerms": {
+    "id": "13-10-terms",
+    "disputeResolverId": "13",
+    "escalationResponsePeriod": "7775999",
+    "feeAmount": "0",
+    "buyerEscalationDeposit": "0"
+  },
+  "metadata": {
+    "name": "a",
+    "description": "desc\n\nTerms for the Boson rNFT Voucher: http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "externalUrl": "http://localhost:3000/#/offer-uuid/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "animationUrl": null,
+    "animationMetadata": null,
+    "licenseUrl": "http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "condition": null,
+    "schemaUrl": "https://schema.org/",
+    "type": "PRODUCT_V1",
+    "image": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+    "attributes": [
+      {
+        "traitType": "Redeemable At",
+        "value": "http://localhost:3000",
+        "displayType": ""
+      },
+      {
+        "traitType": "Redeemable Until",
+        "value": "1685570340000",
+        "displayType": "date"
+      },
+      {
+        "traitType": "Seller",
+        "value": "reg name",
+        "displayType": ""
+      },
+      {
+        "traitType": "Token Type",
+        "value": "BOSON rNFT",
+        "displayType": ""
+      }
+    ],
+    "createdAt": "1683819387",
+    "voided": false,
+    "validFromDate": "1683819900",
+    "validUntilDate": "1685570340",
+    "quantityAvailable": "97",
+    "uuid": "0eaefa-3f54-72ce-0c5a-65a6c201",
+    "product": {
+      "id": "2d62d7-7346-b74-b227-56dbf668dfbb-1",
+      "uuid": "2d62d7-7346-b74-b227-56dbf668dfbb",
+      "version": 1,
+      "title": "a",
+      "description": "desc",
+      "identification_sKU": null,
+      "identification_productId": null,
+      "identification_productIdType": null,
+      "productionInformation_brandName": "reg name",
+      "brand": {
+        "id": "reg name",
+        "name": "reg name"
+      },
+      "productionInformation_manufacturer": null,
+      "productionInformation_manufacturerPartNumber": null,
+      "productionInformation_modelNumber": null,
+      "productionInformation_materials": [],
+      "details_category": "apparel-accessories",
+      "category": {
+        "id": "apparel-accessories",
+        "name": "apparel-accessories"
+      },
+      "details_subCategory": null,
+      "subCategory": null,
+      "details_subCategory2": null,
+      "subCategory2": null,
+      "details_offerCategory": "PHYSICAL",
+      "offerCategory": "PHYSICAL",
+      "details_tags": [
+        "taa"
+      ],
+      "tags": [
+        {
+          "id": "taa",
+          "name": "taa"
+        }
+      ],
+      "details_sections": [],
+      "sections": [],
+      "details_personalisation": [],
+      "personalisation": [],
+      "visuals_images": [
+        {
+          "id": "ipfs://qmqh2jgehkqfke4o8ldvypcnwdqipurvh55jcczuwz96kx-product_image",
+          "url": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+          "tag": "product_image",
+          "type": "IMAGE",
+          "width": 1111,
+          "height": 642
+        }
+      ],
+      "visuals_videos": [],
+      "packaging_packageQuantity": null,
+      "packaging_dimensions_length": null,
+      "packaging_dimensions_width": null,
+      "packaging_dimensions_height": null,
+      "packaging_dimensions_unit": "m",
+      "packaging_weight_value": null,
+      "packaging_weight_unit": "kg",
+      "productV1Seller": {
+        "id": "30-product-v1",
+        "defaultVersion": 1,
+        "name": "my_name",
+        "description": "my_bio",
+        "externalUrl": "www.reg2.com",
+        "tokenId": null,
+        "sellerId": "30",
+        "images": [
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+            "tag": "profile",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          },
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+            "tag": "cover",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          }
+        ],
+        "contactLinks": [
+          {
+            "id": "reg@email.com-email",
+            "url": "reg@email.com",
+            "tag": "email"
+          }
+        ],
+        "contactPreference": "xmtp_and_email",
+        "seller": {
+          "id": "30",
+          "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "authTokenId": "0",
+          "authTokenType": 0,
+          "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+          "active": true,
+          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+          "royaltyPercentage": "200",
+          "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+          "metadata": {
+            "id": "30-seller-metadata",
+            "createdAt": "1687943706",
+            "name": "reg",
+            "description": "reg",
+            "legalTradingName": "legal reg",
+            "type": "SELLER",
+            "kind": "regular",
+            "website": "www.reg2.com",
+            "images": [
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+                "tag": "profile",
+                "type": "image/png",
+                "width": 200,
+                "height": 200,
+                "fit": null,
+                "position": null
+              },
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+                "tag": "cover",
+                "type": "image/jpeg",
+                "width": 1531,
+                "height": 190,
+                "fit": null,
+                "position": null
+              }
+            ],
+            "contactLinks": [
+              {
+                "id": "reg@email.com-email-contact-link",
+                "url": "reg@email.com",
+                "tag": "email"
+              }
+            ],
+            "contactPreference": "xmtp_and_email",
+            "socialLinks": [],
+            "salesChannels": [
+              {
+                "id": "30-custom storefront-customstore1-sale-channel",
+                "tag": "Custom storefront",
+                "name": "customstore1",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                    "lastUpdated": "1687773517"
+                  }
+                ]
+              },
+              {
+                "id": "30-custom storefront-hola-sale-channel",
+                "tag": "Custom storefront",
+                "name": "hola",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                    "lastUpdated": "1687862702"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "salesChannels": []
+    },
+    "variations": [],
+    "productV1Seller": {
+      "id": "30-product-v1",
+      "defaultVersion": 1,
+      "name": "my_name",
+      "description": "my_bio",
+      "externalUrl": "www.reg2.com",
+      "tokenId": null,
+      "sellerId": "30",
+      "images": [
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+          "tag": "profile",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        },
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+          "tag": "cover",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "seller": {
+        "id": "30",
+        "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "authTokenId": "0",
+        "authTokenType": 0,
+        "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+        "active": true,
+        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+        "royaltyPercentage": "200",
+        "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+        "metadata": {
+          "id": "30-seller-metadata",
+          "createdAt": "1687943706",
+          "name": "reg",
+          "description": "reg",
+          "legalTradingName": "legal reg",
+          "type": "SELLER",
+          "kind": "regular",
+          "website": "www.reg2.com",
+          "images": [
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+              "tag": "profile",
+              "type": "image/png",
+              "width": 200,
+              "height": 200,
+              "fit": null,
+              "position": null
+            },
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+              "tag": "cover",
+              "type": "image/jpeg",
+              "width": 1531,
+              "height": 190,
+              "fit": null,
+              "position": null
+            }
+          ],
+          "contactLinks": [
+            {
+              "id": "reg@email.com-email-contact-link",
+              "url": "reg@email.com",
+              "tag": "email"
+            }
+          ],
+          "contactPreference": "xmtp_and_email",
+          "socialLinks": [],
+          "salesChannels": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel",
+              "tag": "Custom storefront",
+              "name": "customstore1",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                  "lastUpdated": "1687773517"
+                }
+              ]
+            },
+            {
+              "id": "30-custom storefront-hola-sale-channel",
+              "tag": "Custom storefront",
+              "name": "hola",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                  "lastUpdated": "1687862702"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "range": null
+}

--- a/packages/core-sdk/tests/exchangePolicy/examples/validOffer.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/validOffer.json
@@ -1,0 +1,596 @@
+{
+  "id": "10",
+  "createdAt": "1683819387",
+  "price": "100000000000000",
+  "sellerDeposit": "0",
+  "protocolFee": "500000000000",
+  "agentFee": "0",
+  "agentId": "0",
+  "buyerCancelPenalty": "0",
+  "quantityAvailable": "97",
+  "quantityInitial": "100",
+  "validFromDate": "1683819900",
+  "validUntilDate": "1685570340",
+  "voucherRedeemableFromDate": "1683819600",
+  "voucherRedeemableUntilDate": "1685570340",
+  "disputePeriodDuration": "2592000",
+  "voucherValidDuration": "0",
+  "resolutionPeriodDuration": "1296000",
+  "metadataUri": "ipfs://QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "metadataHash": "QmSpHGbRyfXqAqJ5xHv8E2TZjy6LDmUYoXUGHrcx7RrqGB",
+  "voided": false,
+  "voidedAt": null,
+  "disputeResolverId": "13",
+  "numberOfCommits": "3",
+  "numberOfRedemptions": "3",
+  "condition": null,
+  "seller": {
+    "id": "30",
+    "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+    "authTokenId": "0",
+    "authTokenType": 0,
+    "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+    "active": true,
+    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+    "royaltyPercentage": "200",
+    "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+    "metadata": {
+      "id": "30-seller-metadata",
+      "createdAt": "1687943706",
+      "name": "reg",
+      "description": "reg",
+      "legalTradingName": "legal reg",
+      "type": "SELLER",
+      "kind": "regular",
+      "website": "www.reg2.com",
+      "images": [
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+          "tag": "profile",
+          "type": "image/png",
+          "width": 200,
+          "height": 200,
+          "fit": null,
+          "position": null
+        },
+        {
+          "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+          "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+          "tag": "cover",
+          "type": "image/jpeg",
+          "width": 1531,
+          "height": 190,
+          "fit": null,
+          "position": null
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email-contact-link",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "socialLinks": [],
+      "salesChannels": [
+        {
+          "id": "30-custom storefront-customstore1-sale-channel",
+          "tag": "Custom storefront",
+          "name": "customstore1",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+              "lastUpdated": "1687773517"
+            }
+          ]
+        },
+        {
+          "id": "30-custom storefront-hola-sale-channel",
+          "tag": "Custom storefront",
+          "name": "hola",
+          "settingsUri": null,
+          "settingsEditor": null,
+          "link": null,
+          "deployments": [
+            {
+              "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+              "product": null,
+              "status": null,
+              "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+              "lastUpdated": "1687862702"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "exchangeToken": {
+    "id": "0x0000000000000000000000000000000000000000",
+    "address": "0x0000000000000000000000000000000000000000",
+    "decimals": "18",
+    "symbol": "MATIC",
+    "name": "Matic"
+  },
+  "disputeResolver": {
+    "id": "13",
+    "escalationResponsePeriod": "7775999",
+    "admin": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "clerk": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "treasury": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "assistant": "0xd347c4a2248b231b39fce4eeb6b3f6e3289d897c",
+    "metadataUri": "ipfs://dispute-resolver-uri",
+    "active": true,
+    "sellerAllowList": [],
+    "fees": [
+      {
+        "id": "13-0x0000000000000000000000000000000000000000-fee",
+        "tokenAddress": "0x0000000000000000000000000000000000000000",
+        "tokenName": "ETH",
+        "token": {
+          "id": "0x0000000000000000000000000000000000000000",
+          "address": "0x0000000000000000000000000000000000000000",
+          "decimals": "18",
+          "symbol": "MATIC",
+          "name": "Matic"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f-fee",
+        "tokenAddress": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+        "tokenName": "DAI",
+        "token": {
+          "id": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "address": "0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f",
+          "decimals": "18",
+          "symbol": "DAI",
+          "name": "DAI"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0-fee",
+        "tokenAddress": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+        "tokenName": "BOSON",
+        "token": {
+          "id": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "address": "0x1f5431e8679630790e8eba3a9b41d1bb4d41aed0",
+          "decimals": "18",
+          "symbol": "BOSON",
+          "name": "Boson Token (PoS)"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832-fee",
+        "tokenAddress": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+        "tokenName": "USDT",
+        "token": {
+          "id": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "address": "0xa02f6adc7926efebbd59fd43a84f4e0c0c91e832",
+          "decimals": "6",
+          "symbol": "USDT",
+          "name": "Tether USD"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa-fee",
+        "tokenAddress": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+        "tokenName": "WETH",
+        "token": {
+          "id": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "address": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+          "decimals": "18",
+          "symbol": "WETH",
+          "name": "Wrapped Ether"
+        },
+        "feeAmount": "0"
+      },
+      {
+        "id": "13-0xe6b8a5cf854791412c1f6efc7caf629f5df1c747-fee",
+        "tokenAddress": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+        "tokenName": "USDC",
+        "token": {
+          "id": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "address": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+          "decimals": "6",
+          "symbol": "USDC",
+          "name": "Mumbai USD Coin"
+        },
+        "feeAmount": "0"
+      }
+    ]
+  },
+  "disputeResolutionTerms": {
+    "id": "13-10-terms",
+    "disputeResolverId": "13",
+    "escalationResponsePeriod": "7775999",
+    "feeAmount": "0",
+    "buyerEscalationDeposit": "0"
+  },
+  "metadata": {
+    "name": "a",
+    "description": "desc\n\nTerms for the Boson rNFT Voucher: http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "externalUrl": "http://localhost:3000/#/offer-uuid/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "animationUrl": null,
+    "animationMetadata": null,
+    "licenseUrl": "http://localhost:3000/#/license/0eaefa-3f54-72ce-0c5a-65a6c201",
+    "condition": null,
+    "schemaUrl": "https://schema.org/",
+    "type": "PRODUCT_V1",
+    "image": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+    "attributes": [
+      {
+        "traitType": "Redeemable At",
+        "value": "http://localhost:3000",
+        "displayType": ""
+      },
+      {
+        "traitType": "Redeemable Until",
+        "value": "1685570340000",
+        "displayType": "date"
+      },
+      {
+        "traitType": "Seller",
+        "value": "reg name",
+        "displayType": ""
+      },
+      {
+        "traitType": "Token Type",
+        "value": "BOSON rNFT",
+        "displayType": ""
+      }
+    ],
+    "createdAt": "1683819387",
+    "voided": false,
+    "validFromDate": "1683819900",
+    "validUntilDate": "1685570340",
+    "quantityAvailable": "97",
+    "uuid": "0eaefa-3f54-72ce-0c5a-65a6c201",
+    "product": {
+      "id": "2d62d7-7346-b74-b227-56dbf668dfbb-1",
+      "uuid": "2d62d7-7346-b74-b227-56dbf668dfbb",
+      "version": 1,
+      "title": "a",
+      "description": "desc",
+      "identification_sKU": null,
+      "identification_productId": null,
+      "identification_productIdType": null,
+      "productionInformation_brandName": "reg name",
+      "brand": {
+        "id": "reg name",
+        "name": "reg name"
+      },
+      "productionInformation_manufacturer": null,
+      "productionInformation_manufacturerPartNumber": null,
+      "productionInformation_modelNumber": null,
+      "productionInformation_materials": [],
+      "details_category": "apparel-accessories",
+      "category": {
+        "id": "apparel-accessories",
+        "name": "apparel-accessories"
+      },
+      "details_subCategory": null,
+      "subCategory": null,
+      "details_subCategory2": null,
+      "subCategory2": null,
+      "details_offerCategory": "PHYSICAL",
+      "offerCategory": "PHYSICAL",
+      "details_tags": [
+        "taa"
+      ],
+      "tags": [
+        {
+          "id": "taa",
+          "name": "taa"
+        }
+      ],
+      "details_sections": [],
+      "sections": [],
+      "details_personalisation": [],
+      "personalisation": [],
+      "visuals_images": [
+        {
+          "id": "ipfs://qmqh2jgehkqfke4o8ldvypcnwdqipurvh55jcczuwz96kx-product_image",
+          "url": "ipfs://QmQh2JgEhkqFke4o8LdVYPcNwdQipuRvH55jCCzUWZ96Kx",
+          "tag": "product_image",
+          "type": "IMAGE",
+          "width": 1111,
+          "height": 642
+        }
+      ],
+      "visuals_videos": [],
+      "packaging_packageQuantity": null,
+      "packaging_dimensions_length": null,
+      "packaging_dimensions_width": null,
+      "packaging_dimensions_height": null,
+      "packaging_dimensions_unit": "m",
+      "packaging_weight_value": null,
+      "packaging_weight_unit": "kg",
+      "productV1Seller": {
+        "id": "30-product-v1",
+        "defaultVersion": 1,
+        "name": "my_name",
+        "description": "my_bio",
+        "externalUrl": "www.reg2.com",
+        "tokenId": null,
+        "sellerId": "30",
+        "images": [
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+            "tag": "profile",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          },
+          {
+            "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+            "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+            "tag": "cover",
+            "type": "IMAGE",
+            "width": 0,
+            "height": 0
+          }
+        ],
+        "contactLinks": [
+          {
+            "id": "reg@email.com-email",
+            "url": "reg@email.com",
+            "tag": "email"
+          }
+        ],
+        "contactPreference": "xmtp_and_email",
+        "seller": {
+          "id": "30",
+          "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+          "authTokenId": "0",
+          "authTokenType": 0,
+          "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+          "active": true,
+          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+          "royaltyPercentage": "200",
+          "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+          "metadata": {
+            "id": "30-seller-metadata",
+            "createdAt": "1687943706",
+            "name": "reg",
+            "description": "reg",
+            "legalTradingName": "legal reg",
+            "type": "SELLER",
+            "kind": "regular",
+            "website": "www.reg2.com",
+            "images": [
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+                "tag": "profile",
+                "type": "image/png",
+                "width": 200,
+                "height": 200,
+                "fit": null,
+                "position": null
+              },
+              {
+                "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+                "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+                "tag": "cover",
+                "type": "image/jpeg",
+                "width": 1531,
+                "height": 190,
+                "fit": null,
+                "position": null
+              }
+            ],
+            "contactLinks": [
+              {
+                "id": "reg@email.com-email-contact-link",
+                "url": "reg@email.com",
+                "tag": "email"
+              }
+            ],
+            "contactPreference": "xmtp_and_email",
+            "socialLinks": [],
+            "salesChannels": [
+              {
+                "id": "30-custom storefront-customstore1-sale-channel",
+                "tag": "Custom storefront",
+                "name": "customstore1",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                    "lastUpdated": "1687773517"
+                  }
+                ]
+              },
+              {
+                "id": "30-custom storefront-hola-sale-channel",
+                "tag": "Custom storefront",
+                "name": "hola",
+                "settingsUri": null,
+                "settingsEditor": null,
+                "link": null,
+                "deployments": [
+                  {
+                    "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                    "product": null,
+                    "status": null,
+                    "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                    "lastUpdated": "1687862702"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "salesChannels": []
+    },
+    "variations": [],
+    "productV1Seller": {
+      "id": "30-product-v1",
+      "defaultVersion": 1,
+      "name": "my_name",
+      "description": "my_bio",
+      "externalUrl": "www.reg2.com",
+      "tokenId": null,
+      "sellerId": "30",
+      "images": [
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp-profile",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/b7c1682e55814fec77bedc631f7713a64ba56b3d05c0ed3c3078bfacae519750.webp",
+          "tag": "profile",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        },
+        {
+          "id": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg-cover",
+          "url": "https://ik.imagekit.io/lens/media-snapshot/e299f316a7b6bca86d6b571585c8891ceafd9ef1a68f10576844147094e9d45a.jpg",
+          "tag": "cover",
+          "type": "IMAGE",
+          "width": 0,
+          "height": 0
+        }
+      ],
+      "contactLinks": [
+        {
+          "id": "reg@email.com-email",
+          "url": "reg@email.com",
+          "tag": "email"
+        }
+      ],
+      "contactPreference": "xmtp_and_email",
+      "seller": {
+        "id": "30",
+        "assistant": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "admin": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "clerk": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "treasury": "0xe28b648541a5376383865672dc1589c02634ec42",
+        "authTokenId": "0",
+        "authTokenType": 0,
+        "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
+        "active": true,
+        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
+        "royaltyPercentage": "200",
+        "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
+        "metadata": {
+          "id": "30-seller-metadata",
+          "createdAt": "1687943706",
+          "name": "reg",
+          "description": "reg",
+          "legalTradingName": "legal reg",
+          "type": "SELLER",
+          "kind": "regular",
+          "website": "www.reg2.com",
+          "images": [
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmnvfqgaszimjciuxypim4brpun2nxkiqmth6rtbcmvbnn-profile",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmNvFQGASzimJciuXyPiM4brpuN2nXKiqMtH6RtBcmvBNN",
+              "tag": "profile",
+              "type": "image/png",
+              "width": 200,
+              "height": 200,
+              "fit": null,
+              "position": null
+            },
+            {
+              "id": "https://bosonprotocol.infura-ipfs.io/ipfs/qmqsvfkcua3l9kxixtphym6vtzvvet5y4eayjnuuycp1kg-cover",
+              "url": "https://bosonprotocol.infura-ipfs.io/ipfs/QmQSVFKCua3L9kxiXtpHYM6Vtzvvet5Y4EAyjnuUyCP1kG",
+              "tag": "cover",
+              "type": "image/jpeg",
+              "width": 1531,
+              "height": 190,
+              "fit": null,
+              "position": null
+            }
+          ],
+          "contactLinks": [
+            {
+              "id": "reg@email.com-email-contact-link",
+              "url": "reg@email.com",
+              "tag": "email"
+            }
+          ],
+          "contactPreference": "xmtp_and_email",
+          "socialLinks": [],
+          "salesChannels": [
+            {
+              "id": "30-custom storefront-customstore1-sale-channel",
+              "tag": "Custom storefront",
+              "name": "customstore1",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-customstore1-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmvsxnwynzhetbyahbsmgvuhqnkyyqsjrsem5xambde7hs-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmVsxnWyNZhETbYahBsmgVuhqNKYyQsjrSeM5XAMbDE7hS",
+                  "lastUpdated": "1687773517"
+                }
+              ]
+            },
+            {
+              "id": "30-custom storefront-hola-sale-channel",
+              "tag": "Custom storefront",
+              "name": "hola",
+              "settingsUri": null,
+              "settingsEditor": null,
+              "link": null,
+              "deployments": [
+                {
+                  "id": "30-custom storefront-hola-sale-channel-https://bosonprotocol.infura-ipfs.io/ipfs/qmrhxgik53crhkx11m518tku8p3ybddcjado3mcrt9hjfj-deployment",
+                  "product": null,
+                  "status": null,
+                  "link": "https://bosonprotocol.infura-ipfs.io/ipfs/QmRhXgik53crHKX11M518tKU8p3yBddCJADo3Mcrt9HJFj",
+                  "lastUpdated": "1687862702"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "exchangePolicy": {
+      "id": "10-metadata-exchange-policy",
+      "uuid": "1683819377084",
+      "version": 1,
+      "label": "Fair Exchange Policy",
+      "template": "ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz",
+      "sellerContactMethod": "Chat App in the dApp",
+      "disputeResolverContactMethod": "email to: disputes-test@redeemeum.com"
+    },
+    "shipping": {
+      "id": "10-metadata-shipping",
+      "defaultVersion": 1,
+      "countryOfOrigin": null,
+      "supportedJurisdictions": [],
+      "redemptionPoint": null,
+      "returnPeriodInDays": 15
+    }
+  },
+  "range": null
+}

--- a/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.local.json
+++ b/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.local.json
@@ -1,0 +1,107 @@
+{
+  "yupSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/person.schema.json",
+    "title": "Person",
+    "description": "A person",
+    "type": "object",
+    "properties": {
+      "disputePeriodDuration": {
+        "description": "Dispute Period Duration",
+        "type": "number",
+        "min": 2592000,
+        "required": true
+      },
+      "disputeResolverId": {
+        "description": "Dispute Resolver",
+        "type": "string",
+        "matches": "^(1)$",
+        "required": true
+      },
+      "exchangeToken": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "description": "Exchange Token",
+            "type": "string",
+            "flags": "i",
+            "pattern": "^(0x0000000000000000000000000000000000000000)$",
+            "required": true
+          }
+        },
+        "required": true
+      },
+      "resolutionPeriodDuration": {
+        "description": "Resolution Period Duration",
+        "type": "number",
+        "min": 1296000,
+        "required": true
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Metadata Type",
+            "type": "string",
+            "matches": "^PRODUCT_V1$",
+            "required": true
+          },
+          "exchangePolicy": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "description": "Buyer/Seller Agreement Template",
+                "type": "string",
+                "flags": "i",
+                "pattern": "^(fairExchangePolicy|ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz)$",
+                "required": true
+              }
+            },
+            "required": true
+          },
+          "shipping": {
+            "type": "object",
+            "properties": {
+              "returnPeriodInDays": {
+                "description": "Return Period (in days)",
+                "type": "number",
+                "min": 15,
+                "required": true
+              }
+            },
+            "required": true
+          }
+        },
+        "required": true
+      }
+    }
+  },
+  "yupConfig": {
+    "errMessages": {
+      "disputePeriodDuration": {
+        "min": "Dispute Period Duration is less than 30 days"
+      },
+      "disputeResolverId": {
+        "matches": "Dispute Resolver is not whitelisted"
+      },
+      "address": {
+        "pattern": "Currency Token is not whitelisted"
+      },
+      "resolutionPeriodDuration": {
+        "min": "Resolution Period Duration is less than 15 days"
+      },
+      "type": {
+        "matches": "Metadata Type is not PRODUCT_V1 standard",
+        "required": "Metadata Type is not specified"
+      },
+      "template": {
+        "pattern": "Buyer/Seller Agreement Template is not standard",
+        "required": "Buyer/Seller Agreement Template is not specified"
+      },
+      "returnPeriodInDays": {
+        "min": "Return Period is less than 15 days",
+        "required": "Return Period is not specified"
+      }
+    }
+  }
+}

--- a/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.production.json
+++ b/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.production.json
@@ -1,0 +1,107 @@
+{
+  "yupSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/person.schema.json",
+    "title": "Person",
+    "description": "A person",
+    "type": "object",
+    "properties": {
+      "disputePeriodDuration": {
+        "description": "Dispute Period Duration",
+        "type": "number",
+        "min": 2592000,
+        "required": true
+      },
+      "disputeResolverId": {
+        "description": "Dispute Resolver",
+        "type": "string",
+        "matches": "^(1)$",
+        "required": true
+      },
+      "exchangeToken": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "description": "Exchange Token",
+            "type": "string",
+            "flags": "i",
+            "pattern": "^(0x0000000000000000000000000000000000000000|0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619|0x9B3B0703D392321AD24338Ff1f846650437A43C9|0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174|0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063|0xc2132D05D31c914a87C6611C10748AEb04B58e8F)$",
+            "required": true
+          }
+        },
+        "required": true
+      },
+      "resolutionPeriodDuration": {
+        "description": "Resolution Period Duration",
+        "type": "number",
+        "min": 1296000,
+        "required": true
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Metadata Type",
+            "type": "string",
+            "matches": "^PRODUCT_V1$",
+            "required": true
+          },
+          "exchangePolicy": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "description": "Buyer/Seller Agreement Template",
+                "type": "string",
+                "flags": "i",
+                "pattern": "^(fairExchangePolicy|ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz)$",
+                "required": true
+              }
+            },
+            "required": true
+          },
+          "shipping": {
+            "type": "object",
+            "properties": {
+              "returnPeriodInDays": {
+                "description": "Return Period (in days)",
+                "type": "number",
+                "min": 15,
+                "required": true
+              }
+            },
+            "required": true
+          }
+        },
+        "required": true
+      }
+    }
+  },
+  "yupConfig": {
+    "errMessages": {
+      "disputePeriodDuration": {
+        "min": "Dispute Period Duration is less than 30 days"
+      },
+      "disputeResolverId": {
+        "matches": "Dispute Resolver is not whitelisted"
+      },
+      "address": {
+        "pattern": "Currency Token is not whitelisted"
+      },
+      "resolutionPeriodDuration": {
+        "min": "Resolution Period Duration is less than 15 days"
+      },
+      "type": {
+        "matches": "Metadata Type is not PRODUCT_V1 standard",
+        "required": "Metadata Type is not specified"
+      },
+      "template": {
+        "pattern": "Buyer/Seller Agreement Template is not standard",
+        "required": "Buyer/Seller Agreement Template is not specified"
+      },
+      "returnPeriodInDays": {
+        "min": "Return Period is less than 15 days",
+        "required": "Return Period is not specified"
+      }
+    }
+  }
+}

--- a/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.production.json
+++ b/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.production.json
@@ -1,9 +1,8 @@
 {
   "yupSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://example.com/person.schema.json",
-    "title": "Person",
-    "description": "A person",
+    "title": "Boson Protocol - Exchange Policy Rules",
+    "description": "Rules to check whether the exchange policy of an offer is fair or not",
     "type": "object",
     "properties": {
       "disputePeriodDuration": {

--- a/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.staging.json
+++ b/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.staging.json
@@ -1,9 +1,8 @@
 {
   "yupSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://example.com/person.schema.json",
-    "title": "Person",
-    "description": "A person",
+    "title": "Boson Protocol - Exchange Policy Rules",
+    "description": "Rules to check whether the exchange policy of an offer is fair or not",
     "type": "object",
     "properties": {
       "disputePeriodDuration": {

--- a/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.staging.json
+++ b/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.staging.json
@@ -1,0 +1,107 @@
+{
+  "yupSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/person.schema.json",
+    "title": "Person",
+    "description": "A person",
+    "type": "object",
+    "properties": {
+      "disputePeriodDuration": {
+        "description": "Dispute Period Duration",
+        "type": "number",
+        "min": 2592000,
+        "required": true
+      },
+      "disputeResolverId": {
+        "description": "Dispute Resolver",
+        "type": "string",
+        "matches": "^(2)$",
+        "required": true
+      },
+      "exchangeToken": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "description": "Exchange Token",
+            "type": "string",
+            "flags": "i",
+            "pattern": "^(0x0000000000000000000000000000000000000000|0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa|0x1f5431E8679630790E8EbA3a9b41d1BB4d41aeD0|0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747|0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f|0xA02f6adc7926efeBBd59Fd43A84f4E0c0c91e832)$",
+            "required": true
+          }
+        },
+        "required": true
+      },
+      "resolutionPeriodDuration": {
+        "description": "Resolution Period Duration",
+        "type": "number",
+        "min": 1296000,
+        "required": true
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Metadata Type",
+            "type": "string",
+            "matches": "^PRODUCT_V1$",
+            "required": true
+          },
+          "exchangePolicy": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "description": "Buyer/Seller Agreement Template",
+                "type": "string",
+                "flags": "i",
+                "pattern": "^(fairExchangePolicy|ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz)$",
+                "required": true
+              }
+            },
+            "required": true
+          },
+          "shipping": {
+            "type": "object",
+            "properties": {
+              "returnPeriodInDays": {
+                "description": "Return Period (in days)",
+                "type": "number",
+                "min": 15,
+                "required": true
+              }
+            },
+            "required": true
+          }
+        },
+        "required": true
+      }
+    }
+  },
+  "yupConfig": {
+    "errMessages": {
+      "disputePeriodDuration": {
+        "min": "Dispute Period Duration is less than 30 days"
+      },
+      "disputeResolverId": {
+        "matches": "Dispute Resolver is not whitelisted"
+      },
+      "address": {
+        "pattern": "Currency Token is not whitelisted"
+      },
+      "resolutionPeriodDuration": {
+        "min": "Resolution Period Duration is less than 15 days"
+      },
+      "type": {
+        "matches": "Metadata Type is not PRODUCT_V1 standard",
+        "required": "Metadata Type is not specified"
+      },
+      "template": {
+        "pattern": "Buyer/Seller Agreement Template is not standard",
+        "required": "Buyer/Seller Agreement Template is not specified"
+      },
+      "returnPeriodInDays": {
+        "min": "Return Period is less than 15 days",
+        "required": "Return Period is not specified"
+      }
+    }
+  }
+}

--- a/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.testing.json
+++ b/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.testing.json
@@ -1,0 +1,107 @@
+{
+  "yupSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/person.schema.json",
+    "title": "Person",
+    "description": "A person",
+    "type": "object",
+    "properties": {
+      "disputePeriodDuration": {
+        "description": "Dispute Period Duration",
+        "type": "number",
+        "min": 2592000,
+        "required": true
+      },
+      "disputeResolverId": {
+        "description": "Dispute Resolver",
+        "type": "string",
+        "matches": "^(13)$",
+        "required": true
+      },
+      "exchangeToken": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "description": "Exchange Token",
+            "type": "string",
+            "flags": "i",
+            "pattern": "^(0x0000000000000000000000000000000000000000|0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa|0x1f5431E8679630790E8EbA3a9b41d1BB4d41aeD0|0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747|0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f|0xA02f6adc7926efeBBd59Fd43A84f4E0c0c91e832)$",
+            "required": true
+          }
+        },
+        "required": true
+      },
+      "resolutionPeriodDuration": {
+        "description": "Resolution Period Duration",
+        "type": "number",
+        "min": 1296000,
+        "required": true
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Metadata Type",
+            "type": "string",
+            "matches": "^PRODUCT_V1$",
+            "required": true
+          },
+          "exchangePolicy": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "description": "Buyer/Seller Agreement Template",
+                "type": "string",
+                "flags": "i",
+                "pattern": "^(fairExchangePolicy|ipfs://QmS6SUVL1mhRq9wyNho914vcHwj3gC491vq7wtdoe34SUz)$",
+                "required": true
+              }
+            },
+            "required": true
+          },
+          "shipping": {
+            "type": "object",
+            "properties": {
+              "returnPeriodInDays": {
+                "description": "Return Period (in days)",
+                "type": "number",
+                "min": 15,
+                "required": true
+              }
+            },
+            "required": true
+          }
+        },
+        "required": true
+      }
+    }
+  },
+  "yupConfig": {
+    "errMessages": {
+      "disputePeriodDuration": {
+        "min": "Dispute Period Duration is less than 30 days"
+      },
+      "disputeResolverId": {
+        "matches": "Dispute Resolver is not whitelisted"
+      },
+      "address": {
+        "pattern": "Currency Token is not whitelisted"
+      },
+      "resolutionPeriodDuration": {
+        "min": "Resolution Period Duration is less than 15 days"
+      },
+      "type": {
+        "matches": "Metadata Type is not PRODUCT_V1 standard",
+        "required": "Metadata Type is not specified"
+      },
+      "template": {
+        "pattern": "Buyer/Seller Agreement Template is not standard",
+        "required": "Buyer/Seller Agreement Template is not specified"
+      },
+      "returnPeriodInDays": {
+        "min": "Return Period is less than 15 days",
+        "required": "Return Period is not specified"
+      }
+    }
+  }
+}

--- a/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.testing.json
+++ b/packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.testing.json
@@ -1,9 +1,8 @@
 {
   "yupSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://example.com/person.schema.json",
-    "title": "Person",
-    "description": "A person",
+    "title": "Boson Protocol - Exchange Policy Rules",
+    "description": "Rules to check whether the exchange policy of an offer is fair or not",
     "type": "object",
     "properties": {
       "disputePeriodDuration": {

--- a/scripts/checkOfferExchangePolicy.ts
+++ b/scripts/checkOfferExchangePolicy.ts
@@ -1,45 +1,31 @@
-import fs from "fs";
-import { buildYup } from "schema-to-yup";
-import { SchemaOf } from "yup";
-
 import { EnvironmentType } from "@bosonprotocol/common/src/types/configs";
 import { providers } from "ethers";
 import { program } from "commander";
 import { getDefaultConfig } from "@bosonprotocol/common/src";
 import { CoreSDK } from "../packages/core-sdk/src";
 import { EthersAdapter } from "../packages/ethers-sdk/src";
+import rulesTesting from "../packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.testing.json";
+import rulesStaging from "../packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.staging.json";
+import rulesProduction from "../packages/core-sdk/tests/exchangePolicy/exchangePolicyRules.production.json";
+
+const rules = {
+  testing: rulesTesting,
+  staging: rulesStaging,
+  production: rulesProduction
+};
 
 program
   .description("Check Exchange policy of an Offer.")
+  .argument("<OFFER_ID>", "Id of the offer to check")
   .option("-e, --env <ENV_NAME>", "Target environment", "testing")
   .parse(process.argv);
 
-const schema = {
-  $schema: "http://json-schema.org/draft-07/schema#",
-  $id: "http://example.com/person.schema.json",
-  title: "Person",
-  description: "A person",
-  type: "object",
-  properties: {
-    disputePeriodDuration: {
-      description: "disputePeriodDuration",
-      type: "number",
-      max: 3600 * 24 * 30 // 30 days to sec
-    }
-  }
-};
-
-const baseSchema: SchemaOf<any> = buildYup(schema, {});
-
 async function main() {
-  //   const [sellerPrivateKey] = program.args;
-  const offerId = "10";
+  const [offerId] = program.args;
 
   const opts = program.opts();
   const envName = opts.env || "testing";
   const defaultConfig = getDefaultConfig(envName as EnvironmentType);
-  const chainId = defaultConfig.chainId;
-//   const sellerWallet = new Wallet(sellerPrivateKey);
 
   const coreSDK = CoreSDK.fromDefaultConfig({
     web3Lib: new EthersAdapter(
@@ -48,11 +34,8 @@ async function main() {
     envName
   });
 
-  const offerData = await coreSDK.getOfferById(offerId);
-  console.log("offerData", offerData);
-
-  const result = baseSchema.validateSync(offerData);
-  console.log("result", result);
+  const result = await coreSDK.checkExchangePolicy(offerId, rules[envName]);
+  console.log(result);
 }
 
 main()

--- a/scripts/checkOfferExchangePolicy.ts
+++ b/scripts/checkOfferExchangePolicy.ts
@@ -1,0 +1,66 @@
+import fs from "fs";
+import { buildYup } from "schema-to-yup";
+import { SchemaOf } from "yup";
+
+import { EnvironmentType } from "@bosonprotocol/common/src/types/configs";
+import { providers } from "ethers";
+import { program } from "commander";
+import { getDefaultConfig } from "@bosonprotocol/common/src";
+import { CoreSDK } from "../packages/core-sdk/src";
+import { EthersAdapter } from "../packages/ethers-sdk/src";
+
+program
+  .description("Check Exchange policy of an Offer.")
+  .option("-e, --env <ENV_NAME>", "Target environment", "testing")
+  .parse(process.argv);
+
+const schema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "http://example.com/person.schema.json",
+  title: "Person",
+  description: "A person",
+  type: "object",
+  properties: {
+    disputePeriodDuration: {
+      description: "disputePeriodDuration",
+      type: "number",
+      max: 3600 * 24 * 30 // 30 days to sec
+    }
+  }
+};
+
+const baseSchema: SchemaOf<any> = buildYup(schema, {});
+
+async function main() {
+  //   const [sellerPrivateKey] = program.args;
+  const offerId = "10";
+
+  const opts = program.opts();
+  const envName = opts.env || "testing";
+  const defaultConfig = getDefaultConfig(envName as EnvironmentType);
+  const chainId = defaultConfig.chainId;
+//   const sellerWallet = new Wallet(sellerPrivateKey);
+
+  const coreSDK = CoreSDK.fromDefaultConfig({
+    web3Lib: new EthersAdapter(
+      new providers.JsonRpcProvider(defaultConfig.jsonRpcUrl)
+    ),
+    envName
+  });
+
+  const offerData = await coreSDK.getOfferById(offerId);
+  console.log("offerData", offerData);
+
+  const result = baseSchema.validateSync(offerData);
+  console.log("result", result);
+}
+
+main()
+  .then(() => {
+    console.log("success");
+    process.exit(0);
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description
a new service is now available in the core-sdk:
`public async checkExchangePolicy(
    offerId: BigNumberish,
    rules: offers.CheckExchangePolicyRules
): Promise<offers.CheckExchangePolicyResult>`

Example of the rules are available here (env dependent):
[exchangePolicyRules.testing.json](packages\core-sdk\tests\exchangePolicy\exchangePolicyRules.testing.json)
[exchangePolicyRules.staging.json](packages\core-sdk\tests\exchangePolicy\exchangePolicyRules.staging.json)
[exchangePolicyRules.production.json](packages\core-sdk\tests\exchangePolicy\exchangePolicyRules.production.json)

## How to test

- unit tests have been added in core-sdk package
- a script has been added to call the service manually
