### PR TITLE
fix: redemption widget - direct click on Redeem exchange

### DIFF
--- a/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
+++ b/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
@@ -269,7 +269,7 @@ export default function RedeemNonModal({
                     myItemsOnExchangeCardClick?.(exchange);
                   }}
                   onRedeemClick={(exchange) => {
-                    setActiveStep(ActiveStep.EXCHANGE_VIEW);
+                    setActiveStep(ActiveStep.REDEEM_FORM);
                     setExchange(exchange);
                     myItemsOnRedeemClick?.(exchange);
                   }}


### PR DESCRIPTION
## Description

relates to https://github.com/bosonprotocol/widgets/issues/14
