### PR TITLE
fix: add content-type header when POST message to redeemCallbackUrl

### DIFF
--- a/packages/react-kit/src/components/config/ConfigContext.ts
+++ b/packages/react-kit/src/components/config/ConfigContext.ts
@@ -20,6 +20,7 @@ export type ConfigContextProps = {
   licenseTemplate: string;
   contactSellerForExchangeUrl: string;
   redeemCallbackUrl?: string;
+  redeemCallbackHeaders?: { [key: string]: string };
   usePendingTransactions?: boolean;
 };
 

--- a/packages/react-kit/src/components/modal/components/Redeem/Confirmation/Confirmation.tsx
+++ b/packages/react-kit/src/components/modal/components/Redeem/Confirmation/Confirmation.tsx
@@ -105,6 +105,7 @@ export default function Confirmation({
         "[callredeemCallbackUrl] redeemCallbackUrl is not defined"
       );
     }
+    // TODO: add wallet signature in the message (structure still TBD - must be verifiable by the backend)
     await fetch(redeemCallbackUrl, {
       method: "POST",
       body: JSON.stringify({
@@ -114,7 +115,11 @@ export default function Confirmation({
         sellerId,
         sellerAddress,
         buyerAddress: await signer?.getAddress()
-      })
+      }),
+      headers: {
+        "content-type": "application/json;charset=UTF-8"
+        // TODO: add optional headers passed as arguments (could be passed as POST request parameters)
+      }
     });
   };
   const handleRedeem = async () => {


### PR DESCRIPTION
## Description

To be done:
- add wallet signature in the redemption message (https://github.com/bosonprotocol/widgets/issues/8)
- allow to pass additional headers to the redemption request (would be used for authentication)

## How to test

{{how can it be tested}}
