### PR TITLE
fix: when a media in not an IPFS link, extractCID still log an error …

### DIFF
--- a/scripts/create-offer-batch.ts
+++ b/scripts/create-offer-batch.ts
@@ -43,10 +43,10 @@ async function main() {
   const offersFullDataJson = offersDataJson.map((specData) => {
     const offerData = { ...offerTemplate, ...specData };
     if (offerData["validFromDateInMS"] === undefined) {
-      offerData["validFromDateInMS"] = Date.now() + 5 * 60000;
+      offerData["validFromDateInMS"] = Date.now();
     }
     if (offerData["voucherRedeemableFromDateInMS"] === undefined) {
-      offerData["voucherRedeemableFromDateInMS"] = Date.now() + 5 * 60000;
+      offerData["voucherRedeemableFromDateInMS"] = Date.now();
     }
     return offerData;
   });

--- a/scripts/pin-to-pinata.ts
+++ b/scripts/pin-to-pinata.ts
@@ -171,12 +171,14 @@ async function main() {
             offer.metadata?.productV1Seller?.images?.map((img) =>
               extractCID(img.url)
             ) || [];
-          const videoCIDs = [...metadataAnimation, ...visualVideos];
+          const videoCIDs = [...metadataAnimation, ...visualVideos].filter(
+            (v) => !!v
+          );
           const imageCIDs = [
             ...metadataImage,
             ...visualImages,
             ...sellerImages
-          ];
+          ].filter((v) => !!v);
 
           // save some metadata for later usage
           for (const videoCID of videoCIDs) {

--- a/scripts/pin-to-pinata.ts
+++ b/scripts/pin-to-pinata.ts
@@ -30,7 +30,8 @@ function extractCID(imageUri: string) {
       CID.parse(cidFromUrl || imageUri);
       return cidFromUrl;
     } catch (error) {
-      throw new Error(`Failed to parse CID from: ${imageUri}`);
+      console.error(`Failed to parse CID from: ${imageUri}`);
+      return undefined;
     }
   }
 }


### PR DESCRIPTION
…but returns undefined instead of throwing an exception, so that the treatment can go on with the rest of the offer's media

## Description

fix #539 

## How to test

manually run pin-to-pinata o,n the staging env
