### PR TITLE
feat: add forcedAccount property on RedemptionWidget

### DIFF
--- a/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
+++ b/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
@@ -212,7 +212,7 @@ export default function RedeemNonModal({
   if (
     forcedAccount &&
     address &&
-    forcedAccount.toLowerCase() !== address?.toLowerCase()
+    forcedAccount.toLowerCase() !== address.toLowerCase()
   ) {
     // force disconnection as the current connected wallet is not the forced one
     disconnect();

--- a/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
+++ b/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
@@ -1,6 +1,12 @@
 import { Form, Formik, FormikProps } from "formik";
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useAccount } from "wagmi";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import { useAccount, useDisconnect } from "wagmi";
 import * as Yup from "yup";
 import { ExchangePolicy } from "./ExchangePolicy/ExchangePolicy";
 import { MyItems, MyItemsProps } from "./MyItems/MyItems";
@@ -81,6 +87,7 @@ export type RedeemNonModalProps = {
   expireVoucherViewOnSuccess?: ExpireVoucherViewProps["onSuccess"];
   cancellationViewOnSuccess?: CancellationViewProps["onSuccess"];
   confirmationViewOnSuccess?: ConfirmationViewProps["onSuccess"];
+  forcedAccount?: string;
 };
 export default function RedeemNonModal({
   exchange: selectedExchange,
@@ -102,7 +109,8 @@ export default function RedeemNonModal({
   exchangeViewOnRaiseDisputeClick,
   expireVoucherViewOnSuccess,
   cancellationViewOnSuccess,
-  confirmationViewOnSuccess
+  confirmationViewOnSuccess,
+  forcedAccount
 }: RedeemNonModalProps) {
   const [exchange, setExchange] = useState<Exchange | null>(null);
   const { sellers, isLoading } = useCurrentSellers();
@@ -195,6 +203,21 @@ export default function RedeemNonModal({
     }
   }, [currentStep]);
   const { address } = useAccount();
+  const { disconnectAsync, status } = useDisconnect();
+  const disconnect = useCallback(() => {
+    if (disconnectAsync && status !== "loading") {
+      disconnectAsync();
+    }
+  }, [disconnectAsync, status]);
+  if (
+    forcedAccount &&
+    address &&
+    forcedAccount.toLowerCase() !== address?.toLowerCase()
+  ) {
+    // force disconnection as the current connected wallet is not the forced one
+    disconnect();
+  }
+
   if (!address) {
     if (currentStep !== ActiveStep.STEPS_OVERVIEW) {
       // reinitialize the wizard step
@@ -214,6 +237,7 @@ export default function RedeemNonModal({
         }}
       >
         <p>Please connect your wallet</p>
+        {forcedAccount && <p>(expected account: {forcedAccount})</p>}
       </NonModal>
     );
   }

--- a/packages/react-kit/src/components/wallet/wallet-connection.ts
+++ b/packages/react-kit/src/components/wallet/wallet-connection.ts
@@ -36,7 +36,15 @@ export function getConnectors(chainId: number, walletConnectProjectId: string) {
     {
       groupName: "Popular",
       wallets: [
-        metaMaskWallet({ chains, projectId }),
+        metaMaskWallet({
+          chains,
+          projectId,
+          shimDisconnect: true,
+          UNSTABLE_shimOnConnectSelectAccount: true
+          // shimDisconnect and UNSTABLE_shimOnConnectSelectAccount options required
+          // to really disconnect metamask if the connected wallet if not the expected one,
+          // and let the user chose another account
+        }),
         walletConnectWallet({ chains, projectId })
       ]
     }

--- a/packages/react-kit/src/stories/widgets/Redemption.stories.tsx
+++ b/packages/react-kit/src/stories/widgets/Redemption.stories.tsx
@@ -59,7 +59,8 @@ Redemption.args = {
     console.log("closeWidgetClick()");
   },
   modalMargin: "2%",
-  bypassMode: RedemptionBypassMode.NORMAL
+  bypassMode: RedemptionBypassMode.NORMAL,
+  forcedAccount: ""
 };
 
 Redemption.decorators = [(Story) => wrapper(Story)];


### PR DESCRIPTION
## Description

The forcedAccount optional property allows to open the redemption widget for a specific account.
In case the wallet is already connected with another account, it forces disconnection

required for https://github.com/bosonprotocol/interface/issues/831 and https://github.com/bosonprotocol/widgets/issues/52

## How to test

react-kit / storybook
