### PR TITLE
fix: force amd64 platform on dockers

### DIFF
--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM --platform=linux/amd64 node:16
 
 COPY . /app
 

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -88,7 +88,16 @@ module.exports = {
         }
       },
       {
-        version: "0.8.17"
+        version: "0.8.17",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+            details: {
+              yul: true
+            }
+          }
+        }
       },
       {
         version: "0.4.17"

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../.
       dockerfile: ./e2e/meta-tx-gateway/Dockerfile
     user: "node:node"
-    image: meta-tx-gateway:20230901143600
+    image: meta-tx-gateway:202309251200
     ports:
       - "8888:8888"
     environment:
@@ -20,7 +20,7 @@ services:
 
   hardhat-node:
     build: ../contracts
-    image: hardhat-node:8319ec72c2335a49b74aeefd232ea9f0a6dfd368_0
+    image: hardhat-node:8319ec72c2335a49b74aeefd232ea9f0a6dfd368_1
     ports:
       - "8545:8545"
     volumes:

--- a/e2e/meta-tx-gateway/Dockerfile
+++ b/e2e/meta-tx-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM --platform=linux/amd64 node:16-alpine
 
 RUN apk --no-cache add --virtual .builds-deps build-base python3 git
 

--- a/packages/common/src/types/accounts.ts
+++ b/packages/common/src/types/accounts.ts
@@ -1,14 +1,67 @@
 import { BigNumberish } from "@ethersproject/bignumber";
 
+/**
+ * CreateSellerArgs
+ *
+ * ## Boson Seller roles
+ *
+ * In Boson Protocol, a Seller account is created for a set of wallet addresses mapped to roles:
+ * - `admin`: the wallet with the `admin` role controls the seller account security, in particular setting up the wallet addresses of the other roles
+ * - `assistant`: the wallet with the `assistant` role controls most of the usual Seller's activities in Boson Protocol: managing offers, managing exchanges, managing disputes,
+ * - `treasury`: the wallet with the `treasury` role receives the money, when withdrawn from the protocol
+ * Note: it is possible to associate the same wallet to the 3 roles. By the way, that is the easiest way to set up a Boson Seller account!
+ * At any time, it is possible to change the wallets mapped to the different roles, no matter what your initial choice was.
+ *
+ * ## Authentication Token feature
+ *
+ * Optionally, the `admin` role can be associated to the wallet owning and **Authentication Token**.
+ * Supported authentication Tokens are:
+ * - ENS on Ethereum
+ * - LENS on Mumbai
+ * Using the Authentication Token feature allows to associate the seller account with a specific Token, instead of a specific account.
+ * If the Auth Token is transferred to another wallet, then the Boson Seller account control is transferred to this new wallet as well, without any other action.
+ *
+ * To use the Auth Token feature, set:
+ * - `admin` address to 0x0000000000000000000000000000000000000000,
+ * - `authTokenType` to AuthTokenType.ENS (on Ethereum) or AuthTokenType.LENS (on Mumbai) {@link AuthTokenType}
+ * - `authTokenId` to the ENS or LENS tokenId owned by the wallet you want to associate to the `admin` role
+ *
+ * To NOT use the Auth Token feature, set:
+ * - `admin` address to the address of the wallet you want to associate to the `admin` role,
+ * - `authTokenType` to AuthTokenType.NONE {@link AuthTokenType}
+ *
+ * ## Boson Seller Metadata
+ *
+ * Optionally the seller account can define some metadata about the seller.
+ * Seller Metadata Schema: https://github.com/bosonprotocol/core-components/blob/main/packages/metadata/src/seller/schema.json
+ * This metadata can be updated at any time using {@link updateSeller}
+ *
+ * ## Voucher Collection
+ *
+ * When the Seller creates some Offers, they will be part of a Collection
+ * Each collection is an NFT contract, whose tokens, the redeemable NFTs, will represent the vouchers (or `exchanges`) for the offers created in that collection.
+ * To improve the render of the NFT collection in an NFT marketplace (eg Opensea), the NFT contract can provide some metadata (see schema at https://docs.opensea.io/docs/contract-level-metadata).
+ * When creating a Seller, a first Collection is created and will receive, by default, all offers created by the Seller until they decide to create other collections.
+ *
+ */
 export type CreateSellerArgs = {
+  /** wallet address of the seller's 'assistant' role */
   assistant: string;
+  /** wallet address of the seller's 'admin' role OR 0x0000000000000000000000000000000000000000 if authTokenType is used */
   admin: string;
+  /** wallet address of the seller's 'treasury' role */
   treasury: string;
+  /** Uri of the metadata of the 1st collection voucher contract */
   contractUri: string;
+  /** Royalty percentage for voucher secondary sales */
   royaltyPercentage: BigNumberish;
+  /** Id of the token owned by the 'admin' wallet, in case authTokenType is used */
   authTokenId: BigNumberish;
+  /** Type of AuthToken {@link AuthTokenType} */
   authTokenType: number;
+  /** Uri of the seller metadata */
   metadataUri: string;
+  /** A tag to identify the seller's first collection */
   collectionId?: string;
 };
 


### PR DESCRIPTION
## Description

fixes #568 

## How to test

on a Mac machine, the following command should NOT fail:
```
cd contracts
docker build .
```