### PR TITLE
feat: redemption widget add handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "pin-to-pinata": "ts-node -P tsconfig.base.json ./scripts/pin-to-pinata.ts",
     "complete-exchange": "ts-node -P tsconfig.base.json ./scripts/complete-exchange.ts",
     "update-contract-uri": "ts-node -P tsconfig.base.json ./scripts/change-contract-uri.ts",
-    "check-offer-exchange-policy": "ts-node -P tsconfig.base.json ./scripts/checkOfferExchangePolicy.ts"
+    "check-offer-exchange-policy": "ts-node -P tsconfig.base.json ./scripts/checkOfferExchangePolicy.ts",
+    "get-buyers": "ts-node -P tsconfig.base.json ./scripts/get-buyers.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/react-kit/src/components/modal/components/Redeem/Confirmation/Confirmation.tsx
+++ b/packages/react-kit/src/components/modal/components/Redeem/Confirmation/Confirmation.tsx
@@ -35,7 +35,11 @@ import {
   useAccount,
   useSigner
 } from "../../../../../hooks/connection/connection";
-import { useRedemptionCallbacks } from "../../../../../hooks/callbacks/useRedemptionCallbacks";
+import {
+  DeliveryInfoCallbackResponse,
+  DeliveryInfoMessage,
+  useRedemptionCallbacks
+} from "../../../../../hooks/callbacks/useRedemptionCallbacks";
 import { NonModalProps } from "../../../nonModal/NonModal";
 import {
   RedemptionWidgetAction,
@@ -81,7 +85,12 @@ export default function Confirmation({
   hideModal
 }: ConfirmationProps) {
   const { envName, configId } = useEnvContext();
-  const { widgetAction, setWidgetAction } = useRedemptionContext();
+  const {
+    widgetAction,
+    setWidgetAction,
+    deliveryInfoHandler,
+    sendDeliveryInfoThroughXMTP
+  } = useRedemptionContext();
   const { postDeliveryInfo, postRedemptionConfirmed, postRedemptionSubmitted } =
     useRedemptionCallbacks();
   const coreSDK = useCoreSDKWithContext();
@@ -101,7 +110,7 @@ export default function Confirmation({
   const showSuccessInitialization =
     chatInitializationStatus === "INITIALIZED" &&
     bosonXmtp &&
-    !postDeliveryInfo;
+    sendDeliveryInfoThroughXMTP;
   const isInitializationValid =
     !!bosonXmtp &&
     ["INITIALIZED", "ALREADY_INITIALIZED"].includes(chatInitializationStatus);
@@ -151,61 +160,52 @@ export default function Confirmation({
       console.error("Error while confirming Redeem", error);
     }
   };
-  const handleConfirmRedemptionInfoWithXMTP = async () => {
-    try {
-      await sendDeliveryDetailsToChat();
-      handleConfirmRedeem();
-      setRedemptionInfoError(null);
-    } catch (error) {
-      Sentry.captureException(error, {
-        extra: {
-          action: "redeem",
-          location: "redeem-modal",
-          exchangeId,
-          buyerId,
-          sellerId,
-          sellerAddress,
-          buyerAddress: address
-        }
-      });
-      console.error(
-        "Error while sending a message with the delivery details",
-        error
-      );
-      setRedemptionInfoError(error as Error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-  const handleConfirmRedemptionInfoWithCallback = async () => {
-    const message = {
-      deliveryDetails: values,
-      ...redemptionInfo
-    };
+  const handleSendRedemptionInfo: (
+    handler: (
+      message: DeliveryInfoMessage,
+      signature?: string
+    ) => Promise<DeliveryInfoCallbackResponse>,
+    message: DeliveryInfoMessage,
+    signature?: string
+  ) => Promise<{
+    resume: boolean;
+  }> = async (handler, message, signature) => {
+    let resume = true;
     try {
       setIsLoading(true);
-      if (!postDeliveryInfo) {
-        throw new Error(`postDeliveryInfo is undefined`);
-      }
-      const response = await postDeliveryInfo(message, signer);
-      setIsLoading(false);
-      if (!response.accepted) {
-        setRedemptionInfoError(
-          new Error(
-            `Redemption information has not been accepted: ${response.reason}`
-          )
-        );
-        setRedemptionInfoAccepted(false);
-        setResumeRedemption(false);
-      } else if (!response.resume) {
-        setRedemptionInfoError(new Error(`Redemption Widget may be closed`));
-        setRedemptionInfoAccepted(true);
-        setResumeRedemption(false);
-        hideModal?.();
-      } else {
-        setRedemptionInfoError(null);
-        setRedemptionInfoAccepted(true);
-        setResumeRedemption(true);
+      if (handler) {
+        await (async () => {
+          const response = await handler(message, signature);
+          if (response) {
+            if (!response.accepted) {
+              setRedemptionInfoError(
+                new Error(
+                  `Redemption information has not been accepted: ${response.reason}`
+                )
+              );
+              setRedemptionInfoAccepted(false);
+              setResumeRedemption(false);
+              resume = false;
+              setIsLoading(false); // to allow trying with another delivery info
+            } else if (!response.resume) {
+              setRedemptionInfoError(
+                new Error(`Redemption Widget may be closed`)
+              );
+              setRedemptionInfoAccepted(true);
+              setResumeRedemption(false);
+              resume = false;
+              hideModal?.();
+            } else {
+              setRedemptionInfoError(null);
+              setRedemptionInfoAccepted(true);
+              setResumeRedemption(true);
+            }
+          } else {
+            throw new Error("Error while calling deliveryInfo handler"); // will be catch just below
+          }
+        })().catch((e) => {
+          throw e; // will be catch just below
+        });
       }
     } catch (error) {
       Sentry.captureException(error, {
@@ -219,11 +219,12 @@ export default function Confirmation({
           buyerAddress: address
         }
       });
-      console.error("Error while calling deliveryInfo callback", error);
+      console.error("Error while calling deliveryInfo handler", error);
       setRedemptionInfoError(error as Error);
-    } finally {
+      resume = false;
       setIsLoading(false);
     }
+    return { resume };
   };
   const handleOnBackClick = () => {
     if (widgetAction === RedemptionWidgetAction.CONFIRM_REDEEM) {
@@ -233,32 +234,46 @@ export default function Confirmation({
     onBackClick();
   };
 
-  const sendDeliveryDetailsToChat = async () => {
-    const value = `DELIVERY ADDRESS:
+  const sendDeliveryDetailsToChat = async (message: DeliveryInfoMessage) => {
+    let resume = true;
+    const accepted = true;
+    let reason = "";
+    try {
+      const value = `DELIVERY ADDRESS:
 
-${FormModel.formFields.name.placeholder}: ${nameField.value}
-${FormModel.formFields.streetNameAndNumber.placeholder}: ${streetNameAndNumberField.value}
-${FormModel.formFields.city.placeholder}: ${cityField.value}
-${FormModel.formFields.state.placeholder}: ${stateField.value}
-${FormModel.formFields.zip.placeholder}: ${zipField.value}
-${FormModel.formFields.country.placeholder}: ${countryField.value}
-${FormModel.formFields.email.placeholder}: ${emailField.value}
-${FormModel.formFields.phone.placeholder}: ${phoneField.value}`;
+${FormModel.formFields.name.placeholder}: ${message.deliveryDetails.name}
+${FormModel.formFields.streetNameAndNumber.placeholder}: ${message.deliveryDetails.streetNameAndNumber}
+${FormModel.formFields.city.placeholder}: ${message.deliveryDetails.city}
+${FormModel.formFields.state.placeholder}: ${message.deliveryDetails.state}
+${FormModel.formFields.zip.placeholder}: ${message.deliveryDetails.zip}
+${FormModel.formFields.country.placeholder}: ${message.deliveryDetails.country}
+${FormModel.formFields.email.placeholder}: ${message.deliveryDetails.email}
+${FormModel.formFields.phone.placeholder}: ${message.deliveryDetails.phone}`;
 
-    const newMessage = {
-      threadId: {
-        exchangeId,
-        buyerId,
-        sellerId
-      },
-      content: {
-        value
-      },
-      contentType: MessageType.String,
-      version
-    } as const;
-    const destinationAddress = utils.getAddress(sellerAddress);
-    await bosonXmtp?.encodeAndSendMessage(newMessage, destinationAddress);
+      const newMessage = {
+        threadId: {
+          exchangeId,
+          buyerId,
+          sellerId
+        },
+        content: {
+          value
+        },
+        contentType: MessageType.String,
+        version
+      } as const;
+      const destinationAddress = utils.getAddress(sellerAddress);
+      await bosonXmtp?.encodeAndSendMessage(newMessage, destinationAddress);
+    } catch (e: unknown) {
+      resume = false;
+      reason = String(e);
+    }
+
+    return {
+      accepted,
+      resume,
+      reason
+    };
   };
 
   return (
@@ -298,7 +313,7 @@ ${FormModel.formFields.phone.placeholder}: ${phoneField.value}`;
           </ThemedButton>
         </Grid>
       </Grid>
-      {!postDeliveryInfo && <InitializeChatWithSuccess />}
+      {sendDeliveryInfoThroughXMTP && <InitializeChatWithSuccess />}
       {showSuccessInitialization && (
         <div>
           <StyledGrid
@@ -321,17 +336,58 @@ ${FormModel.formFields.phone.placeholder}: ${phoneField.value}`;
       <Grid padding="2rem 0 0 0" justifyContent="space-between">
         <StyledRedeemButton
           type="button"
-          onClick={() =>
-            postDeliveryInfo
-              ? redemptionInfoAccepted
-                ? handleConfirmRedeem()
-                : handleConfirmRedemptionInfoWithCallback()
-              : handleConfirmRedemptionInfoWithXMTP()
-          }
+          onClick={async () => {
+            let resume = true;
+            let signature;
+            const message = {
+              deliveryDetails: values,
+              ...redemptionInfo
+            };
+            if (!redemptionInfoAccepted) {
+              setIsLoading(true);
+              setRedemptionInfoError(null);
+              if (sendDeliveryInfoThroughXMTP) {
+                ({ resume } = await handleSendRedemptionInfo(
+                  sendDeliveryDetailsToChat,
+                  message
+                ));
+              }
+              if (resume && deliveryInfoHandler) {
+                if (!signature) {
+                  // add wallet signature in the message (must be verifiable by the receiver)
+                  signature = signer
+                    ? await signer.signMessage(JSON.stringify(message))
+                    : undefined;
+                }
+                ({ resume } = await handleSendRedemptionInfo(
+                  deliveryInfoHandler,
+                  message,
+                  signature
+                ));
+              }
+              if (resume && postDeliveryInfo) {
+                if (!signature) {
+                  // add wallet signature in the message (must be verifiable by the receiver)
+                  signature = signer
+                    ? await signer.signMessage(JSON.stringify(message))
+                    : undefined;
+                }
+                ({ resume } = await handleSendRedemptionInfo(
+                  postDeliveryInfo,
+                  message,
+                  signature
+                ));
+              }
+              setIsLoading(false);
+            }
+            if (resume) {
+              handleConfirmRedeem();
+            }
+          }}
           disabled={
             isLoading ||
-            (!isInitializationValid && !postDeliveryInfo) ||
-            (postDeliveryInfo && redemptionInfoAccepted && !resumeRedemption)
+            (!isInitializationValid && sendDeliveryInfoThroughXMTP) ||
+            (redemptionInfoAccepted && !resumeRedemption)
           }
         >
           <Grid gap="0.5rem">
@@ -356,10 +412,6 @@ ${FormModel.formFields.phone.placeholder}: ${phoneField.value}`;
               web3Provider: signer?.provider as Provider,
               metaTx: coreSDK.metaTxConfig
             }}
-            disabled={
-              // ensure the button is disabled if postDeliveryInfo has failed
-              isLoading || (!isInitializationValid && !postDeliveryInfo)
-            }
             exchangeId={exchangeId}
             onError={(...args) => {
               const [error] = args;

--- a/packages/react-kit/src/components/widgets/redemption/provider/RedemptionContext.tsx
+++ b/packages/react-kit/src/components/widgets/redemption/provider/RedemptionContext.tsx
@@ -46,7 +46,7 @@ export type RedemptionContextProps = {
   // In case the redemption submission shall be handle in frontend
   redemptionSubmittedHandler?: (
     message: RedeemTransactionSubmittedMessage
-  ) => RedeemTransactionSubmittedCallbackResponse;
+  ) => Promise<RedeemTransactionSubmittedCallbackResponse>;
   // Url to POST the callback after a Redeem/Cancel transaction has been submitted, or an error if the submission failed
   postRedemptionSubmittedUrl?: string;
   // Request headers to POST the postRedemptionSubmittedUrl callback
@@ -54,7 +54,7 @@ export type RedemptionContextProps = {
   // In case the redemption confirmation shall be handle in frontend
   redemptionConfirmedHandler?: (
     message: RedeemTransactionConfirmedMessage
-  ) => RedeemTransactionConfirmedCallbackResponse;
+  ) => Promise<RedeemTransactionConfirmedCallbackResponse>;
   // Url to POST the callback after a Redeem/Cancel transaction has been confirmed, or an error if the confirmation failed
   postRedemptionConfirmedUrl?: string;
   // Request headers to POST the postRedemptionConfirmedUrl callback

--- a/packages/react-kit/src/components/widgets/redemption/provider/RedemptionContext.tsx
+++ b/packages/react-kit/src/components/widgets/redemption/provider/RedemptionContext.tsx
@@ -1,6 +1,14 @@
 import { subgraph } from "@bosonprotocol/core-sdk";
 import { createContext, useContext } from "react";
 import { FormType as RedeemFormType } from "../../../modal/components/Redeem/RedeemFormModel";
+import {
+  DeliveryInfoCallbackResponse,
+  DeliveryInfoMessage,
+  RedeemTransactionConfirmedCallbackResponse,
+  RedeemTransactionConfirmedMessage,
+  RedeemTransactionSubmittedCallbackResponse,
+  RedeemTransactionSubmittedMessage
+} from "../../../../hooks/callbacks/useRedemptionCallbacks";
 
 export enum RedemptionWidgetAction {
   // The widget will ask the user to select an Exchange (My Items view)
@@ -24,14 +32,29 @@ export type RedemptionContextProps = {
   setWidgetAction: (widgetAction: RedemptionWidgetAction) => void;
   // default state of exchanges shown in My Items view
   exchangeState: subgraph.ExchangeState;
+  // If the deliveryInfo shall be sent to the seller via XMTP
+  sendDeliveryInfoThroughXMTP: boolean;
+  // A specific handler to transfer deliveryInfo (can be used to post message between frontend windows)
+  deliveryInfoHandler?: (
+    message: DeliveryInfoMessage,
+    signature?: string
+  ) => Promise<DeliveryInfoCallbackResponse>;
   // Url to POST the callback with deliveryInfo
   postDeliveryInfoUrl?: string;
   // Request headers to POST the postDeliveryInfoUrl callback
   postDeliveryInfoHeaders?: { [key: string]: string };
+  // In case the redemption submission shall be handle in frontend
+  redemptionSubmittedHandler?: (
+    message: RedeemTransactionSubmittedMessage
+  ) => RedeemTransactionSubmittedCallbackResponse;
   // Url to POST the callback after a Redeem/Cancel transaction has been submitted, or an error if the submission failed
   postRedemptionSubmittedUrl?: string;
   // Request headers to POST the postRedemptionSubmittedUrl callback
   postRedemptionSubmittedHeaders?: { [key: string]: string };
+  // In case the redemption confirmation shall be handle in frontend
+  redemptionConfirmedHandler?: (
+    message: RedeemTransactionConfirmedMessage
+  ) => RedeemTransactionConfirmedCallbackResponse;
   // Url to POST the callback after a Redeem/Cancel transaction has been confirmed, or an error if the confirmation failed
   postRedemptionConfirmedUrl?: string;
   // Request headers to POST the postRedemptionConfirmedUrl callback

--- a/packages/react-kit/src/hooks/callbacks/useRedemptionCallbacks.ts
+++ b/packages/react-kit/src/hooks/callbacks/useRedemptionCallbacks.ts
@@ -99,17 +99,13 @@ function postDeliveryInfoCallback(
 ) {
   return async (
     message: DeliveryInfoMessage,
-    signer: providers.JsonRpcSigner | undefined
+    signature: string | undefined
   ): Promise<DeliveryInfoCallbackResponse> => {
     if (!postDeliveryInfoUrl) {
       throw new Error(
         "[postDeliveryInfoCallback] postDeliveryInfoUrl is not defined"
       );
     }
-    // add wallet signature in the message (must be verifiable by the backend)
-    const signature = signer
-      ? await signer.signMessage(JSON.stringify(message))
-      : undefined;
     return fetchAndReadResponse("deliveryInfo", postDeliveryInfoUrl, {
       method: "POST",
       body: JSON.stringify({

--- a/packages/react-kit/src/stories/widgets/Redemption.stories.tsx
+++ b/packages/react-kit/src/stories/widgets/Redemption.stories.tsx
@@ -60,6 +60,7 @@ Redemption.args = {
   widgetAction: RedemptionWidgetAction.SELECT_EXCHANGE,
   showRedemptionOverview: true,
   exchangeState: subgraph.ExchangeState.Committed,
+  sendDeliveryInfoThroughXMTP: true,
   forcedAccount: "",
   sellerIds: undefined
 };
@@ -71,6 +72,7 @@ export const RedemptionCallbacks: ComponentStory<typeof RedemptionWidget> =
 
 RedemptionCallbacks.args = {
   ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
   postDeliveryInfoUrl: "http://localhost:3666/deliveryInfo",
   postRedemptionSubmittedUrl: "http://localhost:3666/submitted",
   postRedemptionConfirmedUrl: "http://localhost:3666/confirmed"
@@ -82,6 +84,7 @@ export const RedemptionCallbacksThenClose: ComponentStory<
 
 RedemptionCallbacksThenClose.args = {
   ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
   postDeliveryInfoUrl: "http://localhost:3666/deliveryInfoThenClose",
   postRedemptionSubmittedUrl: "http://localhost:3666/submitted",
   postRedemptionConfirmedUrl: "http://localhost:3666/confirmed"
@@ -93,6 +96,7 @@ export const RedemptionCallbacksRedeemConfirm: ComponentStory<
 
 RedemptionCallbacksRedeemConfirm.args = {
   ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
   showRedemptionOverview: false,
   widgetAction: RedemptionWidgetAction.CONFIRM_REDEEM,
   exchangeId: "149",
@@ -110,6 +114,7 @@ export const RedemptionCallbacksFailure: ComponentStory<
 
 RedemptionCallbacksFailure.args = {
   ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
   postDeliveryInfoUrl: "http://localhost:3666/fail",
   postRedemptionSubmittedUrl: "http://localhost:3666/submitted",
   postRedemptionConfirmedUrl: "http://localhost:3666/confirmed"
@@ -121,6 +126,7 @@ export const RedemptionCallbacksFailure2: ComponentStory<
 
 RedemptionCallbacksFailure2.args = {
   ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
   showRedemptionOverview: false,
   widgetAction: RedemptionWidgetAction.REDEEM_FORM,
   exchangeId: "149",
@@ -135,6 +141,7 @@ export const RedemptionCallbacksFailure3: ComponentStory<
 
 RedemptionCallbacksFailure3.args = {
   ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
   showRedemptionOverview: false,
   widgetAction: RedemptionWidgetAction.CONFIRM_REDEEM,
   exchangeId: "149",
@@ -159,6 +166,7 @@ export const RedemptionCallbacksFailure4: ComponentStory<
 
 RedemptionCallbacksFailure4.args = {
   ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
   showRedemptionOverview: false,
   widgetAction: RedemptionWidgetAction.CONFIRM_REDEEM,
   exchangeId: "149",
@@ -175,4 +183,64 @@ RedemptionCallbacksFailure4.args = {
   postDeliveryInfoUrl: "http://localhost:3666/deliveryInfo",
   postRedemptionSubmittedUrl: "http://localhost:3666/submitted",
   postRedemptionConfirmedUrl: "http://localhost:3666/fail4"
+};
+
+export const RedemptionHandlers: ComponentStory<typeof RedemptionWidget> =
+  Template.bind({});
+
+RedemptionHandlers.args = {
+  ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
+  deliveryInfoHandler: async (message, signature) => {
+    console.log(`deliveryInfoHandler: ${JSON.stringify(message)} ${signature}`);
+    return {
+      accepted: true,
+      reason: "",
+      resume: true
+    };
+  }
+};
+
+export const RedemptionHandlersNoResume: ComponentStory<
+  typeof RedemptionWidget
+> = Template.bind({});
+
+RedemptionHandlersNoResume.args = {
+  ...Redemption.args,
+  deliveryInfoHandler: async (message, signature) => {
+    console.log(`deliveryInfoHandler: ${JSON.stringify(message)} ${signature}`);
+    return {
+      accepted: true,
+      reason: "",
+      resume: false
+    };
+  }
+};
+
+export const RedemptionHandlersFailure1: ComponentStory<
+  typeof RedemptionWidget
+> = Template.bind({});
+
+RedemptionHandlersFailure1.args = {
+  ...Redemption.args,
+  deliveryInfoHandler: async (message, signature) => {
+    console.log(`deliveryInfoHandler: ${JSON.stringify(message)} ${signature}`);
+    return {
+      accepted: false,
+      reason: "Redemption handler is failing",
+      resume: false
+    };
+  }
+};
+
+export const RedemptionHandlersFailure2: ComponentStory<
+  typeof RedemptionWidget
+> = Template.bind({});
+
+RedemptionHandlersFailure2.args = {
+  ...Redemption.args,
+  deliveryInfoHandler: async (message, signature) => {
+    console.log(`deliveryInfoHandler: ${JSON.stringify(message)} ${signature}`);
+    throw new Error("Redemption handler is throwing an exception");
+  }
 };

--- a/packages/react-kit/src/stories/widgets/Redemption.stories.tsx
+++ b/packages/react-kit/src/stories/widgets/Redemption.stories.tsx
@@ -198,6 +198,20 @@ RedemptionHandlers.args = {
       reason: "",
       resume: true
     };
+  },
+  redemptionConfirmedHandler: async (message) => {
+    console.log(`redemptionConfirmedHandler: ${JSON.stringify(message)}`);
+    return {
+      accepted: true,
+      reason: ""
+    };
+  },
+  redemptionSubmittedHandler: async (message) => {
+    console.log(`redemptionSubmittedHandler: ${JSON.stringify(message)}`);
+    return {
+      accepted: true,
+      reason: ""
+    };
   }
 };
 
@@ -241,6 +255,48 @@ RedemptionHandlersFailure2.args = {
   ...Redemption.args,
   deliveryInfoHandler: async (message, signature) => {
     console.log(`deliveryInfoHandler: ${JSON.stringify(message)} ${signature}`);
+    throw new Error("Redemption handler is throwing an exception");
+  }
+};
+
+export const RedemptionHandlersFailure3: ComponentStory<
+  typeof RedemptionWidget
+> = Template.bind({});
+
+RedemptionHandlersFailure3.args = {
+  ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
+  deliveryInfoHandler: async (message, signature) => {
+    console.log(`deliveryInfoHandler: ${JSON.stringify(message)} ${signature}`);
+    return {
+      accepted: true,
+      reason: "",
+      resume: true
+    };
+  },
+  redemptionSubmittedHandler: async (message) => {
+    console.log(`redemptionSubmittedHandler: ${JSON.stringify(message)}`);
+    throw new Error("Redemption handler is throwing an exception");
+  }
+};
+
+export const RedemptionHandlersFailure4: ComponentStory<
+  typeof RedemptionWidget
+> = Template.bind({});
+
+RedemptionHandlersFailure4.args = {
+  ...Redemption.args,
+  sendDeliveryInfoThroughXMTP: false,
+  deliveryInfoHandler: async (message, signature) => {
+    console.log(`deliveryInfoHandler: ${JSON.stringify(message)} ${signature}`);
+    return {
+      accepted: true,
+      reason: "",
+      resume: true
+    };
+  },
+  redemptionConfirmedHandler: async (message) => {
+    console.log(`redemptionConfirmedHandler: ${JSON.stringify(message)}`);
     throw new Error("Redemption handler is throwing an exception");
   }
 };

--- a/scripts/get-buyers.ts
+++ b/scripts/get-buyers.ts
@@ -1,0 +1,52 @@
+import { EnvironmentType } from "@bosonprotocol/common/src/types/configs";
+import { providers } from "ethers";
+import { program } from "commander";
+import { getEnvConfigById } from "@bosonprotocol/common/src";
+import { CoreSDK } from "../packages/core-sdk/src";
+import { EthersAdapter } from "../packages/ethers-sdk/src";
+
+program
+  .description("Get Buyers data from buyer Ids.")
+  .argument("<BUYER_IDS>", "Comma-separated list of of seller Ids")
+  .option("-e, --env <ENV_NAME>", "Target environment", "testing")
+  .option("-c, --configId <CONFIG_ID>", "Config id", "testing-80001-0")
+  .parse(process.argv);
+
+async function main() {
+  const [buyerIdsArg] = program.args;
+  const buyerIds = buyerIdsArg.split(",");
+
+  const opts = program.opts();
+  const envName = opts.env || "testing";
+  const configId = opts.configId || "testing-80001-0";
+  const defaultConfig = getEnvConfigById(envName as EnvironmentType, configId);
+
+  const coreSDK = CoreSDK.fromDefaultConfig({
+    web3Lib: new EthersAdapter(
+      new providers.JsonRpcProvider(defaultConfig.jsonRpcUrl)
+    ),
+    envName,
+    configId
+  });
+
+  let result;
+  if (buyerIds.length === 1) {
+    result = await coreSDK.getBuyerById(buyerIds[0], { includeLogs: true });
+  } else {
+    result = await coreSDK.getBuyers({
+      buyersFilter: { id_in: buyerIds },
+      includeLogs: true
+    });
+  }
+  console.log(result);
+}
+
+main()
+  .then(() => {
+    console.log("success");
+    process.exit(0);
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description

this PR adds some properties to the redemption widget react component:
- sendDeliveryInfoThroughXMTP (required): whether the delivery information shall be sent to the seller via XMTP
- deliveryInfoHandler (optional): will be called when the delivery information is filled in by the user and before the Redeem transaction is submitted to the blockchain, passing the delivery information + a signature and optionally waiting for a response
- redemptionSubmittedHandler (optional): will be called when the Redeem transaction is submitted to the blockchain, passing the transaction details. No response expected
- redemptionConfirmedHandler (optional): will be called when the Redeem transaction is submitted to the blockchain, passing the transaction details. No response expected


## How to test

react-kit storybook