### PR TITLE
fix: do not create an offer when the seller does not exist

### DIFF
--- a/packages/subgraph/src/mappings/account-handler.ts
+++ b/packages/subgraph/src/mappings/account-handler.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import { BigInt } from "@graphprotocol/graph-ts";
 import {
   SellerCreated,
   SellerUpdatePending,
@@ -35,6 +37,11 @@ import {
 import { saveAccountEventLog } from "../entities/event-log";
 import { saveSellerMetadata } from "../entities/metadata/handler";
 import { getSellerMetadataEntityId } from "../entities/metadata/seller";
+
+export function checkSellerExist(sellerId: BigInt): boolean {
+  const seller = Seller.load(sellerId.toString());
+  return !!seller;
+}
 
 export function handleSellerCreatedEventWithoutMetadataUri(
   event: SellerCreatedLegacy

--- a/packages/subgraph/src/mappings/offer-handler.ts
+++ b/packages/subgraph/src/mappings/offer-handler.ts
@@ -1,4 +1,4 @@
-import { BigInt } from "@graphprotocol/graph-ts";
+import { BigInt, log } from "@graphprotocol/graph-ts";
 import {
   OfferCreated,
   OfferVoided,
@@ -17,6 +17,7 @@ import {
   saveDisputeResolutionTermsLegacy
 } from "../entities/dispute-resolution";
 import { saveOfferEventLog } from "../entities/event-log";
+import { checkSellerExist } from "./account-handler";
 
 export function handleOfferCreatedEvent(event: OfferCreated): void {
   const offerId = event.params.offerId;
@@ -29,6 +30,14 @@ export function handleOfferCreatedEvent(event: OfferCreated): void {
     const offerDurationsStruct = event.params.offerDurations;
     const offerFeesStruct = event.params.offerFees;
     const disputeResolutionTermsStruct = event.params.disputeResolutionTerms;
+
+    if (!checkSellerExist(offerStruct.sellerId)) {
+      log.warning(
+        "Offer '{}' won't be created because seller '{}' does not exist",
+        [offerId.toString(), offerStruct.sellerId.toString()]
+      );
+      return;
+    }
 
     offer = new Offer(offerId.toString());
     offer.createdAt = event.block.timestamp;
@@ -96,6 +105,14 @@ export function handleOfferCreatedEventLegacy(event: OfferCreatedLegacy): void {
     const offerDurationsStruct = event.params.offerDurations;
     const offerFeesStruct = event.params.offerFees;
     const disputeResolutionTermsStruct = event.params.disputeResolutionTerms;
+
+    if (!checkSellerExist(offerStruct.sellerId)) {
+      log.warning(
+        "Offer '{}' won't be created because seller '{}' does not exist",
+        [offerId.toString(), offerStruct.sellerId.toString()]
+      );
+      return;
+    }
 
     offer = new Offer(offerId.toString());
     offer.createdAt = event.block.timestamp;

--- a/packages/subgraph/tests/account-handler.test.ts
+++ b/packages/subgraph/tests/account-handler.test.ts
@@ -7,20 +7,19 @@ import {
   mockIpfsFile
 } from "matchstick-as/assembly/index";
 import {
-  handleSellerCreatedEvent,
   handleSellerUpdatedEvent,
   handleBuyerCreatedEvent,
   handleSellerCreatedEventWithoutMetadataUri,
   handleSellerUpdateAppliedEvent
 } from "../src/mappings/account-handler";
 import {
-  createSellerCreatedEvent,
   createSellerUpdatedEvent,
   createBuyerCreatedEvent,
   mockBosonVoucherContractCalls,
   createSellerCreatedEventLegacy,
   createSellerUpdateAppliedEvent,
-  mockCreateProduct
+  mockCreateProduct,
+  createSeller
 } from "./mocks";
 import { getSellerMetadataEntityId } from "../src/entities/metadata/seller";
 import {
@@ -31,7 +30,6 @@ import {
   Offer,
   ProductV1Product,
   SalesChannel,
-  SalesChannelDeployment,
   SellerMetadata
 } from "../generated/schema";
 import { getMetadataEntityId } from "../src/entities/metadata/utils";
@@ -76,30 +74,6 @@ test("handle legacy SellerCreatedEvent", () => {
   );
 });
 
-function createSeller(
-  sellerId: i32,
-  sellerAddress: string,
-  sellerMetadataFilepath: string
-): string {
-  mockBosonVoucherContractCalls(voucherCloneAddress, "ipfs://", 0);
-  mockIpfsFile(sellerMetadataHash, sellerMetadataFilepath);
-  const sellerCreatedEvent = createSellerCreatedEvent(
-    sellerId,
-    sellerAddress,
-    sellerAddress,
-    sellerAddress,
-    sellerAddress,
-    voucherCloneAddress,
-    0,
-    0,
-    sellerAddress,
-    "ipfs://" + sellerMetadataHash
-  );
-
-  handleSellerCreatedEvent(sellerCreatedEvent);
-  return sellerId.toString();
-}
-
 function updateSellerMetadata(
   sellerId: i32,
   sellerMetadataFilepath: string
@@ -123,7 +97,13 @@ function updateSellerMetadata(
 }
 
 test("handle SellerCreatedEvent", () => {
-  const sellerId = createSeller(1, sellerAddress, "tests/metadata/seller.json");
+  const sellerId = createSeller(
+    1,
+    sellerAddress,
+    "tests/metadata/seller.json",
+    voucherCloneAddress,
+    sellerMetadataHash
+  );
 
   assert.fieldEquals("Seller", sellerId, "id", sellerId);
   assert.fieldEquals(
@@ -229,7 +209,13 @@ test("handle BuyerCreatedEvent", () => {
 });
 
 test("add/remove product salesChannels", () => {
-  const sellerId = createSeller(1, sellerAddress, "tests/metadata/seller.json");
+  const sellerId = createSeller(
+    1,
+    sellerAddress,
+    "tests/metadata/seller.json",
+    voucherCloneAddress,
+    sellerMetadataHash
+  );
 
   // mock creation of ProductV1Product for Product_A and Product_B
   let productA = mockCreateProduct(sellerId, "Product_A", 1);

--- a/packages/subgraph/tests/funds-handler.test.ts
+++ b/packages/subgraph/tests/funds-handler.test.ts
@@ -2,8 +2,7 @@ import {
   beforeEach,
   test,
   assert,
-  clearStore,
-  mockIpfsFile
+  clearStore
 } from "matchstick-as/assembly/index";
 import {
   handleFundsDepositedEvent,
@@ -11,16 +10,13 @@ import {
   handleFundsEncumberedEvent,
   handleFundsReleasedEvent
 } from "../src/mappings/funds-handler";
-import {
-  handleSellerCreatedEvent,
-  handleSellerCreatedEventWithoutMetadataUri
-} from "../src/mappings/account-handler";
+import { handleSellerCreatedEventWithoutMetadataUri } from "../src/mappings/account-handler";
 import {
   createFundsDepositedEvent,
   createFundsEncumberedEvent,
   createFundsReleasedEvent,
   createFundsWithdrawnEvent,
-  createSellerCreatedEvent,
+  createSeller,
   createSellerCreatedEventLegacy,
   mockBosonVoucherContractCalls
 } from "./mocks";
@@ -109,21 +105,12 @@ test("handle legacy FundsEncumberedEvent", () => {
 });
 
 test("handle FundsEncumberedEvent", () => {
-  mockBosonVoucherContractCalls(voucherCloneAddress, "ipfs://", 1);
-  mockIpfsFile(sellerMetadataHash, "tests/metadata/seller.json");
-  handleSellerCreatedEvent(
-    createSellerCreatedEvent(
-      sellerId,
-      sellerAddress,
-      sellerAddress,
-      sellerAddress,
-      sellerAddress,
-      voucherCloneAddress,
-      0,
-      0,
-      sellerAddress,
-      "ipfs://" + sellerMetadataHash
-    )
+  createSeller(
+    sellerId,
+    sellerAddress,
+    "tests/metadata/seller.json",
+    voucherCloneAddress,
+    sellerMetadataHash
   );
   const fundsDepositedEvent = createFundsDepositedEvent(
     sellerId,

--- a/packages/subgraph/tests/mocks.ts
+++ b/packages/subgraph/tests/mocks.ts
@@ -892,10 +892,10 @@ export function mockCreateProduct(
 
 export function createSeller(
   sellerId: i32,
-  sellerAddress = "0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7",
-  sellerMetadataFilepath = "tests/metadata/seller.json",
-  voucherCloneAddress = "0x123456789a123456789a123456789a123456789a",
-  sellerMetadataHash = "QmZffs1Uv6pmf4649UpMqinDord9QBerJaWcwRgdenAto1"
+  sellerAddress: string,
+  sellerMetadataFilepath: string,
+  voucherCloneAddress: string,
+  sellerMetadataHash: string
 ): string {
   mockBosonVoucherContractCalls(voucherCloneAddress, "ipfs://", 0);
   mockIpfsFile(sellerMetadataHash, sellerMetadataFilepath);

--- a/packages/subgraph/tests/mocks.ts
+++ b/packages/subgraph/tests/mocks.ts
@@ -28,7 +28,8 @@ import {
 } from "../generated/BosonFundsHandler/IBosonFundsHandler";
 import {
   newMockEvent,
-  createMockedFunction
+  createMockedFunction,
+  mockIpfsFile
 } from "matchstick-as/assembly/index";
 import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts";
 import {
@@ -39,6 +40,7 @@ import {
 import { SellerUpdateApplied } from "../generated/BosonAccountHandler/IBosonAccountHandler";
 import { getProductId } from "../src/entities/metadata/product-v1/product";
 import { ProductV1Media, ProductV1Product } from "../generated/schema";
+import { handleSellerCreatedEvent } from "../src/mappings/account-handler";
 
 export function createOfferCreatedEvent(
   offerId: i32,
@@ -886,4 +888,30 @@ export function mockCreateProduct(
 
   product.save();
   return product;
+}
+
+export function createSeller(
+  sellerId: i32,
+  sellerAddress = "0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7",
+  sellerMetadataFilepath = "tests/metadata/seller.json",
+  voucherCloneAddress = "0x123456789a123456789a123456789a123456789a",
+  sellerMetadataHash = "QmZffs1Uv6pmf4649UpMqinDord9QBerJaWcwRgdenAto1"
+): string {
+  mockBosonVoucherContractCalls(voucherCloneAddress, "ipfs://", 0);
+  mockIpfsFile(sellerMetadataHash, sellerMetadataFilepath);
+  const sellerCreatedEvent = createSellerCreatedEvent(
+    sellerId,
+    sellerAddress,
+    sellerAddress,
+    sellerAddress,
+    sellerAddress,
+    voucherCloneAddress,
+    0,
+    0,
+    sellerAddress,
+    "ipfs://" + sellerMetadataHash
+  );
+
+  handleSellerCreatedEvent(sellerCreatedEvent);
+  return sellerId.toString();
 }

--- a/packages/subgraph/tests/offer-handler.test.ts
+++ b/packages/subgraph/tests/offer-handler.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   createOfferCreatedEvent,
   createOfferVoidedEvent,
+  createSeller,
   mockExchangeTokenContractCalls
 } from "./mocks";
 
@@ -86,6 +87,7 @@ test("handle OfferCreatedEvent with BASE metadata", () => {
     exchangeTokenSymbol
   );
   mockIpfsFile(metadataHash, "tests/metadata/base.json");
+  createSeller(sellerId);
 
   handleOfferCreatedEvent(offerCreatedEvent);
 
@@ -119,6 +121,7 @@ test("handle OfferCreatedEvent with PRODUCT_V1 metadata", () => {
     exchangeTokenSymbol
   );
   mockIpfsFile(metadataHash, "tests/metadata/product-v1-full.json");
+  createSeller(sellerId);
 
   handleOfferCreatedEvent(offerCreatedEvent);
 
@@ -157,6 +160,7 @@ test("handle OfferVoidedEvent", () => {
     exchangeTokenSymbol
   );
   mockIpfsFile(metadataHash, "tests/metadata/base.json");
+  createSeller(sellerId);
   handleOfferCreatedEvent(offerCreatedEvent);
 
   const offerVoidedEvent = createOfferVoidedEvent(1, 1, exchangeTokenAddress);

--- a/packages/subgraph/tests/offer-handler.test.ts
+++ b/packages/subgraph/tests/offer-handler.test.ts
@@ -25,6 +25,9 @@ const metadataHash = "QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB";
 
 const offerId = 1;
 const sellerId = 1;
+const sellerAddress = "0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7";
+const voucherCloneAddress = "0x123456789a123456789a123456789a123456789a";
+const sellerMetadataHash = "QmZffs1Uv6pmf4649UpMqinDord9QBerJaWcwRgdenAto1";
 const price = 1;
 const sellerDeposit = 1;
 const protocolFee = 1;
@@ -87,7 +90,13 @@ test("handle OfferCreatedEvent with BASE metadata", () => {
     exchangeTokenSymbol
   );
   mockIpfsFile(metadataHash, "tests/metadata/base.json");
-  createSeller(sellerId);
+  createSeller(
+    1,
+    sellerAddress,
+    "tests/metadata/seller.json",
+    voucherCloneAddress,
+    sellerMetadataHash
+  );
 
   handleOfferCreatedEvent(offerCreatedEvent);
 
@@ -121,7 +130,13 @@ test("handle OfferCreatedEvent with PRODUCT_V1 metadata", () => {
     exchangeTokenSymbol
   );
   mockIpfsFile(metadataHash, "tests/metadata/product-v1-full.json");
-  createSeller(sellerId);
+  createSeller(
+    1,
+    sellerAddress,
+    "tests/metadata/seller.json",
+    voucherCloneAddress,
+    sellerMetadataHash
+  );
 
   handleOfferCreatedEvent(offerCreatedEvent);
 
@@ -160,7 +175,13 @@ test("handle OfferVoidedEvent", () => {
     exchangeTokenSymbol
   );
   mockIpfsFile(metadataHash, "tests/metadata/base.json");
-  createSeller(sellerId);
+  createSeller(
+    1,
+    sellerAddress,
+    "tests/metadata/seller.json",
+    voucherCloneAddress,
+    sellerMetadataHash
+  );
   handleOfferCreatedEvent(offerCreatedEvent);
 
   const offerVoidedEvent = createOfferVoidedEvent(1, 1, exchangeTokenAddress);


### PR DESCRIPTION
## Description

fixes #613 

## How to test

- existing e2e:test are enough, as they are using orchestration method createSellerAndOffer, ensuring the events are dealt in the correct order
- check the warning messages on mumbai-testing env. Only the offers 540 and 541 for seller 2 should be mentionned
![image](https://github.com/bosonprotocol/core-components/assets/7184124/fdd6968d-15c1-4b5b-b030-9d4d6851a568)

