### PR TITLE
fix: redemption widget - verify seller signature with assistant wallet instead of admin on

### DIFF
--- a/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
+++ b/packages/react-kit/src/components/modal/components/Redeem/RedeemNonModal.tsx
@@ -114,7 +114,7 @@ const checkSignatures = ({
     }
     const originMessage = JSON.stringify({ origin: parentOrigin });
     const firstIndexSignatureThatDoesntMatch = sellersFromSellerIds?.findIndex(
-      ({ admin, lensOwner }, index) => {
+      ({ assistant }, index) => {
         if (!signatures?.[index]) {
           return true;
         }
@@ -122,16 +122,7 @@ const checkSignatures = ({
           .verifyMessage(originMessage, signatures[index])
           .toLowerCase();
 
-        if (
-          admin.toLowerCase() === ethers.constants.AddressZero.toLowerCase() &&
-          lensOwner?.toLowerCase?.() !== signerAddr.toLowerCase()
-        ) {
-          return true;
-        }
-        if (
-          admin.toLowerCase() !== ethers.constants.AddressZero.toLowerCase() &&
-          signerAddr.toLowerCase() !== admin.toLowerCase()
-        ) {
+        if (signerAddr.toLowerCase() !== assistant.toLowerCase()) {
           return true;
         }
         return false;
@@ -149,17 +140,10 @@ const checkSignatures = ({
           <UlWithWordBreak>
             <li>Signatures: {signatures}</li>
             <li>
-              Seller admin address is{" "}
+              Seller assistant address is{" "}
               {sellersFromSellerIds[
                 firstIndexSignatureThatDoesntMatch
-              ]?.admin.toLowerCase() ===
-              ethers.constants.AddressZero.toLowerCase()
-                ? sellersFromSellerIds[
-                    firstIndexSignatureThatDoesntMatch
-                  ]?.lensOwner?.toLowerCase()
-                : sellersFromSellerIds[
-                    firstIndexSignatureThatDoesntMatch
-                  ]?.admin?.toLowerCase()}
+              ]?.assistant?.toLowerCase()}
             </li>
             <li>
               Address that signed the message:{" "}

--- a/scripts/update-seller.ts
+++ b/scripts/update-seller.ts
@@ -176,7 +176,6 @@ async function main() {
     if (
       optInSigner.fields.admin ||
       optInSigner.fields.assistant ||
-      optInSigner.fields.clerk ||
       optInSigner.fields.authToken
     ) {
       console.log(


### PR DESCRIPTION
## Description

refer to https://github.com/bosonprotocol/widgets/issues/110

## How to test

storybook