### PR TITLE
fix: copy-assets fails on Windows

### DIFF
--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -77,7 +77,7 @@
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
     "build": "rimraf dist && tsc && tsc --build tsconfig.cjs.json",
-    "copy-assets": "copyfiles -u 2 src/assets/** dist/esm/assets/ && copyfiles -u 2 src/assets/** dist/cjs/assets/ && copyfiles -u 2 src/assets/**/*  dist/esm/assets/ && copyfiles -u 2 src/assets/**/* dist/cjs/assets/",
+    "copy-assets": "copyfiles -u 2 \"src/assets/**/*\" dist/esm/assets/ && copyfiles -u 2 \"src/assets/**/*\" dist/cjs/assets/",
     "postbuild": "npm run copy-assets"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Description

`copyfiles -u 2 src/assets/** dist/esm/assets/` fails on Windows
Solution found here: https://github.com/calvinmetcalf/copyfiles/issues/61

## How to test

N/A