### PR TITLE
fix: validation error and access to property in wait biconomy

### DIFF
--- a/packages/common/src/utils/validation.ts
+++ b/packages/common/src/utils/validation.ts
@@ -87,7 +87,7 @@ export const createOfferArgsSchema = object({
       then: string()
         .test(
           "not-zero",
-          "Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMShas must be non zero",
+          "Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMS must be non zero",
           isNotZero as any
         )
         .test(...futureDateTestArgs)
@@ -111,7 +111,7 @@ export const createOfferArgsSchema = object({
         ),
       otherwise: string().test(
         "is-zero",
-        "Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMShas must be non zero",
+        "Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMS must be non zero",
         isZero as any
       )
     }),

--- a/packages/common/tests/utils/validation.test.ts
+++ b/packages/common/tests/utils/validation.test.ts
@@ -40,7 +40,7 @@ describe("#createOfferArgsSchema()", () => {
         })
       );
     }).toThrow(
-      /Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMShas must be non zero/
+      /Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMS must be non zero/
     );
   });
 
@@ -53,7 +53,7 @@ describe("#createOfferArgsSchema()", () => {
         })
       );
     }).toThrow(
-      /Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMShas must be non zero/
+      /Exactly one of voucherRedeemableUntilDateInMS and voucherValidDurationInMS must be non zero/
     );
   });
 

--- a/packages/core-sdk/src/meta-tx/handler.ts
+++ b/packages/core-sdk/src/meta-tx/handler.ts
@@ -1270,7 +1270,7 @@ export async function relayMetaTransaction(args: {
         transactionHash: txHash,
         logs: txReceipt?.logs || [],
         effectiveGasPrice: BigNumber.from(waitResponse.data.newGasPrice),
-        blockNumber: txReceipt.blockNumber
+        blockNumber: txReceipt?.blockNumber
       };
     },
     hash: relayTxResponse.txHash


### PR DESCRIPTION
fix: validation text error
fix: return of wait function of meta tx so it doesnt crash if txReceipt is undefined