### PR TITLE
feat: deactivate use of meta-transaction when the connected wallet is…

### DIFF
--- a/packages/common/src/types/web3-lib-adapter.ts
+++ b/packages/common/src/types/web3-lib-adapter.ts
@@ -32,6 +32,7 @@ export type TransactionReceipt = {
 
 export interface Web3LibAdapter {
   getSignerAddress(): Promise<string>;
+  isSignerContract(): Promise<boolean>;
   getChainId(): Promise<number>;
   getBalance(
     addressOrName: string,

--- a/packages/common/tests/mocks.ts
+++ b/packages/common/tests/mocks.ts
@@ -160,6 +160,10 @@ export class MockWeb3LibAdapter implements Web3LibAdapter {
     return this._returnValues.getSignerAddress;
   }
 
+  async isSignerContract(): Promise<boolean> {
+    return false;
+  }
+
   async getChainId() {
     return this._returnValues.getChainId;
   }

--- a/packages/eth-connect-sdk/src/eth-connect-adapter.ts
+++ b/packages/eth-connect-sdk/src/eth-connect-adapter.ts
@@ -44,6 +44,12 @@ export class EthConnectAdapter implements Web3LibAdapter {
     return address;
   }
 
+  public async isSignerContract(): Promise<boolean> {
+    // TODO: to be implemented
+    // (not urgent I guess, as I think there is no way to connect to Decentraland using a contract wallet)
+    return false;
+  }
+
   public async getChainId(): Promise<number> {
     // Use standard requestManager to get the chainId (allow the signer to be connected to another chain)
     const chainId = await this._requestManager.net_version();

--- a/packages/ethers-sdk/src/ethers-adapter.ts
+++ b/packages/ethers-sdk/src/ethers-adapter.ts
@@ -43,6 +43,12 @@ export class EthersAdapter implements Web3LibAdapter {
     return this._signer.getAddress();
   }
 
+  public async isSignerContract(): Promise<boolean> {
+    const address = await this.getSignerAddress();
+    const code = await this._provider.getCode(address);
+    return code != "0x";
+  }
+
   public async getChainId(): Promise<number> {
     return this._signer.getChainId();
   }

--- a/packages/react-kit/src/components/cta/common/CtaButton.tsx
+++ b/packages/react-kit/src/components/cta/common/CtaButton.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { providers } from "ethers";
 
 import { Button } from "../../buttons/Button";
-import { useSignerAddress } from "../../../hooks/useSignerAddress";
 import { useCtaClickHandler, Action } from "../../../hooks/useCtaClickHandler";
 import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 import { ButtonSize } from "../../ui/buttonSize";
 import { useCoreSdkOverrides } from "../../../hooks/core-sdk/useCoreSdkOverrides";
+import { useMetaTx } from "../../../hooks/useMetaTx";
 
 type Props<T> = CtaButtonProps<T> & {
   defaultLabel?: string;
@@ -36,13 +36,12 @@ export function CtaButton<T>({
   ...rest
 }: Props<T>) {
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
-  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
+  const { isMetaTx } = useMetaTx(coreSdk);
 
   const { clickHandler, isLoading } = useCtaClickHandler<T>({
     waitBlocks,
     coreSdk,
-    signerAddress,
-    signerContract,
+    useMetaTx: isMetaTx,
     actions,
     onSuccess,
     successPayload,

--- a/packages/react-kit/src/components/cta/common/CtaButton.tsx
+++ b/packages/react-kit/src/components/cta/common/CtaButton.tsx
@@ -36,12 +36,13 @@ export function CtaButton<T>({
   ...rest
 }: Props<T>) {
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
 
   const { clickHandler, isLoading } = useCtaClickHandler<T>({
     waitBlocks,
     coreSdk,
     signerAddress,
+    signerContract,
     actions,
     onSuccess,
     successPayload,

--- a/packages/react-kit/src/components/cta/funds/DepositFundsButton.tsx
+++ b/packages/react-kit/src/components/cta/funds/DepositFundsButton.tsx
@@ -3,9 +3,9 @@ import { BigNumber, BigNumberish, constants, ethers } from "ethers";
 
 import { CtaButtonProps } from "../common/types";
 import { CtaButton } from "../common/CtaButton";
-import { useSignerAddress } from "../../../hooks/useSignerAddress";
 import { TransactionReceipt } from "@bosonprotocol/common";
 import { useCoreSdkOverrides } from "../../../hooks/core-sdk/useCoreSdkOverrides";
+import { useMetaTx } from "../../../hooks/useMetaTx";
 
 type AdditionalProps = {
   exchangeToken: string;
@@ -28,7 +28,7 @@ export const DepositFundsButton = ({
   const coreSdk = useCoreSdkOverrides({
     coreSdkConfig: restProps.coreSdkConfig
   });
-  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
+  const { isMetaTx, signerAddress } = useMetaTx(coreSdk);
 
   const actions = [
     // Approve exchange token
@@ -68,10 +68,7 @@ export const DepositFundsButton = ({
           nonce: Date.now()
         }),
       additionalMetaTxCondition: Boolean(
-        coreSdk?.isMetaTxConfigSet &&
-          signerAddress &&
-          !signerContract &&
-          exchangeToken !== ethers.constants.AddressZero
+        isMetaTx && exchangeToken !== ethers.constants.AddressZero
       )
     }
   ];

--- a/packages/react-kit/src/components/cta/funds/DepositFundsButton.tsx
+++ b/packages/react-kit/src/components/cta/funds/DepositFundsButton.tsx
@@ -28,7 +28,7 @@ export const DepositFundsButton = ({
   const coreSdk = useCoreSdkOverrides({
     coreSdkConfig: restProps.coreSdkConfig
   });
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
 
   const actions = [
     // Approve exchange token
@@ -70,6 +70,7 @@ export const DepositFundsButton = ({
       additionalMetaTxCondition: Boolean(
         coreSdk?.isMetaTxConfigSet &&
           signerAddress &&
+          !signerContract &&
           exchangeToken !== ethers.constants.AddressZero
       )
     }

--- a/packages/react-kit/src/components/cta/funds/WithdrawFundsButton.tsx
+++ b/packages/react-kit/src/components/cta/funds/WithdrawFundsButton.tsx
@@ -3,9 +3,9 @@ import { BigNumber, BigNumberish } from "ethers";
 
 import { CtaButtonProps } from "../common/types";
 import { CtaButton } from "../common/CtaButton";
-import { useSignerAddress } from "../../../hooks/useSignerAddress";
 import { TransactionReceipt } from "@bosonprotocol/common";
 import { useCoreSdkOverrides } from "../../../hooks/core-sdk/useCoreSdkOverrides";
+import { useMetaTx } from "../../../hooks/useMetaTx";
 
 type AdditionalProps = {
   accountId: string;
@@ -29,7 +29,7 @@ export const WithdrawFundsButton = ({
   const coreSdk = useCoreSdkOverrides({
     coreSdkConfig: restProps.coreSdkConfig
   });
-  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
+  const { isMetaTx } = useMetaTx(coreSdk);
   const tokenList = useMemo(
     () => tokensToWithdraw.map((t) => t.address),
     [tokensToWithdraw]
@@ -51,9 +51,7 @@ export const WithdrawFundsButton = ({
           tokenAmounts,
           nonce: Date.now()
         }),
-      additionalMetaTxCondition: Boolean(
-        coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
-      )
+      additionalMetaTxCondition: isMetaTx
     }
   ];
 

--- a/packages/react-kit/src/components/cta/funds/WithdrawFundsButton.tsx
+++ b/packages/react-kit/src/components/cta/funds/WithdrawFundsButton.tsx
@@ -29,7 +29,7 @@ export const WithdrawFundsButton = ({
   const coreSdk = useCoreSdkOverrides({
     coreSdkConfig: restProps.coreSdkConfig
   });
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
   const tokenList = useMemo(
     () => tokensToWithdraw.map((t) => t.address),
     [tokensToWithdraw]
@@ -52,7 +52,7 @@ export const WithdrawFundsButton = ({
           nonce: Date.now()
         }),
       additionalMetaTxCondition: Boolean(
-        coreSdk.isMetaTxConfigSet && signerAddress
+        coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
       )
     }
   ];

--- a/packages/react-kit/src/components/cta/offer/BatchVoidButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/BatchVoidButton.tsx
@@ -3,12 +3,12 @@ import { BigNumberish, providers } from "ethers";
 
 import { Button } from "../../buttons/Button";
 import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
-import { useSignerAddress } from "../../../hooks/useSignerAddress";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 import { ButtonSize } from "../../ui/buttonSize";
 import { TransactionResponse } from "@bosonprotocol/common";
 import { useCoreSdkOverrides } from "../../../hooks/core-sdk/useCoreSdkOverrides";
+import { useMetaTx } from "../../../hooks/useMetaTx";
 
 type Props = {
   /**
@@ -38,8 +38,7 @@ export const BatchVoidButton = ({
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
-
+  const { isMetaTx } = useMetaTx(coreSdk);
   return (
     <Button
       variant={variant}
@@ -51,10 +50,6 @@ export const BatchVoidButton = ({
           try {
             setIsLoading(true);
             onPendingSignature?.();
-
-            const isMetaTx = Boolean(
-              coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
-            );
 
             if (isMetaTx) {
               const nonce = Date.now();

--- a/packages/react-kit/src/components/cta/offer/BatchVoidButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/BatchVoidButton.tsx
@@ -38,7 +38,7 @@ export const BatchVoidButton = ({
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
 
   return (
     <Button
@@ -53,7 +53,7 @@ export const BatchVoidButton = ({
             onPendingSignature?.();
 
             const isMetaTx = Boolean(
-              coreSdk.isMetaTxConfigSet && signerAddress
+              coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
             );
 
             if (isMetaTx) {

--- a/packages/react-kit/src/components/cta/offer/CommitButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/CommitButton.tsx
@@ -39,7 +39,7 @@ export const CommitButton = ({
   const coreSdk = useCoreSdkOverrides({
     coreSdkConfig: restProps.coreSdkConfig
   });
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress } = useSignerAddress(coreSdk.web3Lib);
 
   useEffect(() => {
     if (onGetSignerAddress) {

--- a/packages/react-kit/src/components/cta/offer/CreateOfferButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/CreateOfferButton.tsx
@@ -40,7 +40,7 @@ export const CreateOfferButton = ({
   ...rest
 }: Props) => {
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -50,7 +50,9 @@ export const CreateOfferButton = ({
       try {
         setIsLoading(true);
         onPendingSignature?.();
-        const isMetaTx = Boolean(coreSdk.isMetaTxConfigSet && signerAddress);
+        const isMetaTx = Boolean(
+          coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
+        );
         const seller = signerAddress && sellerInfo ? sellerInfo : null;
         if (isMultiVariant) {
           if (!hasSellerAccount && seller) {

--- a/packages/react-kit/src/components/cta/offer/CreateOfferButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/CreateOfferButton.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { providers } from "ethers";
 
 import { Button } from "../../buttons/Button";
-import { useSignerAddress } from "../../../hooks/useSignerAddress";
 import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
@@ -10,6 +9,7 @@ import { offers, accounts } from "@bosonprotocol/core-sdk";
 import { TransactionResponse } from "@bosonprotocol/common";
 import { ButtonSize } from "../../ui/buttonSize";
 import { useCoreSdkOverrides } from "../../../hooks/core-sdk/useCoreSdkOverrides";
+import { useMetaTx } from "../../../hooks/useMetaTx";
 
 type Props = {
   hasSellerAccount: boolean;
@@ -40,7 +40,7 @@ export const CreateOfferButton = ({
   ...rest
 }: Props) => {
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
-  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
+  const { isMetaTx, signerAddress } = useMetaTx(coreSdk);
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -50,9 +50,6 @@ export const CreateOfferButton = ({
       try {
         setIsLoading(true);
         onPendingSignature?.();
-        const isMetaTx = Boolean(
-          coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
-        );
         const seller = signerAddress && sellerInfo ? sellerInfo : null;
         if (isMultiVariant) {
           if (!hasSellerAccount && seller) {

--- a/packages/react-kit/src/components/cta/offer/VoidButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/VoidButton.tsx
@@ -3,12 +3,12 @@ import { BigNumberish, providers } from "ethers";
 import { TransactionResponse } from "@bosonprotocol/common";
 
 import { Button } from "../../buttons/Button";
-import { useSignerAddress } from "../../../hooks/useSignerAddress";
 import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 import { ButtonSize } from "../../ui/buttonSize";
 import { useCoreSdkOverrides } from "../../../hooks/core-sdk/useCoreSdkOverrides";
+import { useMetaTx } from "../../../hooks/useMetaTx";
 
 type Props = {
   /**
@@ -38,7 +38,7 @@ export const VoidButton = ({
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
+  const { isMetaTx } = useMetaTx(coreSdk);
 
   return (
     <Button
@@ -51,10 +51,6 @@ export const VoidButton = ({
           try {
             setIsLoading(true);
             onPendingSignature?.();
-
-            const isMetaTx = Boolean(
-              coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
-            );
 
             if (isMetaTx) {
               const nonce = Date.now();

--- a/packages/react-kit/src/components/cta/offer/VoidButton.tsx
+++ b/packages/react-kit/src/components/cta/offer/VoidButton.tsx
@@ -38,7 +38,7 @@ export const VoidButton = ({
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
 
   return (
     <Button
@@ -53,7 +53,7 @@ export const VoidButton = ({
             onPendingSignature?.();
 
             const isMetaTx = Boolean(
-              coreSdk.isMetaTxConfigSet && signerAddress
+              coreSdk.isMetaTxConfigSet && signerAddress && !signerContract
             );
 
             if (isMetaTx) {

--- a/packages/react-kit/src/components/cta/seller/CreateSellerButton.tsx
+++ b/packages/react-kit/src/components/cta/seller/CreateSellerButton.tsx
@@ -36,7 +36,7 @@ export const CreateSellerButton = ({
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const signerAddress = useSignerAddress(coreSdk.web3Lib);
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
 
   return (
     <Button
@@ -51,7 +51,7 @@ export const CreateSellerButton = ({
             setIsLoading(true);
             onPendingSignature?.();
 
-            if (coreSdk.isMetaTxConfigSet && signerAddress) {
+            if (coreSdk.isMetaTxConfigSet && signerAddress && !signerContract) {
               const nonce = Date.now();
 
               const { r, s, v, functionName, functionSignature } =

--- a/packages/react-kit/src/components/cta/seller/CreateSellerButton.tsx
+++ b/packages/react-kit/src/components/cta/seller/CreateSellerButton.tsx
@@ -2,13 +2,13 @@ import React, { useState } from "react";
 import { BigNumberish, providers } from "ethers";
 
 import { Button } from "../../buttons/Button";
-import { useSignerAddress } from "../../../hooks/useSignerAddress";
 import { ButtonTextWrapper, ExtraInfo, LoadingWrapper } from "../common/styles";
 import { CtaButtonProps } from "../common/types";
 import { Loading } from "../../Loading";
 import { CreateSellerArgs, TransactionResponse } from "@bosonprotocol/common";
 import { ButtonSize } from "../../ui/buttonSize";
 import { useCoreSdkOverrides } from "../../../hooks/core-sdk/useCoreSdkOverrides";
+import { useMetaTx } from "../../../hooks/useMetaTx";
 export type ICreateSellerButton = {
   exchangeId: BigNumberish;
   createSellerArgs: CreateSellerArgs;
@@ -36,7 +36,7 @@ export const CreateSellerButton = ({
   const coreSdk = useCoreSdkOverrides({ coreSdkConfig });
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const { signerAddress, signerContract } = useSignerAddress(coreSdk.web3Lib);
+  const { isMetaTx } = useMetaTx(coreSdk);
 
   return (
     <Button
@@ -51,7 +51,7 @@ export const CreateSellerButton = ({
             setIsLoading(true);
             onPendingSignature?.();
 
-            if (coreSdk.isMetaTxConfigSet && signerAddress && !signerContract) {
+            if (isMetaTx) {
               const nonce = Date.now();
 
               const { r, s, v, functionName, functionSignature } =

--- a/packages/react-kit/src/hooks/connection/connection.ts
+++ b/packages/react-kit/src/hooks/connection/connection.ts
@@ -31,7 +31,9 @@ export function useAccount() {
 
   const { user } = useUser();
   const { externalWeb3LibAdapter } = useExternalSigner() ?? {};
-  const externalSignerAddress = useSignerAddress(externalWeb3LibAdapter);
+  const { signerAddress: externalSignerAddress } = useSignerAddress(
+    externalWeb3LibAdapter
+  );
   const account = useMemo(
     () => ({
       address:

--- a/packages/react-kit/src/hooks/index.ts
+++ b/packages/react-kit/src/hooks/index.ts
@@ -6,5 +6,6 @@ export * from "../lib/signer/useCallSignerFromIframe";
 export * from "./useEffectDebugger";
 export * from "./useHandleText";
 export * from "./useExchanges";
+export * from "./useMetaTx";
 export * from "../components/widgets/finance/useOffersBacked";
 export * from "./contracts/useGetTokenUriImage";

--- a/packages/react-kit/src/hooks/useCtaClickHandler.ts
+++ b/packages/react-kit/src/hooks/useCtaClickHandler.ts
@@ -10,6 +10,7 @@ export function useCtaClickHandler<T>({
   waitBlocks,
   coreSdk,
   signerAddress,
+  signerContract,
   actions,
   onPendingSignature,
   onPendingTransaction,
@@ -22,6 +23,7 @@ export function useCtaClickHandler<T>({
   waitBlocks: number;
   coreSdk: CoreSDK;
   signerAddress?: string;
+  signerContract: boolean;
   actions: Action[];
   successPayload: T | ((receipt: providers.TransactionReceipt) => T);
 } & Pick<
@@ -61,8 +63,12 @@ export function useCtaClickHandler<T>({
         }
 
         const isMetaTx =
-          Boolean(coreSdk.isMetaTxConfigSet && signerAddress && signMetaTxFn) &&
-          additionalMetaTxCondition;
+          Boolean(
+            coreSdk.isMetaTxConfigSet &&
+              signerAddress &&
+              !signerContract &&
+              signMetaTxFn
+          ) && additionalMetaTxCondition;
 
         onPendingSignature?.(name);
 

--- a/packages/react-kit/src/hooks/useCtaClickHandler.ts
+++ b/packages/react-kit/src/hooks/useCtaClickHandler.ts
@@ -9,8 +9,7 @@ export { Action, ActionName } from "../components/cta/common/types";
 export function useCtaClickHandler<T>({
   waitBlocks,
   coreSdk,
-  signerAddress,
-  signerContract,
+  useMetaTx,
   actions,
   onPendingSignature,
   onPendingTransaction,
@@ -22,8 +21,7 @@ export function useCtaClickHandler<T>({
 }: {
   waitBlocks: number;
   coreSdk: CoreSDK;
-  signerAddress?: string;
-  signerContract: boolean;
+  useMetaTx: boolean;
   actions: Action[];
   successPayload: T | ((receipt: providers.TransactionReceipt) => T);
 } & Pick<
@@ -62,17 +60,11 @@ export function useCtaClickHandler<T>({
           continue;
         }
 
-        const isMetaTx =
-          Boolean(
-            coreSdk.isMetaTxConfigSet &&
-              signerAddress &&
-              !signerContract &&
-              signMetaTxFn
-          ) && additionalMetaTxCondition;
+        const isMetaTx = useMetaTx && signMetaTxFn && additionalMetaTxCondition;
 
         onPendingSignature?.(name);
 
-        if (isMetaTx && signMetaTxFn) {
+        if (isMetaTx) {
           const nonce = Date.now();
 
           const { r, s, v, functionName, functionSignature } =

--- a/packages/react-kit/src/hooks/useMetaTx.ts
+++ b/packages/react-kit/src/hooks/useMetaTx.ts
@@ -1,0 +1,10 @@
+import { CoreSDK } from "@bosonprotocol/core-sdk";
+import { useSignerAddress } from "./useSignerAddress";
+
+export function useMetaTx(coreSdk: CoreSDK | undefined) {
+  const { signerAddress, signerContract } = useSignerAddress(coreSdk?.web3Lib);
+  const isMetaTx = coreSdk
+    ? Boolean(coreSdk.isMetaTxConfigSet && signerAddress && !signerContract)
+    : false;
+  return { isMetaTx, signerAddress, signerContract };
+}

--- a/packages/react-kit/src/hooks/useSignerAddress.tsx
+++ b/packages/react-kit/src/hooks/useSignerAddress.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 export function useSignerAddress(web3Lib: Web3LibAdapter | undefined) {
   const [signerAddress, setSignerAddress] = useState<string | undefined>();
+  const [signerContract, setSignerContract] = useState<boolean>(false);
 
   useEffect(() => {
     if (web3Lib?.getSignerAddress) {
@@ -16,10 +17,19 @@ export function useSignerAddress(web3Lib: Web3LibAdapter | undefined) {
           console.error(e);
           setSignerAddress(undefined);
         });
+      web3Lib
+        .isSignerContract()
+        .then((isSignerContract) => {
+          setSignerContract(isSignerContract);
+        })
+        .catch((e) => {
+          console.error(e);
+          setSignerContract(false);
+        });
     }
 
     return () => setSignerAddress(undefined);
   }, [web3Lib]);
 
-  return signerAddress;
+  return { signerAddress, signerContract };
 }

--- a/packages/react-kit/src/lib/signer/externalSigner.ts
+++ b/packages/react-kit/src/lib/signer/externalSigner.ts
@@ -60,6 +60,13 @@ const getExternalWeb3LibAdapterListener = ({
         args: undefined
       });
     },
+    isSignerContract: (): Promise<boolean> => {
+      return getDefaultHandleSignerFunction<boolean>({
+        parentOrigin,
+        functionName: "isSignerContract",
+        args: undefined
+      });
+    },
     getChainId: async (): Promise<number> => {
       return getDefaultHandleSignerFunction<number>({
         parentOrigin,


### PR DESCRIPTION
… a contract

## Description

related to https://github.com/bosonprotocol/interface/issues/1026

- Add isSignerContract() method in Web3LibAdapter interface
- Implement isSignerContract() method in EthersAdapter
- mock isSignerContract() method in EthConnectAdapter (always return false)
- Use isSignerContract() everywhere required to chose between meta-transactions and direct transactions

## How to test

There is no way to create a Gnosis Safe Multisig on testnet (Mumbai or Goerli)
I've tested the feature with my personal Multisig on Polygon / usecase: creating a Seller in the dApp on production env (I didn't validate the transaction)
Other usecases have not been tested, though :-( 
