### PR TITLE
chore: some changes for protocol v2.4.0 + price discovery utils

### DIFF
--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -11,7 +11,7 @@
         "@openzeppelin/contracts-upgradeable": "4.9.3"
       },
       "devDependencies": {
-        "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#5166a27e45818c82f551cd90c9a92f21137a0366",
+        "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#324d8ca92c3727fe2957e3bf6ea9307f5e14a936",
         "@manifoldxyz/royalty-registry-solidity": "github:manifoldxyz/royalty-registry-solidity#e5369fc79279ce2e4c6ea2eb5914df51e89e8bd8",
         "@nomicfoundation/hardhat-ethers": "^3.0.5",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
@@ -35,9 +35,9 @@
       "dev": true
     },
     "node_modules/@bosonprotocol/boson-protocol-contracts": {
-      "version": "2.3.0",
-      "resolved": "git+ssh://git@github.com/bosonprotocol/boson-protocol-contracts.git#5166a27e45818c82f551cd90c9a92f21137a0366",
-      "integrity": "sha512-GXxY3vg7MFfuRxzqc3WDuVszZafPgGV0u1FI19slbAChjSxXL9VNlALWbeb2NwRjgduqarPzICaP+vxyOpN7pQ==",
+      "version": "2.4.0",
+      "resolved": "git+ssh://git@github.com/bosonprotocol/boson-protocol-contracts.git#324d8ca92c3727fe2957e3bf6ea9307f5e14a936",
+      "integrity": "sha512-e4raIIzoj/ZjSGDPuC3PxabUGytOzJD4o9jxgag85JvYleoJw1L/AsgjdEMU52FJyFIJGj5n5PXRNKjBAQBPoA==",
       "dev": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -19571,10 +19571,10 @@
       "dev": true
     },
     "@bosonprotocol/boson-protocol-contracts": {
-      "version": "git+ssh://git@github.com/bosonprotocol/boson-protocol-contracts.git#5166a27e45818c82f551cd90c9a92f21137a0366",
-      "integrity": "sha512-GXxY3vg7MFfuRxzqc3WDuVszZafPgGV0u1FI19slbAChjSxXL9VNlALWbeb2NwRjgduqarPzICaP+vxyOpN7pQ==",
+      "version": "git+ssh://git@github.com/bosonprotocol/boson-protocol-contracts.git#324d8ca92c3727fe2957e3bf6ea9307f5e14a936",
+      "integrity": "sha512-e4raIIzoj/ZjSGDPuC3PxabUGytOzJD4o9jxgag85JvYleoJw1L/AsgjdEMU52FJyFIJGj5n5PXRNKjBAQBPoA==",
       "dev": true,
-      "from": "@bosonprotocol/boson-protocol-contracts@github:bosonprotocol/boson-protocol-contracts#5166a27e45818c82f551cd90c9a92f21137a0366",
+      "from": "@bosonprotocol/boson-protocol-contracts@github:bosonprotocol/boson-protocol-contracts#324d8ca92c3727fe2957e3bf6ea9307f5e14a936",
       "requires": {
         "@openzeppelin/contracts": "^4.9.0",
         "@openzeppelin/contracts-upgradeable": "4.9.3"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -8,7 +8,7 @@
     "node": "hardhat node --hostname 0.0.0.0"
   },
   "devDependencies": {
-    "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#5166a27e45818c82f551cd90c9a92f21137a0366",
+    "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#324d8ca92c3727fe2957e3bf6ea9307f5e14a936",
     "@manifoldxyz/royalty-registry-solidity": "github:manifoldxyz/royalty-registry-solidity#e5369fc79279ce2e4c6ea2eb5914df51e89e8bd8",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   hardhat-node:
     build: ../contracts
-    image: hardhat-node:5166a27e45818c82f551cd90c9a92f21137a0366_0
+    image: hardhat-node:324d8ca92c3727fe2957e3bf6ea9307f5e14a936_0
     ports:
       - "8545:8545"
     volumes:

--- a/e2e/tests/accounts.test.ts
+++ b/e2e/tests/accounts.test.ts
@@ -9,7 +9,6 @@ import { utils, constants } from "ethers";
 import {
   initCoreSDKWithFundedWallet,
   ensureCreatedSeller,
-  waitForGraphNodeIndexing,
   createDisputeResolver,
   deployerWallet,
   seedWallet3,
@@ -95,7 +94,7 @@ describe("CoreSDK - accounts", () => {
           escalationResponsePeriodInMS: 123_000
         })
       ).wait();
-      await waitForGraphNodeIndexing(receipt);
+      await coreSDK.waitForGraphNodeIndexing(receipt);
 
       const disputeResolverAfterUpdate = await coreSDK.getDisputeResolverById(
         disputeResolverBeforeUpdate.id
@@ -126,7 +125,7 @@ describe("CoreSDK - accounts", () => {
         }
       });
       await txOptIn.wait();
-      await waitForGraphNodeIndexing(txOptIn);
+      await coreSDK2.waitForGraphNodeIndexing(txOptIn);
       const disputeResolverAfterOptIn = await coreSDK.getDisputeResolverById(
         disputeResolverBeforeUpdate.id
       );
@@ -165,7 +164,7 @@ describe("CoreSDK - accounts", () => {
       const receipt = await (
         await coreSDK.addFeesToDisputeResolver(disputeResolver.id, [secondFee])
       ).wait();
-      await waitForGraphNodeIndexing(receipt);
+      await coreSDK.waitForGraphNodeIndexing(receipt);
 
       const disputeResolverAfterUpdate = await coreSDK.getDisputeResolverById(
         disputeResolver.id
@@ -219,7 +218,7 @@ describe("CoreSDK - accounts", () => {
           [ethDisputeResolutionFee.tokenAddress]
         )
       ).wait();
-      await waitForGraphNodeIndexing(receipt);
+      await coreSDK.waitForGraphNodeIndexing(receipt);
 
       const disputeResolverAfterUpdate = await coreSDK.getDisputeResolverById(
         disputeResolverBeforeUpdate.id
@@ -256,7 +255,7 @@ describe("CoreSDK - accounts", () => {
           seller.id
         ])
       ).wait();
-      await waitForGraphNodeIndexing(receipt);
+      await coreSDK.waitForGraphNodeIndexing(receipt);
 
       const disputeResolverAfterUpdate = await coreSDK.getDisputeResolverById(
         disputeResolver.id
@@ -290,7 +289,7 @@ describe("CoreSDK - accounts", () => {
           [seller.id]
         )
       ).wait();
-      await waitForGraphNodeIndexing(receipt);
+      await coreSDK.waitForGraphNodeIndexing(receipt);
 
       const disputeResolverAfterUpdate = await coreSDK.getDisputeResolverById(
         disputeResolverBeforeUpdate.id
@@ -529,7 +528,7 @@ describe("CoreSDK - accounts", () => {
         }
       });
       await optInTx.wait();
-      await waitForGraphNodeIndexing(optInTx);
+      await coreSDK2.waitForGraphNodeIndexing(optInTx);
       seller = await coreSDK.getSellerById(seller.id as string);
       expect(seller).toBeTruthy();
       expect(seller.assistant).toEqual(randomWallet.address.toLowerCase());

--- a/e2e/tests/core-sdk-collections.test.ts
+++ b/e2e/tests/core-sdk-collections.test.ts
@@ -7,8 +7,7 @@ import {
   initCoreSDKWithFundedWallet,
   publishNftContractMetadata,
   seedWallet20,
-  updateSeller,
-  waitForGraphNodeIndexing
+  updateSeller
 } from "./utils";
 import { Wallet } from "ethers";
 
@@ -104,7 +103,7 @@ describe("Offer collections", () => {
       collectionId: customCollectionId
     });
     await tx.wait();
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK_A.waitForGraphNodeIndexing(tx);
     const collections = await coreSDK_A.getOfferCollections({
       offerCollectionsFilter: {
         sellerId: seller.id
@@ -125,7 +124,7 @@ describe("Offer collections", () => {
       collectionId: customCollectionId
     });
     await tx.wait();
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK_A.waitForGraphNodeIndexing(tx);
     const collections = await coreSDK_A.getOfferCollections({
       offerCollectionsFilter: {
         sellerId: seller.id
@@ -229,7 +228,7 @@ describe("Offer collections", () => {
       collectionId: maxLengthId
     });
     await tx.wait();
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK_A.waitForGraphNodeIndexing(tx);
     const collections = await coreSDK_A.getOfferCollections({
       offerCollectionsFilter: {
         sellerId: seller.id
@@ -287,7 +286,7 @@ describe("Offer collections", () => {
       collectionId: collectionMetadata2.name
     });
     await tx.wait();
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     const collections = await coreSDK.getOfferCollections({
       offerCollectionsFilter: {
         sellerId: seller.id

--- a/e2e/tests/core-sdk-extend-offer.test.ts
+++ b/e2e/tests/core-sdk-extend-offer.test.ts
@@ -5,8 +5,7 @@ import {
   createSellerAndOffer,
   ensureCreatedSeller,
   initCoreSDKWithFundedWallet,
-  seedWallet16,
-  waitForGraphNodeIndexing
+  seedWallet16
 } from "./utils";
 
 jest.setTimeout(60_000);
@@ -33,7 +32,7 @@ describe("core-sdk-extend-offer", () => {
     const tx = await coreSDK.extendOffer(offerId, newValidUntil.toString());
     await tx.wait();
 
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     const offer = await coreSDK.getOfferById(offerId);
     expect(offer.validUntilDate).toEqual(newValidUntil.toString());
   });
@@ -55,7 +54,7 @@ describe("core-sdk-extend-offer", () => {
     );
     await tx.wait();
 
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     const offer1 = await coreSDK.getOfferById(createdOffer1.id);
     expect(offer1.validUntilDate).toEqual(newValidUntil.toString());
     const offer2 = await coreSDK.getOfferById(createdOffer2.id);

--- a/e2e/tests/core-sdk-funds.test.ts
+++ b/e2e/tests/core-sdk-funds.test.ts
@@ -8,7 +8,6 @@ import {
   ensureCreatedSeller,
   ensureMintedAndAllowedTokens,
   MOCK_ERC20_ADDRESS,
-  waitForGraphNodeIndexing,
   seedWallet19,
   createOffer,
   initSellerAndBuyerSDKs,
@@ -233,7 +232,7 @@ describe("core-sdk-funds", () => {
       await (await buyerCoreSDK.redeemVoucher(ex4.id)).wait();
       await (await buyerCoreSDK.completeExchange(ex4.id)).wait();
       const receipt = await (await sellerCoreSDK.revokeVoucher(ex5.id)).wait();
-      await waitForGraphNodeIndexing(receipt);
+      await sellerCoreSDK.waitForGraphNodeIndexing(receipt);
 
       const sellerFundsAfter = await sellerCoreSDK.getFunds({
         fundsFilter: {
@@ -307,7 +306,7 @@ async function depositFunds(args: {
   );
   await depositFundsTxResponse.wait();
 
-  await waitForGraphNodeIndexing(depositFundsTxResponse);
+  await args.coreSDK.waitForGraphNodeIndexing(depositFundsTxResponse);
 
   const funds = await args.coreSDK.getFunds({
     fundsFilter: {
@@ -335,7 +334,7 @@ async function withdrawFunds(args: {
     args.amountsInEth.map((amount) => utils.parseEther(amount))
   );
   await withdrawResponse.wait();
-  await waitForGraphNodeIndexing(withdrawResponse);
+  await args.coreSDK.waitForGraphNodeIndexing(withdrawResponse);
 
   const funds = await args.coreSDK.getFunds({
     fundsFilter: {

--- a/e2e/tests/core-sdk-premint.test.ts
+++ b/e2e/tests/core-sdk-premint.test.ts
@@ -14,8 +14,7 @@ import {
   MOCK_ERC1155_ADDRESS,
   MOCK_SEAPORT_ADDRESS,
   seedWallet14,
-  seedWallet15,
-  waitForGraphNodeIndexing
+  seedWallet15
 } from "./utils";
 
 import { ExchangeState } from "../../packages/core-sdk/src/subgraph";
@@ -52,7 +51,7 @@ describe("core-sdk-premint", () => {
     const receipt = await (
       await coreSDK.reserveRange(offerId, range, "seller")
     ).wait();
-    await waitForGraphNodeIndexing(receipt);
+    await coreSDK.waitForGraphNodeIndexing(receipt);
 
     const offerReserveRange = await coreSDK.getOfferById(offerId);
     expect(Number(offerReserveRange.quantityAvailable)).toBe(
@@ -96,7 +95,7 @@ describe("core-sdk-premint", () => {
     const resultRange = await sellerCoreSDK.getRangeByOfferId(offerId);
     expect(Number(resultRange.length.toString())).toBe(range);
 
-    await waitForGraphNodeIndexing(receipt);
+    await sellerCoreSDK.waitForGraphNodeIndexing(receipt);
     const offer = await sellerCoreSDK.getOfferById(offerId);
     expect(offer.range).toBeTruthy();
 
@@ -110,7 +109,7 @@ describe("core-sdk-premint", () => {
       await sellerCoreSDK.transferFrom(offerId, buyerWallet.address, tokenId)
     ) // this will call commitToPreMintedOffer and create an exchange
       .wait();
-    await waitForGraphNodeIndexing(receipt2);
+    await sellerCoreSDK.waitForGraphNodeIndexing(receipt2);
     const exchange = await sellerCoreSDK.getExchangeById(exchangeId);
     expect(exchange.state).toBe(ExchangeState.COMMITTED);
   });
@@ -141,7 +140,7 @@ describe("core-sdk-premint", () => {
     const resultRange = await sellerCoreSDK.getRangeByOfferId(offerId);
     expect(Number(resultRange.length.toString())).toBe(range);
 
-    await waitForGraphNodeIndexing(receipt);
+    await sellerCoreSDK.waitForGraphNodeIndexing(receipt);
     const offer = await sellerCoreSDK.getOfferById(offerId);
     expect(offer.range).toBeTruthy();
 
@@ -158,14 +157,14 @@ describe("core-sdk-premint", () => {
       )
     ) // this will call commitToPreMintedOffer and create an exchange
       .wait();
-    await waitForGraphNodeIndexing(receipt2);
+    await sellerCoreSDK.waitForGraphNodeIndexing(receipt2);
 
     await (await buyerCoreSDK.redeemVoucher(exchangeId)).wait();
 
     const receipt3 = await (
       await buyerCoreSDK.raiseAndEscalateDispute(exchangeId)
     ).wait();
-    await waitForGraphNodeIndexing(receipt3);
+    await buyerCoreSDK.waitForGraphNodeIndexing(receipt3);
 
     const escalatedExchange = await sellerCoreSDK.getExchangeById(exchangeId);
     expect(escalatedExchange?.dispute?.id).toBeTruthy();
@@ -199,7 +198,7 @@ describe("core-sdk-premint", () => {
       const resultRange = await coreSDK.getRangeByOfferId(offerId);
       expect(Number(resultRange.length.toString())).toBe(range);
 
-      await waitForGraphNodeIndexing(receipt);
+      await coreSDK.waitForGraphNodeIndexing(receipt);
       const offer = await coreSDK.getOfferById(offerId);
       expect(offer.range).toBeTruthy();
 

--- a/e2e/tests/core-sdk-royalties.test.ts
+++ b/e2e/tests/core-sdk-royalties.test.ts
@@ -8,9 +8,7 @@ import {
   initCoreSDKWithFundedWallet,
   initCoreSDKWithWallet,
   prepareMultiVariantOffers,
-  seedWallet23,
-  wait,
-  waitForGraphNodeIndexing
+  seedWallet23
 } from "./utils";
 import { productV1 } from "@bosonprotocol/metadata/src";
 
@@ -100,7 +98,7 @@ describe("Seller royalties recipients", () => {
         };
       })
     );
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     seller = await coreSDK.getSellerById(seller.id);
     expect(seller).toBeTruthy();
     expect(seller.royaltyRecipients).toBeTruthy();
@@ -141,7 +139,7 @@ describe("Seller royalties recipients", () => {
         };
       })
     );
-    await waitForGraphNodeIndexing(tx_2);
+    await coreSDK.waitForGraphNodeIndexing(tx_2);
     seller = await coreSDK.getSellerById(seller.id);
     expect(seller).toBeTruthy();
     expect(seller.royaltyRecipients).toBeTruthy();
@@ -281,7 +279,7 @@ describe("Seller royalties recipients", () => {
         };
       })
     );
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     seller = await coreSDK.getSellerById(seller.id);
     expect(seller).toBeTruthy();
     let royaltyRecipients = seller.royaltyRecipients;
@@ -322,7 +320,7 @@ describe("Seller royalties recipients", () => {
         };
       })
     );
-    await waitForGraphNodeIndexing(tx_2);
+    await coreSDK.waitForGraphNodeIndexing(tx_2);
     seller = await coreSDK.getSellerById(seller.id);
     expect(seller).toBeTruthy();
     royaltyRecipients = seller.royaltyRecipients;
@@ -416,7 +414,7 @@ describe("Seller royalties recipients", () => {
         };
       })
     );
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     seller = await coreSDK.getSellerById(seller.id);
     expect(seller).toBeTruthy();
     let royaltyRecipients = seller.royaltyRecipients;
@@ -442,7 +440,7 @@ describe("Seller royalties recipients", () => {
     const tx_2 = await coreSDK.removeRoyaltyRecipients(seller.id, [
       recipient2Index
     ]);
-    await waitForGraphNodeIndexing(tx_2);
+    await coreSDK.waitForGraphNodeIndexing(tx_2);
     seller = await coreSDK.getSellerById(seller.id);
     expect(seller).toBeTruthy();
     royaltyRecipients = seller.royaltyRecipients;
@@ -655,7 +653,7 @@ describe.only("Offer royalties recipients", () => {
       createdOffer.id,
       newRoyaltyInfo
     );
-    await waitForGraphNodeIndexing(tx2);
+    await coreSDK.waitForGraphNodeIndexing(tx2);
     const offer = await coreSDK.getOfferById(createdOffer.id);
     expect(offer.royaltyInfos).toBeTruthy();
     expect(offer.royaltyInfos.length).toEqual(2);
@@ -701,7 +699,7 @@ describe.only("Offer royalties recipients", () => {
       [createdOffer.id],
       newRoyaltyInfo
     );
-    await waitForGraphNodeIndexing(tx2);
+    await coreSDK.waitForGraphNodeIndexing(tx2);
     const offer = await coreSDK.getOfferById(createdOffer.id);
     expect(offer.royaltyInfos).toBeTruthy();
     expect(offer.royaltyInfos.length).toEqual(2);
@@ -775,7 +773,7 @@ describe.only("Offer royalties recipients", () => {
       createdOffers.map((offer) => offer.id),
       newRoyaltyInfo
     );
-    await waitForGraphNodeIndexing(tx2);
+    await coreSDK.waitForGraphNodeIndexing(tx2);
     createdOffers.forEach(async (createdOffer) => {
       const offer = await coreSDK.getOfferById(createdOffer.id);
       expect(offer.royaltyInfos).toBeTruthy();

--- a/e2e/tests/core-sdk-set-contract-uri.test.ts
+++ b/e2e/tests/core-sdk-set-contract-uri.test.ts
@@ -1,13 +1,7 @@
-import { BigNumber, Wallet } from "ethers";
-import { CoreSDK } from "../../packages/core-sdk/src";
-
 import {
-  createOffer,
   createSellerAndOffer,
-  ensureCreatedSeller,
   initCoreSDKWithFundedWallet,
-  seedWallet18,
-  waitForGraphNodeIndexing
+  seedWallet18
 } from "./utils";
 
 jest.setTimeout(60_000);
@@ -37,7 +31,7 @@ describe("core-sdk-set-contract-uri", () => {
     const tx = await coreSDK.setContractURI(newContractURI, collectionIndex);
     await tx.wait();
 
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     const sellerWithNewContractURI = await coreSDK.getSellerById(
       createdOffer.seller.id
     );

--- a/e2e/tests/core-sdk.test.ts
+++ b/e2e/tests/core-sdk.test.ts
@@ -19,7 +19,6 @@ import {
   ensureCreatedSeller,
   ensureMintedAndAllowedTokens,
   MOCK_ERC20_ADDRESS,
-  waitForGraphNodeIndexing,
   seedWallet4,
   seedWallet5,
   seedWallet6,
@@ -111,7 +110,7 @@ describe("core-sdk", () => {
 
       const txResponse = await coreSDK.voidOffer(createdOffer.id);
       await txResponse.wait();
-      await waitForGraphNodeIndexing(txResponse);
+      await coreSDK.waitForGraphNodeIndexing(txResponse);
 
       const offer = await coreSDK.getOfferById(createdOffer.id);
       expect(offer.voided).toBe(true);
@@ -172,7 +171,7 @@ describe("core-sdk", () => {
       const createdGroupTx = await sellerCoreSDK.createGroup(groupToCreate);
       await createdGroupTx.wait();
 
-      await waitForGraphNodeIndexing(createdGroupTx);
+      await sellerCoreSDK.waitForGraphNodeIndexing(createdGroupTx);
 
       // Check the 3 offers are linked to the condition in the SubGraph
       for (const offerId of offerIds) {
@@ -362,7 +361,7 @@ describe("core-sdk", () => {
 
         await createdGroupTx.wait();
 
-        await waitForGraphNodeIndexing(createdGroupTx);
+        await sellerCoreSDK.waitForGraphNodeIndexing(createdGroupTx);
 
         const offerWithCondition = await sellerCoreSDK.getOfferById(
           createdOffer.id
@@ -460,7 +459,7 @@ describe("core-sdk", () => {
 
         await createdGroupTx.wait();
 
-        await waitForGraphNodeIndexing(createdGroupTx);
+        await sellerCoreSDK.waitForGraphNodeIndexing(createdGroupTx);
 
         const exchange = await commitToConditionalOffer({
           buyerCoreSDK,
@@ -548,7 +547,7 @@ describe("core-sdk", () => {
         );
 
         const createOfferCond = await createOfferCondTx.wait();
-        await waitForGraphNodeIndexing(createOfferCond);
+        await sellerCoreSDK.waitForGraphNodeIndexing(createOfferCond);
 
         const offerId = sellerCoreSDK.getCreatedOfferIdFromLogs(
           createOfferCond.logs
@@ -640,7 +639,7 @@ describe("core-sdk", () => {
         );
 
         const createOfferCond = await createOfferCondTx.wait();
-        await waitForGraphNodeIndexing(createOfferCond);
+        await sellerCoreSDK.waitForGraphNodeIndexing(createOfferCond);
 
         const offerId = sellerCoreSDK.getCreatedOfferIdFromLogs(
           createOfferCond.logs
@@ -802,7 +801,7 @@ describe("core-sdk", () => {
         );
 
         const receipt = await createOfferCondTx.wait();
-        await waitForGraphNodeIndexing(receipt);
+        await sellerCoreSDK.waitForGraphNodeIndexing(receipt);
 
         const offerId = buyerCoreSDK.getCreatedOfferIdFromLogs(receipt.logs);
         const buyerAddress = await buyerWallet.getAddress();
@@ -948,7 +947,7 @@ describe("core-sdk", () => {
         );
 
         const receipt = await createOfferCondTx.wait();
-        await waitForGraphNodeIndexing(receipt);
+        await sellerCoreSDK.waitForGraphNodeIndexing(receipt);
         const offerId = buyerCoreSDK.getCreatedOfferIdFromLogs(receipt.logs);
 
         if (!offerId) {
@@ -965,7 +964,7 @@ describe("core-sdk", () => {
           const receipt = await (
             await buyerCoreSDK.commitToConditionalOffer(offerId, tokenId)
           ).wait();
-          await waitForGraphNodeIndexing(receipt);
+          await buyerCoreSDK.waitForGraphNodeIndexing(receipt);
         }
 
         const buyerAddress = await buyerWallet.getAddress();
@@ -1041,7 +1040,7 @@ describe("core-sdk", () => {
 
       const txResponse = await sellerCoreSDK.revokeVoucher(exchange.id);
       await txResponse.wait();
-      await waitForGraphNodeIndexing(txResponse);
+      await sellerCoreSDK.waitForGraphNodeIndexing(txResponse);
       const exchangeAfterRevoke = await sellerCoreSDK.getExchangeById(
         exchange.id
       );
@@ -1069,7 +1068,7 @@ describe("core-sdk", () => {
 
       const txResponse = await buyerCoreSDK.cancelVoucher(exchange.id);
       await txResponse.wait();
-      await waitForGraphNodeIndexing(txResponse);
+      await buyerCoreSDK.waitForGraphNodeIndexing(txResponse);
       const exchangeAfterRevoke = await buyerCoreSDK.getExchangeById(
         exchange.id
       );
@@ -1097,7 +1096,7 @@ describe("core-sdk", () => {
 
       const txResponse = await buyerCoreSDK.redeemVoucher(exchange.id);
       await txResponse.wait();
-      await waitForGraphNodeIndexing(txResponse);
+      await buyerCoreSDK.waitForGraphNodeIndexing(txResponse);
       const exchangeAfterRevoke = await buyerCoreSDK.getExchangeById(
         exchange.id
       );
@@ -1141,7 +1140,7 @@ describe("core-sdk", () => {
       const txResponse2 = await buyerCoreSDK.redeemVoucher(exchange2.id);
       await txResponse2.wait();
 
-      await waitForGraphNodeIndexing(txResponse2);
+      await buyerCoreSDK.waitForGraphNodeIndexing(txResponse2);
       const exchangesAfterComplete = await completeExchangeBatch({
         coreSDK: buyerCoreSDK,
         exchangeIds: [exchange1.id, exchange2.id]
@@ -1161,7 +1160,6 @@ describe("core-sdk", () => {
       const buyerCoreSDK = initCoreSDKWithWallet(buyerWallet);
 
       beforeEach(async () => {
-        // await waitForGraphNodeIndexing(); //?
         await ensureCreatedSeller(sellerWallet);
 
         // before each case, create offer + commit + redeem
@@ -1178,7 +1176,7 @@ describe("core-sdk", () => {
 
         const txResponse = await buyerCoreSDK.redeemVoucher(exchange.id);
         await txResponse.wait();
-        await waitForGraphNodeIndexing(txResponse);
+        await buyerCoreSDK.waitForGraphNodeIndexing(txResponse);
       });
 
       test("raise dispute", async () => {
@@ -1217,7 +1215,7 @@ describe("core-sdk", () => {
 
         const txResponse = await buyerCoreSDK.redeemVoucher(exchange.id);
         await txResponse.wait();
-        await waitForGraphNodeIndexing(txResponse);
+        await buyerCoreSDK.waitForGraphNodeIndexing(txResponse);
 
         // Raise the dispute
         await raiseDispute(exchange.id, buyerCoreSDK);
@@ -1384,7 +1382,7 @@ async function depositFunds(args: {
   );
   await depositFundsTxResponse.wait();
 
-  await waitForGraphNodeIndexing(depositFundsTxResponse);
+  await args.coreSDK.waitForGraphNodeIndexing(depositFundsTxResponse);
 
   const funds = await args.coreSDK.getFunds({
     fundsFilter: {
@@ -1415,7 +1413,7 @@ async function commitToConditionalOffer(args: {
   const exchangeId = args.buyerCoreSDK.getCommittedExchangeIdFromLogs(
     commitToOfferTxReceipt.logs
   );
-  await waitForGraphNodeIndexing(commitToOfferTxReceipt);
+  await args.buyerCoreSDK.waitForGraphNodeIndexing(commitToOfferTxReceipt);
   const exchange = await args.sellerCoreSDK.getExchangeById(
     exchangeId as string
   );
@@ -1430,7 +1428,7 @@ async function completeExchange(args: {
     args.exchangeId
   );
   await completeExchangeTxResponse.wait();
-  await waitForGraphNodeIndexing(completeExchangeTxResponse);
+  await args.coreSDK.waitForGraphNodeIndexing(completeExchangeTxResponse);
   const exchangeAfterComplete = await args.coreSDK.getExchangeById(
     args.exchangeId
   );
@@ -1445,7 +1443,7 @@ async function completeExchangeBatch(args: {
     args.exchangeIds
   );
   await completeExchangeTxResponse.wait();
-  await waitForGraphNodeIndexing(completeExchangeTxResponse);
+  await args.coreSDK.waitForGraphNodeIndexing(completeExchangeTxResponse);
   const exchangesAfterComplete = await args.coreSDK.getExchanges({
     exchangesFilter: {
       id_in: args.exchangeIds.map((id) => id.toString())
@@ -1464,7 +1462,7 @@ async function raiseDispute(exchangeId: string, buyerCoreSDK: CoreSDK) {
 
   const txResponse = await buyerCoreSDK.raiseDispute(exchangeId);
   await txResponse.wait();
-  await waitForGraphNodeIndexing(txResponse);
+  await buyerCoreSDK.waitForGraphNodeIndexing(txResponse);
   const exchangeAfterDispute = await buyerCoreSDK.getExchangeById(exchangeId);
   expect(exchangeAfterDispute.state).toBe(ExchangeState.DISPUTED);
   expect(exchangeAfterDispute.completedDate).toBeNull();
@@ -1496,7 +1494,7 @@ async function checkDisputeResolving(exchangeId: string, coreSDK: CoreSDK) {
 async function retractDispute(exchangeId: string, buyerCoreSDK: CoreSDK) {
   const txResponse = await buyerCoreSDK.retractDispute(exchangeId);
   await txResponse.wait();
-  await waitForGraphNodeIndexing(txResponse);
+  await buyerCoreSDK.waitForGraphNodeIndexing(txResponse);
 }
 
 async function checkDisputeRetracted(exchangeId: string, coreSDK: CoreSDK) {
@@ -1550,7 +1548,7 @@ async function resolveDispute(
       sigV
     });
     await txResponse.wait();
-    await waitForGraphNodeIndexing(txResponse);
+    await resolverSDK.waitForGraphNodeIndexing(txResponse);
   }
 }
 
@@ -1586,7 +1584,7 @@ async function checkDisputeResolved(
 async function escalateDispute(exchangeId: string, buyerCoreSDK: CoreSDK) {
   const txResponse = await buyerCoreSDK.escalateDispute(exchangeId);
   await txResponse.wait();
-  await waitForGraphNodeIndexing(txResponse);
+  await buyerCoreSDK.waitForGraphNodeIndexing(txResponse);
 }
 
 async function checkDisputeEscalated(exchangeId: string, coreSDK: CoreSDK) {
@@ -1627,7 +1625,7 @@ async function decideDispute(
 ) {
   const txResponse = await drCoreSDK.decideDispute(exchangeId, buyerPercent);
   await txResponse.wait();
-  await waitForGraphNodeIndexing(txResponse);
+  await drCoreSDK.waitForGraphNodeIndexing(txResponse);
 }
 
 async function checkDisputeDecided(
@@ -1669,7 +1667,7 @@ async function extendDisputeTimeout(
     newTimeout
   );
   await txResponse.wait();
-  await waitForGraphNodeIndexing(txResponse);
+  await sellerCoreSDK.waitForGraphNodeIndexing(txResponse);
 }
 
 async function checkDisputeTimeout(
@@ -1688,7 +1686,7 @@ async function checkDisputeTimeout(
 async function refuseDispute(exchangeId: string, drCoreSDK: CoreSDK) {
   const txResponse = await drCoreSDK.refuseEscalatedDispute(exchangeId);
   await txResponse.wait();
-  await waitForGraphNodeIndexing(txResponse);
+  await drCoreSDK.waitForGraphNodeIndexing(txResponse);
 }
 
 async function checkDisputeRefused(exchangeId: string, coreSDK: CoreSDK) {
@@ -1719,5 +1717,5 @@ async function checkDisputeRefused(exchangeId: string, coreSDK: CoreSDK) {
 async function expireDispute(exchangeId: string, coreSDK: CoreSDK) {
   const txResponse = await coreSDK.expireDispute(exchangeId);
   await txResponse.wait();
-  await waitForGraphNodeIndexing(txResponse);
+  await coreSDK.waitForGraphNodeIndexing(txResponse);
 }

--- a/e2e/tests/fundsEventLogs.test.ts
+++ b/e2e/tests/fundsEventLogs.test.ts
@@ -1,10 +1,8 @@
-import { subgraph } from "../../packages/core-sdk/src";
 import { EventType } from "../../packages/core-sdk/src/subgraph";
 import {
   createSellerAndOffer,
   initCoreSDKWithFundedWallet,
-  seedWallet13,
-  waitForGraphNodeIndexing
+  seedWallet13
 } from "./utils";
 
 jest.setTimeout(60_000);
@@ -39,7 +37,7 @@ describe("fundsEventLogs", () => {
     expect(eventLogs.length).toEqual(0);
     const tx = await coreSDK.commitToOffer(createdOffer.id);
     await tx.wait();
-    await waitForGraphNodeIndexing(tx);
+    await coreSDK.waitForGraphNodeIndexing(tx);
     funds = await coreSDK.getFunds({
       fundsFilter: {
         account: createdOffer.seller.id,

--- a/e2e/tests/meta-tx.test.ts
+++ b/e2e/tests/meta-tx.test.ts
@@ -12,7 +12,6 @@ import {
   ensureMintedAndAllowedTokens,
   seedWallet7,
   seedWallet8,
-  waitForGraphNodeIndexing,
   metadata,
   createOffer,
   seedWallet11,
@@ -167,7 +166,7 @@ describe("meta-tx", () => {
       expect(metaTxReceipt.transactionHash).toBeTruthy();
       expect(BigNumber.from(metaTxReceipt.effectiveGasPrice).gt(0)).toBe(true);
 
-      await waitForGraphNodeIndexing(metaTxReceipt);
+      await sellerCoreSDK.waitForGraphNodeIndexing(metaTxReceipt);
       const existingSeller = await sellerCoreSDK.getSellerById(seller.id);
       expect(existingSeller.pendingSeller?.admin).toBe(
         randomWallet.address.toLowerCase()
@@ -258,7 +257,7 @@ describe("meta-tx", () => {
         });
       await metaTxUpdateSellerRandom.wait();
 
-      await waitForGraphNodeIndexing(metaTxUpdateSellerRandom);
+      await seller1CoreSDK.waitForGraphNodeIndexing(metaTxUpdateSellerRandom);
 
       nonce = Date.now();
       const { r, s, v, functionName, functionSignature } =
@@ -286,7 +285,7 @@ describe("meta-tx", () => {
       expect(metaTxReceipt.transactionHash).toBeTruthy();
       expect(BigNumber.from(metaTxReceipt.effectiveGasPrice).gt(0)).toBe(true);
 
-      await waitForGraphNodeIndexing(metaTxReceipt);
+      await randomCoreSDK.waitForGraphNodeIndexing(metaTxReceipt);
       const existingSeller = await seller1CoreSDK.getSellerById(seller1.id);
       expect(existingSeller.pendingSeller?.admin).toBe(constants.AddressZero);
       expect(existingSeller.admin.toLowerCase()).toBe(
@@ -422,7 +421,7 @@ describe("meta-tx", () => {
         metaTxReceipt.logs
       );
       expect(groupId).toBeTruthy();
-      await waitForGraphNodeIndexing(metaTxReceipt);
+      await sellerCoreSDK.waitForGraphNodeIndexing(metaTxReceipt);
       const tokenGatedOffer = await sellerCoreSDK.getOfferById(createdOffer.id);
       expect(tokenGatedOffer.condition).toBeTruthy();
     });
@@ -488,7 +487,7 @@ describe("meta-tx", () => {
         metaTxReceipt.logs
       );
       expect(offerId).toBeTruthy();
-      await waitForGraphNodeIndexing(metaTxReceipt);
+      await sellerCoreSDK.waitForGraphNodeIndexing(metaTxReceipt);
       const tokenGatedOffer = await sellerCoreSDK.getOfferById(
         offerId as string
       );
@@ -876,7 +875,7 @@ describe("meta-tx", () => {
       expect(metaTxReceipt.transactionHash).toBeTruthy();
       expect(BigNumber.from(metaTxReceipt.effectiveGasPrice).gt(0)).toBe(true);
 
-      await waitForGraphNodeIndexing(metaTxReceipt);
+      await newSellerCoreSDK.waitForGraphNodeIndexing(metaTxReceipt);
       const fundsAfter = await getFunds(
         newSellerCoreSDK,
         seller.id,
@@ -913,7 +912,7 @@ describe("meta-tx", () => {
       );
       await depositTx.wait();
 
-      await waitForGraphNodeIndexing(depositTx);
+      await newSellerCoreSDK.waitForGraphNodeIndexing(depositTx);
       const fundsAfterDeposit = await getFunds(
         newSellerCoreSDK,
         seller.id,
@@ -950,7 +949,7 @@ describe("meta-tx", () => {
       expect(metaTxReceipt.transactionHash).toBeTruthy();
       expect(BigNumber.from(metaTxReceipt.effectiveGasPrice).gt(0)).toBe(true);
 
-      await waitForGraphNodeIndexing(metaTxReceipt);
+      await newSellerCoreSDK.waitForGraphNodeIndexing(metaTxReceipt);
       const fundsAfter = await getFunds(
         newSellerCoreSDK,
         seller.id,
@@ -968,7 +967,7 @@ describe("meta-tx", () => {
         commitTxReceipt.logs
       );
       expect(exchangeId).toBeTruthy();
-      await waitForGraphNodeIndexing(commitTxReceipt);
+      await buyerCoreSDK.waitForGraphNodeIndexing(commitTxReceipt);
       const redeemTx = await buyerCoreSDK.redeemVoucher(exchangeId as string);
       await redeemTx.wait();
 
@@ -1004,7 +1003,7 @@ describe("meta-tx", () => {
         commitTxReceipt.logs
       );
       expect(exchangeId).toBeTruthy();
-      await waitForGraphNodeIndexing(commitTxReceipt);
+      await buyerCoreSDK.waitForGraphNodeIndexing(commitTxReceipt);
       const redeemTx = await buyerCoreSDK.redeemVoucher(exchangeId as string);
       await redeemTx.wait();
 
@@ -1045,7 +1044,7 @@ describe("meta-tx", () => {
         commitTxReceipt.logs
       );
       expect(exchangeId).toBeTruthy();
-      await waitForGraphNodeIndexing(commitTxReceipt);
+      await buyerCoreSDK.waitForGraphNodeIndexing(commitTxReceipt);
       const redeemTx = await buyerCoreSDK.redeemVoucher(exchangeId as string);
       await redeemTx.wait();
 
@@ -1086,7 +1085,7 @@ describe("meta-tx", () => {
         commitTxReceipt.logs
       ) as string;
       expect(exchangeId).toBeTruthy();
-      await waitForGraphNodeIndexing(commitTxReceipt);
+      await buyerCoreSDK.waitForGraphNodeIndexing(commitTxReceipt);
       const redeemTx = await buyerCoreSDK.redeemVoucher(exchangeId);
       await redeemTx.wait();
 
@@ -1139,7 +1138,7 @@ describe("meta-tx", () => {
         commitTxReceipt.logs
       ) as string;
       expect(exchangeId).toBeTruthy();
-      await waitForGraphNodeIndexing(commitTxReceipt);
+      await buyerCoreSDK.waitForGraphNodeIndexing(commitTxReceipt);
       const redeemTx = await buyerCoreSDK.redeemVoucher(exchangeId);
       await redeemTx.wait();
 
@@ -1147,7 +1146,7 @@ describe("meta-tx", () => {
         exchangeId as string
       );
       await raiseDisputeTx.wait();
-      await waitForGraphNodeIndexing(raiseDisputeTx);
+      await buyerCoreSDK.waitForGraphNodeIndexing(raiseDisputeTx);
 
       const dispute = await buyerCoreSDK.getDisputeById(exchangeId);
       const newTimeout = BigNumber.from(dispute.timeout).add(12).toString();
@@ -1434,7 +1433,7 @@ async function createOfferAndDepositFunds(sellerWallet: Wallet) {
     MOCK_ERC20_ADDRESS
   );
   await depositFundsTx.wait();
-  await waitForGraphNodeIndexing(depositFundsTx);
+  await sellerCoreSDK.waitForGraphNodeIndexing(depositFundsTx);
 
   return offerId as string;
 }

--- a/e2e/tests/productV1.test.ts
+++ b/e2e/tests/productV1.test.ts
@@ -21,7 +21,6 @@ import {
   resolveDateValidity,
   seedWallet10,
   wait,
-  waitForGraphNodeIndexing,
   serializeVariant
 } from "./utils";
 import { SEC_PER_DAY } from "../../packages/common/src/utils/timestamp";
@@ -529,7 +528,7 @@ describe("Multi-variant offers tests", () => {
     // Commit to the offer
     const commitTx = await coreSDK.commitToOffer(offer?.id as string);
     await commitTx.wait();
-    await waitForGraphNodeIndexing(commitTx);
+    await coreSDK.waitForGraphNodeIndexing(commitTx);
 
     const productWithVariants = await coreSDK.getProductWithVariants(
       offer?.seller.id as string,
@@ -712,7 +711,7 @@ describe("Multi-variant offers tests", () => {
       // Void the offer1
       const voidTx = await coreSDK.voidOffer(offers[0].id);
       await voidTx.wait();
-      await waitForGraphNodeIndexing(voidTx);
+      await coreSDK.waitForGraphNodeIndexing(voidTx);
 
       // Check the notVoidedVariants for product1 only includes the offer2
       let allProductsWithVariants =
@@ -729,7 +728,7 @@ describe("Multi-variant offers tests", () => {
         offers[3].id
       ]);
       await batchVoidTx.wait();
-      await waitForGraphNodeIndexing(batchVoidTx);
+      await coreSDK.waitForGraphNodeIndexing(batchVoidTx);
 
       // Check the notVoidedVariants for product2 do not include any offer
       allProductsWithVariants =

--- a/e2e/tests/subgraph.meta.test.ts
+++ b/e2e/tests/subgraph.meta.test.ts
@@ -1,4 +1,4 @@
-import { getSubgraphBlockNumber, waitForGraphNodeIndexing } from "./utils";
+import { getSubgraphBlockNumber, initCoreSDKWithWallet } from "./utils";
 import {
   TransactionResponse,
   TransactionReceipt
@@ -14,7 +14,8 @@ describe("subgraph meta", () => {
   test("wait for a given blockNumber", async () => {
     let currentBlock = await getSubgraphBlockNumber();
     const target = currentBlock + 2;
-    await waitForGraphNodeIndexing(target);
+    const coreSDK = initCoreSDKWithWallet(undefined);
+    await coreSDK.waitForGraphNodeIndexing(target);
     currentBlock = await getSubgraphBlockNumber();
     expect(currentBlock).toBeGreaterThanOrEqual(target);
   });
@@ -30,7 +31,8 @@ describe("subgraph meta", () => {
         });
       }
     } as TransactionResponse;
-    await waitForGraphNodeIndexing(txResponse);
+    const coreSDK = initCoreSDKWithWallet(undefined);
+    await coreSDK.waitForGraphNodeIndexing(txResponse);
     currentBlock = await getSubgraphBlockNumber();
     expect(currentBlock).toBeGreaterThanOrEqual(target);
   });
@@ -40,7 +42,8 @@ describe("subgraph meta", () => {
     const txReceipt = {
       blockNumber: target
     } as TransactionReceipt;
-    await waitForGraphNodeIndexing(txReceipt);
+    const coreSDK = initCoreSDKWithWallet(undefined);
+    await coreSDK.waitForGraphNodeIndexing(txReceipt);
     currentBlock = await getSubgraphBlockNumber();
     expect(currentBlock).toBeGreaterThanOrEqual(target);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-tsdoc": "^0.2.16",
         "form-data": "^4.0.0",
         "graphql": "^16.8.1",
+        "ipfs-utils": "^9.0.14",
         "lerna": "^5.5.1",
         "prettier": "^2.6.2",
         "run-script-os": "^1.1.6",
@@ -23577,23 +23578,30 @@
       "license": "MIT"
     },
     "node_modules/ipfs-utils": {
-      "version": "9.0.7",
-      "license": "MIT",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
+      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
       "dependencies": {
         "any-signal": "^3.0.0",
+        "browser-readablestream-to-it": "^1.0.0",
         "buffer": "^6.0.1",
         "electron-fetch": "^1.7.2",
         "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
         "iso-url": "^1.1.5",
+        "it-all": "^1.0.4",
         "it-glob": "^1.0.1",
         "it-to-stream": "^1.0.0",
         "merge-options": "^3.0.4",
         "nanoid": "^3.1.20",
         "native-fetch": "^3.0.0",
-        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-        "react-native-fetch-api": "^2.0.0",
+        "node-fetch": "^2.6.8",
+        "react-native-fetch-api": "^3.0.0",
         "stream-to-it": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-utils/node_modules/buffer": {
@@ -23623,13 +23631,41 @@
       "license": "MIT"
     },
     "node_modules/ipfs-utils/node_modules/node-fetch": {
-      "name": "@achingbrain/node-fetch",
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ipfs-utils/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/ipfs-utils/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/iron-webcrypto": {
@@ -33773,8 +33809,9 @@
       }
     },
     "node_modules/react-native-fetch-api": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
       "dependencies": {
         "p-defer": "^3.0.0"
       }
@@ -43109,29 +43146,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "packages/subgraph/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "packages/subgraph/node_modules/chalk": {
       "version": "3.0.0",
       "license": "MIT",
@@ -43234,38 +43248,6 @@
         "npm": ">=3.0.0"
       }
     },
-    "packages/subgraph/node_modules/ipfs-utils": {
-      "version": "9.0.14",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
-      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
-      "dependencies": {
-        "any-signal": "^3.0.0",
-        "browser-readablestream-to-it": "^1.0.0",
-        "buffer": "^6.0.1",
-        "electron-fetch": "^1.7.2",
-        "err-code": "^3.0.1",
-        "is-electron": "^2.2.0",
-        "iso-url": "^1.1.5",
-        "it-all": "^1.0.4",
-        "it-glob": "^1.0.1",
-        "it-to-stream": "^1.0.0",
-        "merge-options": "^3.0.4",
-        "nanoid": "^3.1.20",
-        "native-fetch": "^3.0.0",
-        "node-fetch": "^2.6.8",
-        "react-native-fetch-api": "^3.0.0",
-        "stream-to-it": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "packages/subgraph/node_modules/ipfs-utils/node_modules/any-signal": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
-    },
     "packages/subgraph/node_modules/js-yaml": {
       "version": "3.14.1",
       "license": "MIT",
@@ -43314,25 +43296,6 @@
         "node": ">=8"
       }
     },
-    "packages/subgraph/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "packages/subgraph/node_modules/prettier": {
       "version": "3.0.3",
       "license": "MIT",
@@ -43344,14 +43307,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "packages/subgraph/node_modules/react-native-fetch-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
-      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
-      "dependencies": {
-        "p-defer": "^3.0.0"
       }
     },
     "packages/subgraph/node_modules/semver": {
@@ -43374,25 +43329,6 @@
         "abort-controller": "^3.0.0",
         "native-abort-controller": "^1.0.4",
         "retimer": "^3.0.0"
-      }
-    },
-    "packages/subgraph/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "packages/subgraph/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "packages/subgraph/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-tsdoc": "^0.2.16",
     "form-data": "^4.0.0",
     "graphql": "^16.8.1",
+    "ipfs-utils": "^9.0.14",
     "lerna": "^5.5.1",
     "prettier": "^2.6.2",
     "run-script-os": "^1.1.6",

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -1,0 +1,7 @@
+import { ParamType } from "@ethersproject/abi";
+
+export type ErrorFragment = {
+  name: string;
+  type: "error";
+  inputs: Array<ParamType>;
+};

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -4,6 +4,7 @@ export * from "./offers";
 export * from "./accounts";
 export * from "./groups";
 export * from "./vouchers";
+export * from "./errors";
 
 import {
   AnyMetadata as _AnyMetadata,

--- a/packages/core-sdk/src/accounts/queries.graphql
+++ b/packages/core-sdk/src/accounts/queries.graphql
@@ -266,7 +266,10 @@ fragment BaseOfferCollectionFields on OfferCollection {
   id
   sellerId
   collectionIndex
-  collectionAddress
+  collectionContract {
+    address
+    contractUri
+  }
   externalIdHash
   externalId
   metadata {
@@ -379,7 +382,6 @@ fragment BaseSellerFields on Seller {
   authTokenType
   voucherCloneAddress
   active
-  contractURI
   royaltyRecipients {
     id
     recipient {

--- a/packages/core-sdk/src/core-sdk.ts
+++ b/packages/core-sdk/src/core-sdk.ts
@@ -25,6 +25,7 @@ import { ERC721Mixin } from "./erc721/mixin";
 import { ERC1155Mixin } from "./erc1155/mixin";
 import { ERC165Mixin } from "./erc165/mixin";
 import { ProtocolConfigMixin } from "./protocol-config/mixin";
+import { ErrorMixin } from "./errors/mixin";
 
 export class CoreSDK extends BaseCoreSDK {
   /**
@@ -145,7 +146,8 @@ export interface CoreSDK
     ERC721Mixin,
     ERC1155Mixin,
     ERC165Mixin,
-    ProtocolConfigMixin {}
+    ProtocolConfigMixin,
+    ErrorMixin {}
 applyMixins(CoreSDK, [
   MetadataMixin,
   AccountsMixin,
@@ -163,5 +165,6 @@ applyMixins(CoreSDK, [
   ERC721Mixin,
   ERC1155Mixin,
   ERC165Mixin,
-  ProtocolConfigMixin
+  ProtocolConfigMixin,
+  ErrorMixin
 ]);

--- a/packages/core-sdk/src/core-sdk.ts
+++ b/packages/core-sdk/src/core-sdk.ts
@@ -26,6 +26,7 @@ import { ERC1155Mixin } from "./erc1155/mixin";
 import { ERC165Mixin } from "./erc165/mixin";
 import { ProtocolConfigMixin } from "./protocol-config/mixin";
 import { ErrorMixin } from "./errors/mixin";
+import { SubgraphMixin } from "./subgraph/mixin";
 
 export class CoreSDK extends BaseCoreSDK {
   /**
@@ -147,7 +148,8 @@ export interface CoreSDK
     ERC1155Mixin,
     ERC165Mixin,
     ProtocolConfigMixin,
-    ErrorMixin {}
+    ErrorMixin,
+    SubgraphMixin {}
 applyMixins(CoreSDK, [
   MetadataMixin,
   AccountsMixin,
@@ -166,5 +168,6 @@ applyMixins(CoreSDK, [
   ERC1155Mixin,
   ERC165Mixin,
   ProtocolConfigMixin,
-  ErrorMixin
+  ErrorMixin,
+  SubgraphMixin
 ]);

--- a/packages/core-sdk/src/errors/mixin.ts
+++ b/packages/core-sdk/src/errors/mixin.ts
@@ -31,7 +31,6 @@ export class ErrorMixin extends BaseCoreSDK {
     if (this._errorsMap.size === 0) {
       Object.keys(abis).forEach((abi) => {
         const iface = new Interface(abis[abi]);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Object.keys(iface.errors).forEach((error) => {
           const sigHash = iface.getSighash(error);
           this._errorsMap.set(

--- a/packages/core-sdk/src/errors/mixin.ts
+++ b/packages/core-sdk/src/errors/mixin.ts
@@ -1,0 +1,45 @@
+import { Interface } from "@ethersproject/abi";
+import { abis, ErrorFragment } from "@bosonprotocol/common";
+import { BaseCoreSDK } from "./../mixins/base-core-sdk";
+
+export class ErrorMixin extends BaseCoreSDK {
+  public parseError(error: object): object {
+    return { ...error, decoded: this.recurseParseError(error) };
+  }
+
+  private recurseParseError(error: object): string | undefined {
+    if (this.isValidError(error)) {
+      return this.decodeError(error["data"]);
+    }
+    if (error["error"]) {
+      return this.recurseParseError(error["error"]);
+    }
+    return undefined;
+  }
+
+  private isValidError(error: object): boolean {
+    return error["data"] && /^0x[0-9a-fA-F]{8}$/.test(error["data"]);
+  }
+
+  private decodeError(data: string): string | undefined {
+    this.parseAbis();
+    const error = this._errorsMap.get(data.toLowerCase());
+    return error?.name;
+  }
+
+  private parseAbis() {
+    if (this._errorsMap.size === 0) {
+      Object.keys(abis).forEach((abi) => {
+        const iface = new Interface(abis[abi]);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Object.keys(iface.errors).forEach((error) => {
+          const sigHash = iface.getSighash(error);
+          this._errorsMap.set(
+            sigHash.toLowerCase(),
+            iface.errors[error] as ErrorFragment
+          );
+        });
+      });
+    }
+  }
+}

--- a/packages/core-sdk/src/exchanges/mixin.ts
+++ b/packages/core-sdk/src/exchanges/mixin.ts
@@ -1,7 +1,7 @@
 import { BaseCoreSDK } from "./../mixins/base-core-sdk";
 import * as subgraph from "../subgraph";
 import { TransactionResponse, Log } from "@bosonprotocol/common";
-import { BigNumberish } from "@ethersproject/bignumber";
+import { BigNumberish, BigNumber } from "@ethersproject/bignumber";
 import { getValueFromLogs } from "../utils/logs";
 import {
   commitToOffer,
@@ -207,5 +207,22 @@ export class ExchangesMixin extends BaseCoreSDK {
       exchangeId,
       subgraphUrl: this._subgraphUrl
     });
+  }
+
+  public getExchangeTokenId(
+    exchangeId: BigNumberish,
+    offerId: BigNumberish
+  ): BigNumber {
+    // Since v2.2.1, tokenId = exchangeId | offerId << 128
+    return BigNumber.from(offerId).shl(128).add(exchangeId);
+  }
+
+  public parseTokenId(tokenId: BigNumberish): {
+    offerId: BigNumber;
+    exchangeId: BigNumber;
+  } {
+    const offerId = BigNumber.from(tokenId).shr(128);
+    const exchangeId = BigNumber.from(tokenId).mask(128);
+    return { offerId, exchangeId };
   }
 }

--- a/packages/core-sdk/src/metadata/storeMetadataItems.ts
+++ b/packages/core-sdk/src/metadata/storeMetadataItems.ts
@@ -11,7 +11,7 @@ export async function storeMetadataItems(args: {
       const offerMetadata = await args.metadataStorage?.getMetadata(
         offerToCreate.metadataUri
       );
-      if (offerMetadata.type === "BUNDLE") {
+      if (offerMetadata?.type === "BUNDLE") {
         await Promise.all(
           offerMetadata.items.map((item) => {
             return storeMetadataOnTheGraph({

--- a/packages/core-sdk/src/mixins/base-core-sdk.ts
+++ b/packages/core-sdk/src/mixins/base-core-sdk.ts
@@ -3,7 +3,8 @@ import {
   MetadataStorage,
   MetaTxConfig,
   ContractAddresses,
-  Lens
+  Lens,
+  ErrorFragment
 } from "@bosonprotocol/common";
 import { TokenInfoManager } from "../utils/tokenInfoManager";
 
@@ -16,6 +17,8 @@ export class BaseCoreSDK {
   protected _protocolDiamond: string;
   protected _chainId: number;
   protected _tokenInfoManager: TokenInfoManager;
+
+  protected _errorsMap = new Map<string, ErrorFragment>();
 
   protected _metaTxConfig?: Partial<MetaTxConfig>;
   protected _lens?: Lens;

--- a/packages/core-sdk/src/subgraph.ts
+++ b/packages/core-sdk/src/subgraph.ts
@@ -693,7 +693,6 @@ export enum BaseMetadataEntity_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -1237,7 +1236,6 @@ export enum BundleMetadataEntity_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -1322,6 +1320,76 @@ export enum Buyer_OrderBy {
   ID = "id",
   LOGS = "logs",
   WALLET = "wallet"
+}
+
+/**
+ * Collection Contract
+ *
+ */
+export type CollectionContract = {
+  __typename?: "CollectionContract";
+  address: Scalars["Bytes"]["output"];
+  collection: OfferCollection;
+  contractUri: Scalars["String"]["output"];
+  id: Scalars["ID"]["output"];
+};
+
+export type CollectionContract_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  address?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_contains?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_gt?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_gte?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_in?: InputMaybe<Array<Scalars["Bytes"]["input"]>>;
+  address_lt?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_lte?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_not?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_not_contains?: InputMaybe<Scalars["Bytes"]["input"]>;
+  address_not_in?: InputMaybe<Array<Scalars["Bytes"]["input"]>>;
+  and?: InputMaybe<Array<InputMaybe<CollectionContract_Filter>>>;
+  collection_?: InputMaybe<OfferCollection_Filter>;
+  contractUri?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_contains?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_ends_with?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_gt?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_gte?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  contractUri_lt?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_lte?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_not?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  contractUri_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_starts_with?: InputMaybe<Scalars["String"]["input"]>;
+  contractUri_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  id?: InputMaybe<Scalars["ID"]["input"]>;
+  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
+  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
+  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
+  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
+  id_not?: InputMaybe<Scalars["ID"]["input"]>;
+  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  or?: InputMaybe<Array<InputMaybe<CollectionContract_Filter>>>;
+};
+
+export enum CollectionContract_OrderBy {
+  ADDRESS = "address",
+  COLLECTION = "collection",
+  COLLECTION__COLLECTIONINDEX = "collection__collectionIndex",
+  COLLECTION__EXTERNALID = "collection__externalId",
+  COLLECTION__EXTERNALIDHASH = "collection__externalIdHash",
+  COLLECTION__ID = "collection__id",
+  COLLECTION__SELLERID = "collection__sellerId",
+  CONTRACTURI = "contractUri",
+  ID = "id"
 }
 
 /**
@@ -2434,7 +2502,6 @@ export enum Dispute_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -3150,7 +3217,6 @@ export enum Exchange_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -4043,7 +4109,6 @@ export enum MetadataInterface_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -4649,7 +4714,7 @@ export type OfferRoyaltyInfosArgs = {
  */
 export type OfferCollection = {
   __typename?: "OfferCollection";
-  collectionAddress: Scalars["Bytes"]["output"];
+  collectionContract: CollectionContract;
   collectionIndex: Scalars["BigInt"]["output"];
   externalId: Scalars["String"]["output"];
   externalIdHash: Scalars["Bytes"]["output"];
@@ -4676,16 +4741,35 @@ export type OfferCollection_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<OfferCollection_Filter>>>;
-  collectionAddress?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_contains?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_gt?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_gte?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_in?: InputMaybe<Array<Scalars["Bytes"]["input"]>>;
-  collectionAddress_lt?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_lte?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_not?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_not_contains?: InputMaybe<Scalars["Bytes"]["input"]>;
-  collectionAddress_not_in?: InputMaybe<Array<Scalars["Bytes"]["input"]>>;
+  collectionContract?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_?: InputMaybe<CollectionContract_Filter>;
+  collectionContract_contains?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_ends_with?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_gt?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_gte?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  collectionContract_lt?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_lte?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_not?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_not_contains_nocase?: InputMaybe<
+    Scalars["String"]["input"]
+  >;
+  collectionContract_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_not_ends_with_nocase?: InputMaybe<
+    Scalars["String"]["input"]
+  >;
+  collectionContract_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  collectionContract_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_not_starts_with_nocase?: InputMaybe<
+    Scalars["String"]["input"]
+  >;
+  collectionContract_starts_with?: InputMaybe<Scalars["String"]["input"]>;
+  collectionContract_starts_with_nocase?: InputMaybe<
+    Scalars["String"]["input"]
+  >;
   collectionIndex?: InputMaybe<Scalars["BigInt"]["input"]>;
   collectionIndex_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
   collectionIndex_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
@@ -4787,7 +4871,10 @@ export type OfferCollection_Filter = {
 };
 
 export enum OfferCollection_OrderBy {
-  COLLECTIONADDRESS = "collectionAddress",
+  COLLECTIONCONTRACT = "collectionContract",
+  COLLECTIONCONTRACT__ADDRESS = "collectionContract__address",
+  COLLECTIONCONTRACT__CONTRACTURI = "collectionContract__contractUri",
+  COLLECTIONCONTRACT__ID = "collectionContract__id",
   COLLECTIONINDEX = "collectionIndex",
   EXTERNALID = "externalId",
   EXTERNALIDHASH = "externalIdHash",
@@ -4808,7 +4895,6 @@ export enum OfferCollection_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -5405,7 +5491,6 @@ export enum Offer_OrderBy {
   BUYERCANCELPENALTY = "buyerCancelPenalty",
   COLLECTION = "collection",
   COLLECTIONINDEX = "collectionIndex",
-  COLLECTION__COLLECTIONADDRESS = "collection__collectionAddress",
   COLLECTION__COLLECTIONINDEX = "collection__collectionIndex",
   COLLECTION__EXTERNALID = "collection__externalId",
   COLLECTION__EXTERNALIDHASH = "collection__externalIdHash",
@@ -5491,7 +5576,6 @@ export enum Offer_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -5734,7 +5818,6 @@ export enum PendingSeller_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -7208,7 +7291,6 @@ export enum ProductV1MetadataEntity_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -9772,7 +9854,6 @@ export enum ProductV1Seller_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -10229,6 +10310,8 @@ export type Query = {
   bundleMetadataEntity?: Maybe<BundleMetadataEntity>;
   buyer?: Maybe<Buyer>;
   buyers: Array<Buyer>;
+  collectionContract?: Maybe<CollectionContract>;
+  collectionContracts: Array<CollectionContract>;
   conditionEntities: Array<ConditionEntity>;
   conditionEntity?: Maybe<ConditionEntity>;
   conditionalCommitAuthorizedEventLog?: Maybe<ConditionalCommitAuthorizedEventLog>;
@@ -10430,6 +10513,22 @@ export type QueryBuyersArgs = {
   skip?: InputMaybe<Scalars["Int"]["input"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Buyer_Filter>;
+};
+
+export type QueryCollectionContractArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars["ID"]["input"];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+export type QueryCollectionContractsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<CollectionContract_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<CollectionContract_Filter>;
 };
 
 export type QueryConditionEntitiesArgs = {
@@ -11686,7 +11785,6 @@ export enum RoyaltyRecipientXSeller_OrderBy {
   SELLER__AUTHTOKENID = "seller__authTokenId",
   SELLER__AUTHTOKENTYPE = "seller__authTokenType",
   SELLER__CLERK = "seller__clerk",
-  SELLER__CONTRACTURI = "seller__contractURI",
   SELLER__ID = "seller__id",
   SELLER__METADATAURI = "seller__metadataUri",
   SELLER__SELLERID = "seller__sellerId",
@@ -12036,7 +12134,6 @@ export type Seller = Account & {
   authTokenType: Scalars["Int"]["output"];
   clerk: Scalars["Bytes"]["output"];
   collections: Array<OfferCollection>;
-  contractURI: Scalars["String"]["output"];
   exchanges: Array<Exchange>;
   funds: Array<FundsEntity>;
   id: Scalars["ID"]["output"];
@@ -12705,26 +12802,6 @@ export type Seller_Filter = {
   clerk_not_contains?: InputMaybe<Scalars["Bytes"]["input"]>;
   clerk_not_in?: InputMaybe<Array<Scalars["Bytes"]["input"]>>;
   collections_?: InputMaybe<OfferCollection_Filter>;
-  contractURI?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_contains?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_gt?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_gte?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  contractURI_lt?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_lte?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_not?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  contractURI_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  contractURI_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
   exchanges_?: InputMaybe<Exchange_Filter>;
   funds_?: InputMaybe<FundsEntity_Filter>;
   id?: InputMaybe<Scalars["ID"]["input"]>;
@@ -12819,7 +12896,6 @@ export enum Seller_OrderBy {
   AUTHTOKENTYPE = "authTokenType",
   CLERK = "clerk",
   COLLECTIONS = "collections",
-  CONTRACTURI = "contractURI",
   EXCHANGES = "exchanges",
   FUNDS = "funds",
   ID = "id",
@@ -12865,6 +12941,8 @@ export type Subscription = {
   bundleMetadataEntity?: Maybe<BundleMetadataEntity>;
   buyer?: Maybe<Buyer>;
   buyers: Array<Buyer>;
+  collectionContract?: Maybe<CollectionContract>;
+  collectionContracts: Array<CollectionContract>;
   conditionEntities: Array<ConditionEntity>;
   conditionEntity?: Maybe<ConditionEntity>;
   conditionalCommitAuthorizedEventLog?: Maybe<ConditionalCommitAuthorizedEventLog>;
@@ -13066,6 +13144,22 @@ export type SubscriptionBuyersArgs = {
   skip?: InputMaybe<Scalars["Int"]["input"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Buyer_Filter>;
+};
+
+export type SubscriptionCollectionContractArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars["ID"]["input"];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+export type SubscriptionCollectionContractsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<CollectionContract_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<CollectionContract_Filter>;
 };
 
 export type SubscriptionConditionEntitiesArgs = {
@@ -14278,16 +14372,19 @@ export type GetSellerByIdQueryQuery = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     collections: Array<{
       __typename?: "OfferCollection";
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -14412,7 +14509,6 @@ export type GetSellerByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -14492,9 +14588,13 @@ export type GetSellerByIdQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -14628,7 +14728,6 @@ export type GetSellerByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -14863,7 +14962,6 @@ export type GetSellerByIdQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -15241,7 +15339,6 @@ export type GetSellerByIdQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -15382,7 +15479,6 @@ export type GetSellerByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -15545,7 +15641,6 @@ export type GetSellerByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -15811,16 +15906,19 @@ export type GetSellersQueryQuery = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     collections: Array<{
       __typename?: "OfferCollection";
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -15945,7 +16043,6 @@ export type GetSellersQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -16025,9 +16122,13 @@ export type GetSellersQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -16161,7 +16262,6 @@ export type GetSellersQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -16396,7 +16496,6 @@ export type GetSellersQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -16774,7 +16873,6 @@ export type GetSellersQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -16915,7 +17013,6 @@ export type GetSellersQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -17078,7 +17175,6 @@ export type GetSellersQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -17388,7 +17484,6 @@ export type GetBuyerByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -17636,7 +17731,6 @@ export type GetBuyersQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -17911,7 +18005,6 @@ export type GetDisputeResolverByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -17991,9 +18084,13 @@ export type GetDisputeResolverByIdQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -18127,7 +18224,6 @@ export type GetDisputeResolverByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -18362,7 +18458,6 @@ export type GetDisputeResolverByIdQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -18740,7 +18835,6 @@ export type GetDisputeResolverByIdQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -18881,7 +18975,6 @@ export type GetDisputeResolverByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -19216,7 +19309,6 @@ export type GetDisputeResolversQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -19296,9 +19388,13 @@ export type GetDisputeResolversQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -19432,7 +19528,6 @@ export type GetDisputeResolversQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -19667,7 +19762,6 @@ export type GetDisputeResolversQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -20045,7 +20139,6 @@ export type GetDisputeResolversQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -20186,7 +20279,6 @@ export type GetDisputeResolversQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -20438,7 +20530,6 @@ export type GetOfferCollectionsQueryQuery = {
     id: string;
     sellerId: string;
     collectionIndex: string;
-    collectionAddress: string;
     externalIdHash: string;
     externalId: string;
     seller: {
@@ -20452,7 +20543,6 @@ export type GetOfferCollectionsQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -20618,7 +20708,6 @@ export type GetOfferCollectionsQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -20698,9 +20787,13 @@ export type GetOfferCollectionsQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -20834,7 +20927,6 @@ export type GetOfferCollectionsQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -21069,7 +21161,6 @@ export type GetOfferCollectionsQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -21447,7 +21538,6 @@ export type GetOfferCollectionsQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -21588,7 +21678,6 @@ export type GetOfferCollectionsQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -21705,6 +21794,11 @@ export type GetOfferCollectionsQueryQuery = {
         owner: string;
       } | null;
     }>;
+    collectionContract: {
+      __typename?: "CollectionContract";
+      address: string;
+      contractUri: string;
+    };
     metadata?: {
       __typename?: "NftContractMetadata";
       id: string;
@@ -21739,7 +21833,6 @@ export type OfferCollectionFieldsFragment = {
   id: string;
   sellerId: string;
   collectionIndex: string;
-  collectionAddress: string;
   externalIdHash: string;
   externalId: string;
   seller: {
@@ -21753,7 +21846,6 @@ export type OfferCollectionFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -21919,7 +22011,6 @@ export type OfferCollectionFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -21999,9 +22090,13 @@ export type OfferCollectionFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -22135,7 +22230,6 @@ export type OfferCollectionFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -22368,7 +22462,6 @@ export type OfferCollectionFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -22736,7 +22829,6 @@ export type OfferCollectionFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -22877,7 +22969,6 @@ export type OfferCollectionFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -22994,6 +23085,11 @@ export type OfferCollectionFieldsFragment = {
       owner: string;
     } | null;
   }>;
+  collectionContract: {
+    __typename?: "CollectionContract";
+    address: string;
+    contractUri: string;
+  };
   metadata?: {
     __typename?: "NftContractMetadata";
     id: string;
@@ -23011,9 +23107,13 @@ export type BaseOfferCollectionFieldsFragment = {
   id: string;
   sellerId: string;
   collectionIndex: string;
-  collectionAddress: string;
   externalIdHash: string;
   externalId: string;
+  collectionContract: {
+    __typename?: "CollectionContract";
+    address: string;
+    contractUri: string;
+  };
   metadata?: {
     __typename?: "NftContractMetadata";
     id: string;
@@ -23037,16 +23137,19 @@ export type SellerFieldsFragment = {
   authTokenType: number;
   voucherCloneAddress: string;
   active: boolean;
-  contractURI: string;
   metadataUri: string;
   collections: Array<{
     __typename?: "OfferCollection";
     id: string;
     sellerId: string;
     collectionIndex: string;
-    collectionAddress: string;
     externalIdHash: string;
     externalId: string;
+    collectionContract: {
+      __typename?: "CollectionContract";
+      address: string;
+      contractUri: string;
+    };
     metadata?: {
       __typename?: "NftContractMetadata";
       id: string;
@@ -23171,7 +23274,6 @@ export type SellerFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -23251,9 +23353,13 @@ export type SellerFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -23387,7 +23493,6 @@ export type SellerFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -23620,7 +23725,6 @@ export type SellerFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -23988,7 +24092,6 @@ export type SellerFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -24129,7 +24232,6 @@ export type SellerFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -24292,7 +24394,6 @@ export type SellerFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -24572,7 +24673,6 @@ export type BaseSellerFieldsFragment = {
   authTokenType: number;
   voucherCloneAddress: string;
   active: boolean;
-  contractURI: string;
   metadataUri: string;
   royaltyRecipients?: Array<{
     __typename?: "RoyaltyRecipientXSeller";
@@ -24729,7 +24829,6 @@ export type BuyerFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -24992,7 +25091,6 @@ export type DisputeResolverFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -25072,9 +25170,13 @@ export type DisputeResolverFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -25208,7 +25310,6 @@ export type DisputeResolverFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -25441,7 +25542,6 @@ export type DisputeResolverFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -25809,7 +25909,6 @@ export type DisputeResolverFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -25950,7 +26049,6 @@ export type DisputeResolverFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -26301,7 +26399,6 @@ export type GetDisputeByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -26388,7 +26485,6 @@ export type GetDisputeByIdQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -26542,7 +26638,6 @@ export type GetDisputesQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -26629,7 +26724,6 @@ export type GetDisputesQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -26773,7 +26867,6 @@ export type DisputeFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -26860,7 +26953,6 @@ export type DisputeFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -27075,7 +27167,6 @@ export type GetExchangeTokenByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -27155,9 +27246,13 @@ export type GetExchangeTokenByIdQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -27291,7 +27386,6 @@ export type GetExchangeTokenByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -27526,7 +27620,6 @@ export type GetExchangeTokenByIdQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -27904,7 +27997,6 @@ export type GetExchangeTokenByIdQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -28045,7 +28137,6 @@ export type GetExchangeTokenByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -28291,7 +28382,6 @@ export type GetExchangeTokensQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -28371,9 +28461,13 @@ export type GetExchangeTokensQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -28507,7 +28601,6 @@ export type GetExchangeTokensQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -28742,7 +28835,6 @@ export type GetExchangeTokensQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -29120,7 +29212,6 @@ export type GetExchangeTokensQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -29261,7 +29352,6 @@ export type GetExchangeTokensQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -29485,7 +29575,6 @@ export type ExchangeTokenFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -29565,9 +29654,13 @@ export type ExchangeTokenFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -29701,7 +29794,6 @@ export type ExchangeTokenFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -29934,7 +30026,6 @@ export type ExchangeTokenFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -30302,7 +30393,6 @@ export type ExchangeTokenFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -30443,7 +30533,6 @@ export type ExchangeTokenFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -30850,7 +30939,6 @@ export type GetExchangeByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -30930,9 +31018,13 @@ export type GetExchangeByIdQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -31066,7 +31158,6 @@ export type GetExchangeByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -31301,7 +31392,6 @@ export type GetExchangeByIdQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -31679,7 +31769,6 @@ export type GetExchangeByIdQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -31820,7 +31909,6 @@ export type GetExchangeByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -31969,7 +32057,6 @@ export type GetExchangeByIdQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -32162,7 +32249,6 @@ export type GetExchangesQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -32242,9 +32328,13 @@ export type GetExchangesQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -32378,7 +32468,6 @@ export type GetExchangesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -32613,7 +32702,6 @@ export type GetExchangesQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -32991,7 +33079,6 @@ export type GetExchangesQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -33132,7 +33219,6 @@ export type GetExchangesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -33281,7 +33367,6 @@ export type GetExchangesQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -33464,7 +33549,6 @@ export type ExchangeFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -33544,9 +33628,13 @@ export type ExchangeFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -33680,7 +33768,6 @@ export type ExchangeFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -33913,7 +34000,6 @@ export type ExchangeFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -34281,7 +34367,6 @@ export type ExchangeFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -34422,7 +34507,6 @@ export type ExchangeFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -34566,7 +34650,6 @@ export type ExchangeFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -34684,7 +34767,6 @@ export type BaseExchangeFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -35005,7 +35087,6 @@ export type GetBaseMetadataEntityByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -35085,9 +35166,13 @@ export type GetBaseMetadataEntityByIdQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -35221,7 +35306,6 @@ export type GetBaseMetadataEntityByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -35456,7 +35540,6 @@ export type GetBaseMetadataEntityByIdQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -35834,7 +35917,6 @@ export type GetBaseMetadataEntityByIdQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -35975,7 +36057,6 @@ export type GetBaseMetadataEntityByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -36103,7 +36184,6 @@ export type GetBaseMetadataEntityByIdQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -36322,7 +36402,6 @@ export type GetBaseMetadataEntitiesQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -36402,9 +36481,13 @@ export type GetBaseMetadataEntitiesQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -36538,7 +36621,6 @@ export type GetBaseMetadataEntitiesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -36773,7 +36855,6 @@ export type GetBaseMetadataEntitiesQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -37151,7 +37232,6 @@ export type GetBaseMetadataEntitiesQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -37292,7 +37372,6 @@ export type GetBaseMetadataEntitiesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -37420,7 +37499,6 @@ export type GetBaseMetadataEntitiesQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -37629,7 +37707,6 @@ export type BaseMetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -37709,9 +37786,13 @@ export type BaseMetadataEntityFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -37845,7 +37926,6 @@ export type BaseMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -38078,7 +38158,6 @@ export type BaseMetadataEntityFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -38446,7 +38525,6 @@ export type BaseMetadataEntityFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -38587,7 +38665,6 @@ export type BaseMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -38715,7 +38792,6 @@ export type BaseMetadataEntityFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -38923,7 +38999,6 @@ export type BaseBaseMetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -39003,9 +39078,13 @@ export type BaseBaseMetadataEntityFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -39139,7 +39218,6 @@ export type BaseBaseMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -39372,7 +39450,6 @@ export type BaseBaseMetadataEntityFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -39740,7 +39817,6 @@ export type BaseBaseMetadataEntityFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -39881,7 +39957,6 @@ export type BaseBaseMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -40009,7 +40084,6 @@ export type BaseBaseMetadataEntityFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -40213,7 +40287,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -40352,7 +40425,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -40432,9 +40504,13 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -40568,7 +40644,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -40803,7 +40878,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -41181,7 +41255,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -41322,7 +41395,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -41450,7 +41522,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -41569,7 +41640,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -41804,7 +41874,6 @@ export type GetBundleMetadataEntityByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -42104,7 +42173,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -42243,7 +42311,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -42323,9 +42390,13 @@ export type GetBundleMetadataEntitiesQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -42459,7 +42530,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -42694,7 +42764,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -43072,7 +43141,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -43213,7 +43281,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -43341,7 +43408,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -43460,7 +43526,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -43695,7 +43760,6 @@ export type GetBundleMetadataEntitiesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -43985,7 +44049,6 @@ export type BundleMetadataEntityFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -44124,7 +44187,6 @@ export type BundleMetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -44204,9 +44266,13 @@ export type BundleMetadataEntityFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -44340,7 +44406,6 @@ export type BundleMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -44573,7 +44638,6 @@ export type BundleMetadataEntityFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -44941,7 +45005,6 @@ export type BundleMetadataEntityFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -45082,7 +45145,6 @@ export type BundleMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -45210,7 +45272,6 @@ export type BundleMetadataEntityFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -45329,7 +45390,6 @@ export type BundleMetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -45564,7 +45624,6 @@ export type BundleMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -45853,7 +45912,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -45992,7 +46050,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -46072,9 +46129,13 @@ export type BaseBundleMetadataEntityFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -46208,7 +46269,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -46441,7 +46501,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -46809,7 +46868,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -46950,7 +47008,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -47078,7 +47135,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -47197,7 +47253,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -47432,7 +47487,6 @@ export type BaseBundleMetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -47755,7 +47809,6 @@ export type GetProductV1ProductsQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -47977,7 +48030,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -48116,7 +48168,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -48196,9 +48247,13 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
           id: string;
           sellerId: string;
           collectionIndex: string;
-          collectionAddress: string;
           externalIdHash: string;
           externalId: string;
+          collectionContract: {
+            __typename?: "CollectionContract";
+            address: string;
+            contractUri: string;
+          };
           metadata?: {
             __typename?: "NftContractMetadata";
             id: string;
@@ -48332,7 +48387,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -48567,7 +48621,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                           authTokenType: number;
                           voucherCloneAddress: string;
                           active: boolean;
-                          contractURI: string;
                           metadataUri: string;
                           royaltyRecipients?: Array<{
                             __typename?: "RoyaltyRecipientXSeller";
@@ -48945,7 +48998,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -49086,7 +49138,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -49317,7 +49368,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -49456,7 +49506,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -49536,9 +49585,13 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
             id: string;
             sellerId: string;
             collectionIndex: string;
-            collectionAddress: string;
             externalIdHash: string;
             externalId: string;
+            collectionContract: {
+              __typename?: "CollectionContract";
+              address: string;
+              contractUri: string;
+            };
             metadata?: {
               __typename?: "NftContractMetadata";
               id: string;
@@ -49672,7 +49725,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -49907,7 +49959,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                             authTokenType: number;
                             voucherCloneAddress: string;
                             active: boolean;
-                            contractURI: string;
                             metadataUri: string;
                             royaltyRecipients?: Array<{
                               __typename?: "RoyaltyRecipientXSeller";
@@ -50285,7 +50336,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -50426,7 +50476,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -50554,7 +50603,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -50673,7 +50721,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -50912,7 +50959,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -51182,7 +51228,6 @@ export type GetProductV1ProductsWithVariantsQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -51404,7 +51449,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -51543,7 +51587,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -51623,9 +51666,13 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
           id: string;
           sellerId: string;
           collectionIndex: string;
-          collectionAddress: string;
           externalIdHash: string;
           externalId: string;
+          collectionContract: {
+            __typename?: "CollectionContract";
+            address: string;
+            contractUri: string;
+          };
           metadata?: {
             __typename?: "NftContractMetadata";
             id: string;
@@ -51759,7 +51806,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -51994,7 +52040,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                           authTokenType: number;
                           voucherCloneAddress: string;
                           active: boolean;
-                          contractURI: string;
                           metadataUri: string;
                           royaltyRecipients?: Array<{
                             __typename?: "RoyaltyRecipientXSeller";
@@ -52372,7 +52417,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -52513,7 +52557,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -52744,7 +52787,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -52883,7 +52925,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -52963,9 +53004,13 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
             id: string;
             sellerId: string;
             collectionIndex: string;
-            collectionAddress: string;
             externalIdHash: string;
             externalId: string;
+            collectionContract: {
+              __typename?: "CollectionContract";
+              address: string;
+              contractUri: string;
+            };
             metadata?: {
               __typename?: "NftContractMetadata";
               id: string;
@@ -53099,7 +53144,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -53334,7 +53378,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                             authTokenType: number;
                             voucherCloneAddress: string;
                             active: boolean;
-                            contractURI: string;
                             metadataUri: string;
                             royaltyRecipients?: Array<{
                               __typename?: "RoyaltyRecipientXSeller";
@@ -53712,7 +53755,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -53853,7 +53895,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -53981,7 +54022,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -54100,7 +54140,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -54339,7 +54378,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -54609,7 +54647,6 @@ export type GetAllProductsWithNotVoidedVariantsQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -54845,7 +54882,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -54984,7 +55020,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -55064,9 +55099,13 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -55200,7 +55239,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -55435,7 +55473,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -55813,7 +55850,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -55954,7 +55990,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -56082,7 +56117,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -56280,7 +56314,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -56421,7 +56454,6 @@ export type GetProductV1MetadataEntityByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -56627,7 +56659,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -56766,7 +56797,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -56846,9 +56876,13 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -56982,7 +57016,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -57217,7 +57250,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -57595,7 +57627,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -57736,7 +57767,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -57864,7 +57894,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -58062,7 +58091,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -58203,7 +58231,6 @@ export type GetProductV1MetadataEntitiesQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -58399,7 +58426,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -58538,7 +58564,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -58618,9 +58643,13 @@ export type ProductV1MetadataEntityFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -58754,7 +58783,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -58987,7 +59015,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -59355,7 +59382,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -59496,7 +59522,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -59624,7 +59649,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -59822,7 +59846,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -59963,7 +59986,6 @@ export type ProductV1MetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -60158,7 +60180,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -60297,7 +60318,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -60377,9 +60397,13 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -60513,7 +60537,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -60746,7 +60769,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -61114,7 +61136,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -61255,7 +61276,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -61383,7 +61403,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -61581,7 +61600,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -61722,7 +61740,6 @@ export type BaseProductV1MetadataEntityFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -61933,7 +61950,6 @@ export type BaseProductV1ProductFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -62144,7 +62160,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -62283,7 +62298,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -62363,9 +62377,13 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -62499,7 +62517,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -62734,7 +62751,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -63112,7 +63128,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -63253,7 +63268,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -63484,7 +63498,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -63623,7 +63636,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -63703,9 +63715,13 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
           id: string;
           sellerId: string;
           collectionIndex: string;
-          collectionAddress: string;
           externalIdHash: string;
           externalId: string;
+          collectionContract: {
+            __typename?: "CollectionContract";
+            address: string;
+            contractUri: string;
+          };
           metadata?: {
             __typename?: "NftContractMetadata";
             id: string;
@@ -63839,7 +63855,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -64074,7 +64089,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                           authTokenType: number;
                           voucherCloneAddress: string;
                           active: boolean;
-                          contractURI: string;
                           metadataUri: string;
                           royaltyRecipients?: Array<{
                             __typename?: "RoyaltyRecipientXSeller";
@@ -64452,7 +64466,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -64593,7 +64606,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -64721,7 +64733,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -64840,7 +64851,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -65079,7 +65089,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -65349,7 +65358,6 @@ export type BaseProductV1ProductWithVariantsFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -65560,7 +65568,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -65699,7 +65706,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -65779,9 +65785,13 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
         id: string;
         sellerId: string;
         collectionIndex: string;
-        collectionAddress: string;
         externalIdHash: string;
         externalId: string;
+        collectionContract: {
+          __typename?: "CollectionContract";
+          address: string;
+          contractUri: string;
+        };
         metadata?: {
           __typename?: "NftContractMetadata";
           id: string;
@@ -65915,7 +65925,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -66150,7 +66159,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                         authTokenType: number;
                         voucherCloneAddress: string;
                         active: boolean;
-                        contractURI: string;
                         metadataUri: string;
                         royaltyRecipients?: Array<{
                           __typename?: "RoyaltyRecipientXSeller";
@@ -66528,7 +66536,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -66669,7 +66676,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -66900,7 +66906,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -67039,7 +67044,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -67119,9 +67123,13 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
           id: string;
           sellerId: string;
           collectionIndex: string;
-          collectionAddress: string;
           externalIdHash: string;
           externalId: string;
+          collectionContract: {
+            __typename?: "CollectionContract";
+            address: string;
+            contractUri: string;
+          };
           metadata?: {
             __typename?: "NftContractMetadata";
             id: string;
@@ -67255,7 +67263,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -67490,7 +67497,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                           authTokenType: number;
                           voucherCloneAddress: string;
                           active: boolean;
-                          contractURI: string;
                           metadataUri: string;
                           royaltyRecipients?: Array<{
                             __typename?: "RoyaltyRecipientXSeller";
@@ -67868,7 +67874,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -68009,7 +68014,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -68137,7 +68141,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -68256,7 +68259,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
           authTokenType: number;
           voucherCloneAddress: string;
           active: boolean;
-          contractURI: string;
           metadataUri: string;
           royaltyRecipients?: Array<{
             __typename?: "RoyaltyRecipientXSeller";
@@ -68495,7 +68497,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
                   authTokenType: number;
                   voucherCloneAddress: string;
                   active: boolean;
-                  contractURI: string;
                   metadataUri: string;
                   royaltyRecipients?: Array<{
                     __typename?: "RoyaltyRecipientXSeller";
@@ -68765,7 +68766,6 @@ export type BaseProductV1ProductWithNotVoidedVariantsFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -68948,7 +68948,6 @@ export type BaseProductV1SellerFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -69193,7 +69192,6 @@ export type GetOfferByIdQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -69332,7 +69330,6 @@ export type GetOfferByIdQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -69412,9 +69409,13 @@ export type GetOfferByIdQueryQuery = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -69548,7 +69549,6 @@ export type GetOfferByIdQueryQuery = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -69781,7 +69781,6 @@ export type GetOfferByIdQueryQuery = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -70149,7 +70148,6 @@ export type GetOfferByIdQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -70290,7 +70288,6 @@ export type GetOfferByIdQueryQuery = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -70499,7 +70496,6 @@ export type GetOffersQueryQuery = {
         authTokenType: number;
         voucherCloneAddress: string;
         active: boolean;
-        contractURI: string;
         metadataUri: string;
         royaltyRecipients?: Array<{
           __typename?: "RoyaltyRecipientXSeller";
@@ -70638,7 +70634,6 @@ export type GetOffersQueryQuery = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -70718,9 +70713,13 @@ export type GetOffersQueryQuery = {
       id: string;
       sellerId: string;
       collectionIndex: string;
-      collectionAddress: string;
       externalIdHash: string;
       externalId: string;
+      collectionContract: {
+        __typename?: "CollectionContract";
+        address: string;
+        contractUri: string;
+      };
       metadata?: {
         __typename?: "NftContractMetadata";
         id: string;
@@ -70854,7 +70853,6 @@ export type GetOffersQueryQuery = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -71087,7 +71085,6 @@ export type GetOffersQueryQuery = {
                       authTokenType: number;
                       voucherCloneAddress: string;
                       active: boolean;
-                      contractURI: string;
                       metadataUri: string;
                       royaltyRecipients?: Array<{
                         __typename?: "RoyaltyRecipientXSeller";
@@ -71455,7 +71452,6 @@ export type GetOffersQueryQuery = {
                 authTokenType: number;
                 voucherCloneAddress: string;
                 active: boolean;
-                contractURI: string;
                 metadataUri: string;
                 royaltyRecipients?: Array<{
                   __typename?: "RoyaltyRecipientXSeller";
@@ -71596,7 +71592,6 @@ export type GetOffersQueryQuery = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -71897,7 +71892,6 @@ export type OfferFieldsFragment = {
       authTokenType: number;
       voucherCloneAddress: string;
       active: boolean;
-      contractURI: string;
       metadataUri: string;
       royaltyRecipients?: Array<{
         __typename?: "RoyaltyRecipientXSeller";
@@ -72036,7 +72030,6 @@ export type OfferFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -72116,9 +72109,13 @@ export type OfferFieldsFragment = {
     id: string;
     sellerId: string;
     collectionIndex: string;
-    collectionAddress: string;
     externalIdHash: string;
     externalId: string;
+    collectionContract: {
+      __typename?: "CollectionContract";
+      address: string;
+      contractUri: string;
+    };
     metadata?: {
       __typename?: "NftContractMetadata";
       id: string;
@@ -72252,7 +72249,6 @@ export type OfferFieldsFragment = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -72485,7 +72481,6 @@ export type OfferFieldsFragment = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -72853,7 +72848,6 @@ export type OfferFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -72994,7 +72988,6 @@ export type OfferFieldsFragment = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -73203,7 +73196,6 @@ export type BaseOfferFieldsFragment = {
     authTokenType: number;
     voucherCloneAddress: string;
     active: boolean;
-    contractURI: string;
     metadataUri: string;
     royaltyRecipients?: Array<{
       __typename?: "RoyaltyRecipientXSeller";
@@ -73283,9 +73275,13 @@ export type BaseOfferFieldsFragment = {
     id: string;
     sellerId: string;
     collectionIndex: string;
-    collectionAddress: string;
     externalIdHash: string;
     externalId: string;
+    collectionContract: {
+      __typename?: "CollectionContract";
+      address: string;
+      contractUri: string;
+    };
     metadata?: {
       __typename?: "NftContractMetadata";
       id: string;
@@ -73419,7 +73415,6 @@ export type BaseOfferFieldsFragment = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -73652,7 +73647,6 @@ export type BaseOfferFieldsFragment = {
                     authTokenType: number;
                     voucherCloneAddress: string;
                     active: boolean;
-                    contractURI: string;
                     metadataUri: string;
                     royaltyRecipients?: Array<{
                       __typename?: "RoyaltyRecipientXSeller";
@@ -74020,7 +74014,6 @@ export type BaseOfferFieldsFragment = {
               authTokenType: number;
               voucherCloneAddress: string;
               active: boolean;
-              contractURI: string;
               metadataUri: string;
               royaltyRecipients?: Array<{
                 __typename?: "RoyaltyRecipientXSeller";
@@ -74161,7 +74154,6 @@ export type BaseOfferFieldsFragment = {
             authTokenType: number;
             voucherCloneAddress: string;
             active: boolean;
-            contractURI: string;
             metadataUri: string;
             royaltyRecipients?: Array<{
               __typename?: "RoyaltyRecipientXSeller";
@@ -74292,7 +74284,10 @@ export const BaseOfferCollectionFieldsFragmentDoc = gql`
     id
     sellerId
     collectionIndex
-    collectionAddress
+    collectionContract {
+      address
+      contractUri
+    }
     externalIdHash
     externalId
     metadata {
@@ -74364,7 +74359,6 @@ export const BaseSellerFieldsFragmentDoc = gql`
     authTokenType
     voucherCloneAddress
     active
-    contractURI
     royaltyRecipients {
       id
       recipient {

--- a/packages/core-sdk/src/subgraph/mixin.ts
+++ b/packages/core-sdk/src/subgraph/mixin.ts
@@ -1,0 +1,70 @@
+import { GraphQLClient, gql } from "graphql-request";
+import { TransactionReceipt, TransactionResponse } from "@bosonprotocol/common";
+import { BaseCoreSDK } from "./../mixins/base-core-sdk";
+
+export class SubgraphMixin extends BaseCoreSDK {
+  public async waitForGraphNodeIndexing(
+    blockNumberOrTransaction?: number | TransactionResponse | TransactionReceipt
+  ) {
+    let blockToWaitFor = 0;
+    if (typeof blockNumberOrTransaction === "number") {
+      blockToWaitFor = blockNumberOrTransaction;
+    } else if (blockNumberOrTransaction?.["blockNumber"]) {
+      blockToWaitFor = (blockNumberOrTransaction as TransactionReceipt)
+        .blockNumber;
+    } else if (blockNumberOrTransaction?.["wait"]) {
+      const txReceipt = await (
+        blockNumberOrTransaction as TransactionResponse
+      ).wait();
+      blockToWaitFor = txReceipt.blockNumber;
+    }
+    if (blockToWaitFor > 0) {
+      let currentBlock = await this.getSubgraphBlockNumber();
+      let oldCurrentBlock = currentBlock;
+      let sameBlockNumber = 0;
+      const MAX_SAME_BLOCK = 20;
+      while (currentBlock < blockToWaitFor) {
+        console.log(
+          `Wait for subgraph indexing (${currentBlock}/${blockToWaitFor})`
+        );
+        await this.wait(1_000);
+        currentBlock = await this.getSubgraphBlockNumber();
+        if (currentBlock === oldCurrentBlock) {
+          if (sameBlockNumber++ >= MAX_SAME_BLOCK) {
+            // Seems that the subgraph does not update its current block
+            console.error(
+              `Seems that the subgraph does not update its current block after ${currentBlock}`
+            );
+            await this.wait(5_000);
+            return;
+          }
+        }
+        oldCurrentBlock = currentBlock;
+      }
+      return;
+    }
+    await this.wait(30_000);
+  }
+
+  public async getSubgraphBlockNumber(): Promise<number> {
+    const client = new GraphQLClient(this._subgraphUrl);
+    const response = await client.request<{
+      _meta?: { block?: { number?: number } };
+    }>(gql`
+      query MyQuery {
+        _meta {
+          block {
+            number
+          }
+        }
+      }
+    `);
+    return response?._meta?.block?.number || 0;
+  }
+
+  protected async wait(ms: number) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+}

--- a/packages/core-sdk/tests/errors/decodeErrors.test.ts
+++ b/packages/core-sdk/tests/errors/decodeErrors.test.ts
@@ -1,0 +1,76 @@
+import { Interface } from "@ethersproject/abi";
+import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
+import { CoreSDK, abis } from "../../src";
+import { ErrorFragment } from "@bosonprotocol/common/src";
+
+const errorsMap = new Map<string, ErrorFragment>();
+const errorHashes: string[] = [];
+
+function parseErrors() {
+  Object.keys(abis).forEach((abi) => {
+    const iface = new Interface(abis[abi]);
+    Object.keys(iface.errors).forEach((error) => {
+      const sigHash = iface.getSighash(error);
+      if (!errorsMap.has(sigHash)) {
+        errorHashes.push(sigHash);
+        errorsMap.set(
+          sigHash,
+          iface.errors[error] as ErrorFragment
+        );  
+      }
+    });
+  });
+}
+
+parseErrors();
+
+let coreSDK: CoreSDK;
+
+beforeEach(() => {
+  coreSDK = CoreSDK.fromDefaultConfig({
+    web3Lib: new MockWeb3LibAdapter(),
+    envName: "testing",
+    configId: "testing-80001-0"
+  });
+  expect(coreSDK).toBeInstanceOf(CoreSDK);
+})
+
+test.each(errorHashes)("decode error %p", (errorHash) => {
+  const random = Math.floor(Math.random() * 4); // random integer between 0 and 3
+  const error = buildError(errorHash, random);
+  const fragment = errorsMap.get(errorHash);
+  expect(fragment).toBeTruthy();
+  const decodedError = coreSDK.parseError(error);
+  expect(decodedError["decoded"]).toBeTruthy();
+  expect(decodedError["decoded"]).toEqual(fragment?.name);
+})
+
+test("decode unknown error code", () => {
+  const random = Math.floor(Math.random() * 4); // random integer between 0 and 3
+  const unknownErrorHash = "0xabcdef01";
+  const found = Array.from(errorsMap.keys()).some((hash) => hash.toLowerCase() === unknownErrorHash.toLowerCase());
+  // be sure the error hash does not exist
+  expect(found).toBe(false);
+  const error = buildError(unknownErrorHash, random);
+  const decodedError = coreSDK.parseError(error);
+  expect(decodedError["decoded"]).toBeFalsy();
+})
+
+test("decode no error code", () => {
+  const error = { dummy: "dummy", error: { dummy: "dummy" } };
+  const decodedError = coreSDK.parseError(error);
+  expect(decodedError["decoded"]).toBeFalsy();
+})
+
+function buildError(errorHash: string, depth: number = 0): object {
+  if (depth > 0) {
+    return {
+      dummy: "dummy",
+      error: buildError(errorHash, depth - 1)
+    }
+  }
+  return {
+    dummy: "dummy",
+    data: errorHash
+  };
+}

--- a/packages/core-sdk/tests/errors/decodeErrors.test.ts
+++ b/packages/core-sdk/tests/errors/decodeErrors.test.ts
@@ -13,10 +13,7 @@ function parseErrors() {
       const sigHash = iface.getSighash(error);
       if (!errorsMap.has(sigHash)) {
         errorHashes.push(sigHash);
-        errorsMap.set(
-          sigHash,
-          iface.errors[error] as ErrorFragment
-        );  
+        errorsMap.set(sigHash, iface.errors[error] as ErrorFragment);
       }
     });
   });
@@ -33,7 +30,7 @@ beforeEach(() => {
     configId: "testing-80001-0"
   });
   expect(coreSDK).toBeInstanceOf(CoreSDK);
-})
+});
 
 test.each(errorHashes)("decode error %p", (errorHash) => {
   const random = Math.floor(Math.random() * 4); // random integer between 0 and 3
@@ -43,31 +40,33 @@ test.each(errorHashes)("decode error %p", (errorHash) => {
   const decodedError = coreSDK.parseError(error);
   expect(decodedError["decoded"]).toBeTruthy();
   expect(decodedError["decoded"]).toEqual(fragment?.name);
-})
+});
 
 test("decode unknown error code", () => {
   const random = Math.floor(Math.random() * 4); // random integer between 0 and 3
   const unknownErrorHash = "0xabcdef01";
-  const found = Array.from(errorsMap.keys()).some((hash) => hash.toLowerCase() === unknownErrorHash.toLowerCase());
+  const found = Array.from(errorsMap.keys()).some(
+    (hash) => hash.toLowerCase() === unknownErrorHash.toLowerCase()
+  );
   // be sure the error hash does not exist
   expect(found).toBe(false);
   const error = buildError(unknownErrorHash, random);
   const decodedError = coreSDK.parseError(error);
   expect(decodedError["decoded"]).toBeFalsy();
-})
+});
 
 test("decode no error code", () => {
   const error = { dummy: "dummy", error: { dummy: "dummy" } };
   const decodedError = coreSDK.parseError(error);
   expect(decodedError["decoded"]).toBeFalsy();
-})
+});
 
-function buildError(errorHash: string, depth: number = 0): object {
+function buildError(errorHash: string, depth = 0): object {
   if (depth > 0) {
     return {
       dummy: "dummy",
       error: buildError(errorHash, depth - 1)
-    }
+    };
   }
   return {
     dummy: "dummy",

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer1.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer1.json
@@ -34,7 +34,6 @@
     "authTokenType": 0,
     "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
     "active": true,
-    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
     "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
     "metadata": {
       "id": "30-seller-metadata",
@@ -362,7 +361,6 @@
           "authTokenType": 0,
           "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
           "active": true,
-          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
           "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
           "metadata": {
             "id": "30-seller-metadata",
@@ -490,7 +488,6 @@
         "authTokenType": 0,
         "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
         "active": true,
-        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
         "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
         "metadata": {
           "id": "30-seller-metadata",

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer2.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer2.json
@@ -34,7 +34,6 @@
     "authTokenType": 0,
     "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
     "active": true,
-    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
     "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
     "metadata": {
       "id": "30-seller-metadata",
@@ -362,7 +361,6 @@
           "authTokenType": 0,
           "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
           "active": true,
-          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
           "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
           "metadata": {
             "id": "30-seller-metadata",
@@ -490,7 +488,6 @@
         "authTokenType": 0,
         "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
         "active": true,
-        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
         "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
         "metadata": {
           "id": "30-seller-metadata",

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer3.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer3.json
@@ -34,7 +34,6 @@
     "authTokenType": 0,
     "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
     "active": true,
-    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
     "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
     "metadata": {
       "id": "30-seller-metadata",
@@ -361,7 +360,6 @@
           "authTokenType": 0,
           "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
           "active": true,
-          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
           "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
           "metadata": {
             "id": "30-seller-metadata",
@@ -489,7 +487,6 @@
         "authTokenType": 0,
         "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
         "active": true,
-        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
         "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
         "metadata": {
           "id": "30-seller-metadata",

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer4.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer4.json
@@ -34,7 +34,6 @@
     "authTokenType": 0,
     "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
     "active": true,
-    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
     "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
     "metadata": {
       "id": "30-seller-metadata",

--- a/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer5.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/invalidOffer5.json
@@ -34,7 +34,6 @@
     "authTokenType": 0,
     "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
     "active": true,
-    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
     "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
     "metadata": {
       "id": "30-seller-metadata",
@@ -362,7 +361,6 @@
           "authTokenType": 0,
           "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
           "active": true,
-          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
           "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
           "metadata": {
             "id": "30-seller-metadata",
@@ -490,7 +488,6 @@
         "authTokenType": 0,
         "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
         "active": true,
-        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
         "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
         "metadata": {
           "id": "30-seller-metadata",

--- a/packages/core-sdk/tests/exchangePolicy/examples/validOffer.json
+++ b/packages/core-sdk/tests/exchangePolicy/examples/validOffer.json
@@ -34,7 +34,6 @@
     "authTokenType": 0,
     "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
     "active": true,
-    "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
     "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
     "metadata": {
       "id": "30-seller-metadata",
@@ -362,7 +361,6 @@
           "authTokenType": 0,
           "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
           "active": true,
-          "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
           "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
           "metadata": {
             "id": "30-seller-metadata",
@@ -490,7 +488,6 @@
         "authTokenType": 0,
         "voucherCloneAddress": "0x87ef301c97c72648bab63c0ea77eddf145d4317b",
         "active": true,
-        "contractURI": "ipfs://QmXV5eGPvsLevPPaSyYwV97yHbY1vPfRKK3Y7mpRKKtQ4d",
         "metadataUri": "ipfs://QmeebkVhK1jgwwX4mKnBSfNv47vqDeeAZ6MZ5SjLUv7c31",
         "metadata": {
           "id": "30-seller-metadata",

--- a/packages/core-sdk/tests/exchanges/tokenId.test.ts
+++ b/packages/core-sdk/tests/exchanges/tokenId.test.ts
@@ -1,0 +1,78 @@
+import { BigNumberish, BigNumber } from "@ethersproject/bignumber";
+import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
+import { CoreSDK, getEnvConfigs } from "../../src";
+import { SUBGRAPH_URL } from "../mocks";
+
+describe("tokenId to exchangeId", () => {
+  const defaultConfig = getEnvConfigs("testing")[0];
+  const coreSDK = new CoreSDK({
+    web3Lib: new MockWeb3LibAdapter(),
+    subgraphUrl: SUBGRAPH_URL,
+    protocolDiamond: defaultConfig.contracts.protocolDiamond,
+    chainId: defaultConfig.chainId
+  });
+  const shiftOfferId = (offerId: BigNumberish): BigNumber =>
+    BigNumber.from(offerId).mul(BigNumber.from(2).pow(128));
+  const LIST: {
+    offerId: BigNumberish;
+    exchangeId: BigNumberish;
+    tokenId: BigNumberish;
+  }[] = [
+    {
+      offerId: 0,
+      exchangeId: 0,
+      tokenId: 0
+    },
+    {
+      offerId: "0",
+      exchangeId: "0",
+      tokenId: "0"
+    },
+    {
+      offerId: 1,
+      exchangeId: 1,
+      tokenId: shiftOfferId(1).add(1)
+    },
+    {
+      offerId: "1",
+      exchangeId: "1",
+      tokenId: shiftOfferId(1).add(1).toString()
+    },
+    {
+      offerId: 10,
+      exchangeId: 20,
+      tokenId: shiftOfferId(10).add(20)
+    },
+    {
+      offerId: 20,
+      exchangeId: 10,
+      tokenId: shiftOfferId(20).add(10)
+    },
+    {
+      offerId: "730",
+      exchangeId: "394",
+      tokenId: "248406127852285078328263463425190794363274"
+    }
+  ];
+
+  describe("exchangeId + offerId => tokenId", () => {
+    test.each(LIST)(
+      `check tokenId %p`,
+      async ({ offerId, exchangeId, tokenId }) => {
+        const _tokenId = coreSDK.getExchangeTokenId(exchangeId, offerId);
+        expect(_tokenId.toString()).toEqual(tokenId.toString());
+      }
+    );
+  });
+  describe("tokenId => exchangeId + offerId", () => {
+    test.each(LIST)(
+      `check {offerId, exchangeId} %p`,
+      async ({ offerId, exchangeId, tokenId }) => {
+        const { offerId: _offerId, exchangeId: _exchangeId } =
+          coreSDK.parseTokenId(tokenId);
+        expect(_offerId.toString()).toEqual(offerId.toString());
+        expect(_exchangeId.toString()).toEqual(exchangeId.toString());
+      }
+    );
+  });
+});

--- a/packages/core-sdk/tests/mocks.ts
+++ b/packages/core-sdk/tests/mocks.ts
@@ -85,7 +85,6 @@ export function mockRawOfferFromSubgraph(
     collection: {
       id: "1-collection-0",
       collectionContract: {
-        id: ZERO_ADDRESS,
         address: ZERO_ADDRESS,
         contractUri: "ipfs://seller-contract-uri"
       },

--- a/packages/core-sdk/tests/mocks.ts
+++ b/packages/core-sdk/tests/mocks.ts
@@ -58,7 +58,6 @@ export function mockRawSellerFromSubgraph(
         minRoyaltyPercentage: "0"
       }
     ],
-    contractURI: "ipfs://seller-contract-uri",
     funds: [],
     offers: [],
     collections: [],
@@ -85,7 +84,11 @@ export function mockRawOfferFromSubgraph(
     collectionIndex: "0",
     collection: {
       id: "1-collection-0",
-      collectionAddress: ZERO_ADDRESS,
+      collectionContract: {
+        id: ZERO_ADDRESS,
+        address: ZERO_ADDRESS,
+        contractUri: "ipfs://seller-contract-uri"
+      },
       collectionIndex: "0",
       externalId: "initial",
       externalIdHash: "0x00",
@@ -143,7 +146,6 @@ export function mockRawOfferFromSubgraph(
       authTokenType: 0,
       voucherCloneAddress: ZERO_ADDRESS,
       active: true,
-      contractURI: "ipfs://seller-contract-uri",
       metadataUri: sellerMetadataUri,
       royaltyRecipients: [
         {
@@ -246,7 +248,6 @@ export function mockRawExchangeFromSubgraph(
       authTokenType: 0,
       voucherCloneAddress: ZERO_ADDRESS,
       active: true,
-      contractURI: "ipfs://seller-contract-uri",
       metadataUri: sellerMetadataUri,
       royaltyRecipients: [
         {

--- a/packages/core-sdk/tests/offers/handler.test.ts
+++ b/packages/core-sdk/tests/offers/handler.test.ts
@@ -128,7 +128,6 @@ describe("#voidOffer()", () => {
             ],
             voucherCloneAddress: "0x0000111122223333444455556666777788889999",
             active: true,
-            contractURI: "ipfs://seller-contract-uri",
             metadataUri: sellerMetadataUri
           }
         })
@@ -179,7 +178,6 @@ describe("#voidOffer()", () => {
             ],
             voucherCloneAddress: "0x0000111122223333444455556666777788889999",
             active: true,
-            contractURI: "ipfs://seller-contract-uri",
             metadataUri: sellerMetadataUri
           }
         })
@@ -276,7 +274,6 @@ describe("#voidOfferBatch()", () => {
               ],
               voucherCloneAddress: "0x0000111122223333444455556666777788889999",
               active: true,
-              contractURI: "ipfs://seller-contract-uri",
               metadataUri: sellerMetadataUri
             }
           })
@@ -330,7 +327,6 @@ describe("#voidOfferBatch()", () => {
               ],
               voucherCloneAddress: "0x0000111122223333444455556666777788889999",
               active: true,
-              contractURI: "ipfs://seller-contract-uri",
               metadataUri: sellerMetadataUri
             }
           })

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -612,11 +612,21 @@ type OfferCollection @entity {
   seller: Seller!
   sellerId: BigInt!
   collectionIndex: BigInt!
-  collectionAddress: Bytes!
+  collectionContract: CollectionContract!
   externalIdHash: Bytes!
   externalId: String!
   offers: [Offer!]! @derivedFrom(field: "collection")
   metadata: NftContractMetadata
+}
+
+"""
+Collection Contract
+"""
+type CollectionContract @entity {
+  id: ID!
+  address: Bytes!
+  contractUri: String!
+  collection: OfferCollection! @derivedFrom(field: "collectionContract")
 }
 
 """
@@ -700,7 +710,6 @@ type Seller implements Account @entity {
   authTokenId: BigInt!
   authTokenType: Int!
   logs: [EventLog!]! @derivedFrom(field: "account")
-  contractURI: String!
   "Percentage as integer, to get decimals divide by 10000. E.g. 1 = 0.01%, 10000 = 100%"
   royaltyRecipients: [RoyaltyRecipientXSeller!] @derivedFrom(field: "seller")
   pendingSeller: PendingSeller @derivedFrom(field: "seller")

--- a/packages/subgraph/src/mappings/account-handler.ts
+++ b/packages/subgraph/src/mappings/account-handler.ts
@@ -94,8 +94,11 @@ export function handleSellerCreatedEventWithoutMetadataUri(
   const externalIdHash = crypto.keccak256(Bytes.fromUTF8(externalId));
   // save original collection
   const collectionId = getOfferCollectionId(sellerId, "0");
-  const collectionContractId = event.params.voucherCloneAddress.toString();
-  saveCollectionContract(collectionContractId, collectionMetadataUri);
+  const collectionContractId = event.params.voucherCloneAddress.toHexString();
+  saveCollectionContract(
+    event.params.voucherCloneAddress,
+    collectionMetadataUri
+  );
   saveCollectionMetadata(
     collectionId,
     collectionMetadataUri,
@@ -154,8 +157,11 @@ export function handleSellerCreatedEvent(event: SellerCreated): void {
   const externalIdHash = crypto.keccak256(Bytes.fromUTF8(externalId));
   // save original collection
   const collectionId = getOfferCollectionId(sellerId, "0");
-  const collectionContractId = event.params.voucherCloneAddress.toString();
-  saveCollectionContract(collectionContractId, collectionMetadataUri);
+  const collectionContractId = event.params.voucherCloneAddress.toHexString();
+  saveCollectionContract(
+    event.params.voucherCloneAddress,
+    collectionMetadataUri
+  );
   saveCollectionMetadata(
     collectionId,
     collectionMetadataUri,
@@ -600,14 +606,15 @@ export function getOfferCollectionId(
 }
 
 export function saveCollectionContract(
-  contractAddress: string,
+  contractAddress: Address,
   contractUri: string
 ): void {
-  let collectionContract = CollectionContract.load(contractAddress);
+  const collectionContractId = contractAddress.toHexString();
+  let collectionContract = CollectionContract.load(collectionContractId);
 
   if (!collectionContract) {
-    collectionContract = new CollectionContract(contractAddress);
-    collectionContract.address = Bytes.fromHexString(contractAddress);
+    collectionContract = new CollectionContract(collectionContractId);
+    collectionContract.address = contractAddress;
   }
   collectionContract.contractUri = contractUri;
 
@@ -671,8 +678,8 @@ export function handleCollectionCreatedEvent(event: CollectionCreated): void {
     event.params.collectionAddress
   );
   const collectionMetadataUri = bosonVoucherContract.contractURI();
-  const collectionContractId = event.params.collectionAddress.toString();
-  saveCollectionContract(collectionContractId, collectionMetadataUri);
+  const collectionContractId = event.params.collectionAddress.toHexString();
+  saveCollectionContract(event.params.collectionAddress, collectionMetadataUri);
   saveCollectionMetadata(
     offerCollectionId,
     collectionMetadataUri,

--- a/packages/subgraph/src/mappings/account-handler.ts
+++ b/packages/subgraph/src/mappings/account-handler.ts
@@ -40,7 +40,8 @@ import {
   PendingDisputeResolver,
   OfferCollection,
   RoyaltyRecipientXSeller,
-  RoyaltyRecipient
+  RoyaltyRecipient,
+  CollectionContract
 } from "../../generated/schema";
 import { BosonVoucher } from "../../generated/templates";
 import {
@@ -86,7 +87,6 @@ export function handleSellerCreatedEventWithoutMetadataUri(
   seller.authTokenId = authTokenFromEvent.tokenId;
   seller.authTokenType = authTokenFromEvent.tokenType;
   seller.active = true;
-  seller.contractURI = collectionMetadataUri;
   seller.metadataUri = "";
   seller.save();
 
@@ -94,6 +94,8 @@ export function handleSellerCreatedEventWithoutMetadataUri(
   const externalIdHash = crypto.keccak256(Bytes.fromUTF8(externalId));
   // save original collection
   const collectionId = getOfferCollectionId(sellerId, "0");
+  const collectionContractId = event.params.voucherCloneAddress.toString();
+  saveCollectionContract(collectionContractId, collectionMetadataUri);
   saveCollectionMetadata(
     collectionId,
     collectionMetadataUri,
@@ -103,7 +105,7 @@ export function handleSellerCreatedEventWithoutMetadataUri(
     collectionId,
     event.params.sellerId,
     new BigInt(0),
-    event.params.voucherCloneAddress,
+    collectionContractId,
     Bytes.fromHexString(externalIdHash.toHexString()),
     externalId
   );
@@ -143,7 +145,6 @@ export function handleSellerCreatedEvent(event: SellerCreated): void {
   seller.authTokenId = authTokenFromEvent.tokenId;
   seller.authTokenType = authTokenFromEvent.tokenType;
   seller.active = true;
-  seller.contractURI = collectionMetadataUri;
   seller.metadataUri = sellerFromEvent.metadataUri || "";
   seller.metadata = getSellerMetadataEntityId(seller.id.toString());
   seller.save();
@@ -153,6 +154,8 @@ export function handleSellerCreatedEvent(event: SellerCreated): void {
   const externalIdHash = crypto.keccak256(Bytes.fromUTF8(externalId));
   // save original collection
   const collectionId = getOfferCollectionId(sellerId, "0");
+  const collectionContractId = event.params.voucherCloneAddress.toString();
+  saveCollectionContract(collectionContractId, collectionMetadataUri);
   saveCollectionMetadata(
     collectionId,
     collectionMetadataUri,
@@ -162,7 +165,7 @@ export function handleSellerCreatedEvent(event: SellerCreated): void {
     collectionId,
     event.params.sellerId,
     new BigInt(0),
-    event.params.voucherCloneAddress,
+    collectionContractId,
     Bytes.fromHexString(externalIdHash.toHexString()),
     externalId
   );
@@ -596,11 +599,26 @@ export function getOfferCollectionId(
   return offerCollectionId;
 }
 
+export function saveCollectionContract(
+  contractAddress: string,
+  contractUri: string
+): void {
+  let collectionContract = CollectionContract.load(contractAddress);
+
+  if (!collectionContract) {
+    collectionContract = new CollectionContract(contractAddress);
+    collectionContract.address = Bytes.fromHexString(contractAddress);
+  }
+  collectionContract.contractUri = contractUri;
+
+  collectionContract.save();
+}
+
 function saveOfferCollection(
   offerCollectionId: string,
   sellerId: BigInt,
   collectionIndex: BigInt,
-  collectionAddress: Address,
+  collectionContractId: string,
   externalIdHash: Bytes,
   externalId: string
 ): void {
@@ -615,7 +633,7 @@ function saveOfferCollection(
     offerCollection.sellerId = sellerId;
     offerCollection.seller = sellerId.toString();
     offerCollection.collectionIndex = collectionIndex;
-    offerCollection.collectionAddress = collectionAddress;
+    offerCollection.collectionContract = collectionContractId;
     offerCollection.externalIdHash = externalIdHash;
     offerCollection.externalId = externalId;
     offerCollection.metadata = offerCollectionId;
@@ -653,6 +671,8 @@ export function handleCollectionCreatedEvent(event: CollectionCreated): void {
     event.params.collectionAddress
   );
   const collectionMetadataUri = bosonVoucherContract.contractURI();
+  const collectionContractId = event.params.collectionAddress.toString();
+  saveCollectionContract(collectionContractId, collectionMetadataUri);
   saveCollectionMetadata(
     offerCollectionId,
     collectionMetadataUri,
@@ -662,7 +682,7 @@ export function handleCollectionCreatedEvent(event: CollectionCreated): void {
     offerCollectionId,
     sellerId,
     collectionIndex,
-    event.params.collectionAddress,
+    collectionContractId,
     event.params.externalId,
     externalId
   );

--- a/packages/subgraph/src/mappings/boson-voucher.ts
+++ b/packages/subgraph/src/mappings/boson-voucher.ts
@@ -1,23 +1,21 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import {
   ContractURIChanged,
-  IBosonVoucher,
   VouchersPreMinted
 } from "../../generated/BosonAccountHandler/IBosonVoucher";
-import { Offer, RangeEntity, Seller } from "../../generated/schema";
+import { CollectionContract, RangeEntity } from "../../generated/schema";
 import { getRangeId } from "./offer-handler";
 
 export function handleContractURIChanged(event: ContractURIChanged): void {
   const newContractURI = event.params.contractURI;
-
-  const bosonVoucherContract = IBosonVoucher.bind(event.address);
-  const sellerId = bosonVoucherContract.getSellerId().toString();
-  let seller = Seller.load(sellerId);
-  if (!seller) {
-    seller = new Seller(sellerId);
+  const collectionContractId = event.address.toString();
+  let collectionContract = CollectionContract.load(collectionContractId);
+  if (!collectionContract) {
+    collectionContract = new CollectionContract(collectionContractId);
+    collectionContract.address = event.address;
   }
-  seller.contractURI = newContractURI;
-  seller.save();
+  collectionContract.contractUri = newContractURI;
+  collectionContract.save();
 }
 
 export function handlePreMint(event: VouchersPreMinted): void {
@@ -30,9 +28,17 @@ export function handlePreMint(event: VouchersPreMinted): void {
 
   let rangeEntity = RangeEntity.load(rangeId);
   if (!rangeEntity) {
+    // Not really expected that the RangeEntity does not exists yet.
+    // (may mean the VouchersPreMinted event is handled before the RangeReserved one)
+    // In any case, make sure all the mandatory parameters are set
     rangeEntity = new RangeEntity(rangeId);
+    rangeEntity.start = BigInt.fromI32(0);
+    rangeEntity.end = BigInt.fromI32(0);
+    rangeEntity.owner = Bytes.fromHexString("0x00");
+    rangeEntity.minted = BigInt.zero();
   }
-  const preminted = endId.minus(startId);
+  // preminted = size of the interval [startID,endId]
+  const preminted = endId.minus(startId).plus(BigInt.fromI32(1));
   rangeEntity.minted = rangeEntity.minted.plus(preminted);
   rangeEntity.save();
 }

--- a/packages/subgraph/src/mappings/boson-voucher.ts
+++ b/packages/subgraph/src/mappings/boson-voucher.ts
@@ -8,7 +8,7 @@ import { getRangeId } from "./offer-handler";
 
 export function handleContractURIChanged(event: ContractURIChanged): void {
   const newContractURI = event.params.contractURI;
-  const collectionContractId = event.address.toString();
+  const collectionContractId = event.address.toHexString();
   let collectionContract = CollectionContract.load(collectionContractId);
   if (!collectionContract) {
     collectionContract = new CollectionContract(collectionContractId);

--- a/packages/subgraph/src/mappings/offer-handler.ts
+++ b/packages/subgraph/src/mappings/offer-handler.ts
@@ -404,11 +404,11 @@ export function handleRangeReservedEvent(event: RangeReserved): void {
 
     if (!rangeEntity) {
       rangeEntity = new RangeEntity(rangeId);
+      rangeEntity.minted = BigInt.zero();
     }
     rangeEntity.start = event.params.startExchangeId;
     rangeEntity.end = event.params.endExchangeId;
     rangeEntity.owner = event.params.owner;
-    rangeEntity.minted = BigInt.zero();
     rangeEntity.save();
 
     const rangeLength = rangeEntity.end

--- a/packages/subgraph/tests/boson-voucher.test.ts
+++ b/packages/subgraph/tests/boson-voucher.test.ts
@@ -1,2 +1,47 @@
-// TODO: add test for handleContractURIChanged
-// TODO: add test for handlePreMint
+import { test, assert } from "matchstick-as/assembly/index";
+import { createContractURIChanged, createVouchersPreMinted } from "./mocks";
+import {
+  handleContractURIChanged,
+  handlePreMint
+} from "../src/mappings/boson-voucher";
+import { Address } from "@graphprotocol/graph-ts";
+
+test("handle ContractURIChanged", () => {
+  const voucherAddress = Address.fromString(
+    "0x0123456789012345678901234567890123456789"
+  );
+  const contractURIChanged1 = createContractURIChanged(
+    voucherAddress,
+    "oriUri"
+  );
+  handleContractURIChanged(contractURIChanged1);
+  assert.fieldEquals(
+    "CollectionContract",
+    voucherAddress.toString(),
+    "address",
+    "0x0123456789012345678901234567890123456789"
+  );
+  assert.fieldEquals(
+    "CollectionContract",
+    voucherAddress.toString(),
+    "contractUri",
+    "oriUri"
+  );
+  const contractURIChanged2 = createContractURIChanged(
+    voucherAddress,
+    "newUri"
+  );
+  handleContractURIChanged(contractURIChanged2);
+  assert.fieldEquals(
+    "CollectionContract",
+    voucherAddress.toString(),
+    "contractUri",
+    "newUri"
+  );
+});
+
+test("handle PreMintEvent", () => {
+  const vouchersPreMinted = createVouchersPreMinted(1, 1, 1);
+  handlePreMint(vouchersPreMinted);
+  assert.fieldEquals("RangeEntity", "1-range", "minted", "1");
+});

--- a/packages/subgraph/tests/boson-voucher.test.ts
+++ b/packages/subgraph/tests/boson-voucher.test.ts
@@ -17,13 +17,13 @@ test("handle ContractURIChanged", () => {
   handleContractURIChanged(contractURIChanged1);
   assert.fieldEquals(
     "CollectionContract",
-    voucherAddress.toString(),
+    voucherAddress.toHexString(),
     "address",
     "0x0123456789012345678901234567890123456789"
   );
   assert.fieldEquals(
     "CollectionContract",
-    voucherAddress.toString(),
+    voucherAddress.toHexString(),
     "contractUri",
     "oriUri"
   );
@@ -34,7 +34,7 @@ test("handle ContractURIChanged", () => {
   handleContractURIChanged(contractURIChanged2);
   assert.fieldEquals(
     "CollectionContract",
-    voucherAddress.toString(),
+    voucherAddress.toHexString(),
     "contractUri",
     "newUri"
   );

--- a/packages/subgraph/tests/mocks.ts
+++ b/packages/subgraph/tests/mocks.ts
@@ -81,6 +81,7 @@ import {
   GroupUpdated
 } from "../generated/BosonGroupHandler/IBosonGroupHandler";
 import { getDisputeResolutionTermsId } from "../src/entities/dispute-resolution";
+import { ContractURIChanged, VouchersPreMinted } from "../generated/BosonAccountHandler/IBosonVoucher";
 
 export class RoyaltyInfo {
   recipients: string[];
@@ -1343,7 +1344,6 @@ export function mockSeller(sellerId: string): Seller {
   );
   seller.authTokenType = 0;
   seller.authTokenId = BigInt.fromI32(0);
-  seller.contractURI = "ipfs://sellerContractUri";
   seller.metadataUri = "ipfs://sellerMetadataUri";
   seller.save();
   return seller;
@@ -1742,4 +1742,48 @@ export function createOfferRoyaltyInfoUpdatedEvent(
   offerRoyaltyInfoUpdated.parameters.push(executedByParam);
 
   return offerRoyaltyInfoUpdated;
+}
+
+export function createVouchersPreMinted(
+  offerId: i32,
+  startId: i32,
+  endId: i32
+): VouchersPreMinted {
+  const vouchersPreMinted = changetype<VouchersPreMinted>(newMockEvent());
+  vouchersPreMinted.parameters = [];
+  const offerIdParam = new ethereum.EventParam(
+    "offerId",
+    ethereum.Value.fromI32(offerId)
+  );
+  const startIdParam = new ethereum.EventParam(
+    "startId",
+    ethereum.Value.fromI32(startId)
+  );
+  const endIdParam = new ethereum.EventParam(
+    "endId",
+    ethereum.Value.fromI32(endId)
+  );
+
+  vouchersPreMinted.parameters.push(offerIdParam);
+  vouchersPreMinted.parameters.push(startIdParam);
+  vouchersPreMinted.parameters.push(endIdParam);
+
+  return vouchersPreMinted;
+}
+
+export function createContractURIChanged(
+  contractAddress: Address,
+  contractURI: string
+): ContractURIChanged {
+  const contractURIChanged = changetype<ContractURIChanged>(newMockEvent());
+  contractURIChanged.parameters = [];
+  contractURIChanged.address = contractAddress;
+  const contractURIParam = new ethereum.EventParam(
+    "contractURI",
+    ethereum.Value.fromString(contractURI)
+  );
+
+  contractURIChanged.parameters.push(contractURIParam);
+
+  return contractURIChanged;
 }

--- a/scripts/change-contract-uri.ts
+++ b/scripts/change-contract-uri.ts
@@ -38,7 +38,8 @@ async function main() {
   console.log(
     `Updating seller's voucher on env ${envName} on chain ${chainId}...`
   );
-  const txResponse = await coreSDK.setContractURI(contractURI);
+  const collectionIndex = 0;
+  const txResponse = await coreSDK.setContractURI(contractURI, collectionIndex);
   await txResponse.wait();
   console.log(`Tx hash: ${txResponse.hash}`);
 


### PR DESCRIPTION
## Description

- change/adapt subgraph schema to manage contractUri per collection, instead of per seller (each seller can have several collection, each collection has a contractUri that defines the collection metadata)
- add coreSDK methods getExchangeTokenId() and parseTokenId() to convert tokenId to exchangeID + offerId, and vice-versa
- upgrade to the latest protocol commit (no change in Solidity code)
- add Subgraph Mixin in CoreSDK, with method waitForGraphNodeIndexing()
- replace utility function waitForGraphNodeIndexing() with coreSDK.waitForGraphNodeIndexing() in all e2e tests
- upgrade ipfs-utils dependency to remove issue with ipfs-http-client since node v18 (https://discuss.ipfs.tech/t/uploading-to-ipfs/16533/3)
- add Errors Mixin in CoreSDK with method coreSDK.parseError() that allow to decode protocol errors from error hash code (in case the provider doesn't do it already)

## How to test

- new tests have been added to cover new code
- e2e tests adapted with coreSDK.waitForGraphNodeIndexing()
