### PR TITLE
fix: export-abis script is failing since prettier dependency upgrade

### DIFF
--- a/packages/common/src/abis/Seaport.json
+++ b/packages/common/src/abis/Seaport.json
@@ -390,6 +390,21 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "TStoreAlreadyActivated",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TStoreNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TloadTestContractDeploymentFailed",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -740,6 +755,13 @@
     ],
     "name": "OrdersMatched",
     "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "__activateTstore",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
     "inputs": [
@@ -1720,7 +1742,7 @@
           }
         ],
         "internalType": "struct BasicOrderParameters",
-        "name": "parameters",
+        "name": "",
         "type": "tuple"
       }
     ],
@@ -1843,7 +1865,7 @@
           }
         ],
         "internalType": "struct BasicOrderParameters",
-        "name": "parameters",
+        "name": "",
         "type": "tuple"
       }
     ],

--- a/scripts/export-abis.ts
+++ b/scripts/export-abis.ts
@@ -38,9 +38,13 @@ async function main() {
   const prettierConfig = await prettier.resolveConfig(
     `${process.cwd()}/.prettierrc`
   );
+  const formatted = await prettier.format(indexFileContent, {
+    ...prettierConfig,
+    parser: "typescript"
+  });
   fs.writeFileSync(
     `${process.cwd()}/packages/common/src/abis/index.ts`,
-    prettier.format(indexFileContent, prettierConfig || {})
+    formatted
   );
 }
 


### PR DESCRIPTION
## Description

{{what was done}}

## How to test

{{how can it be tested}}
