### PR TITLE
chore: externalize validateMetadata from react hook

### DIFF
--- a/packages/react-kit/src/hooks/ipfs/useIpfsStorage.ts
+++ b/packages/react-kit/src/hooks/ipfs/useIpfsStorage.ts
@@ -1,3 +1,4 @@
+import { validateMetadata } from "@bosonprotocol/core-sdk";
 import { useConfigContext } from "../../components/config/ConfigContext";
 import { useIpfsContext } from "../../components/ipfs/IpfsContext";
 import { useIpfsMetadataStorage } from "../useIpfsMetadataStorage";
@@ -9,6 +10,7 @@ export function useIpfsStorage() {
   const storage = useIpfsMetadataStorage(
     config.envName,
     config.configId,
+    validateMetadata,
     ipfsMetadataStorageUrl,
     ipfsMetadataStorageHeaders
   );

--- a/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
+++ b/packages/react-kit/src/hooks/useIpfsMetadataStorage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import {
   getEnvConfigById,
   ConfigId,
-  validateMetadata
+  AnyMetadata
 } from "@bosonprotocol/core-sdk";
 import { IpfsMetadataStorage } from "@bosonprotocol/ipfs-storage";
 import { EnvironmentType } from "@bosonprotocol/common/src/types";
@@ -18,19 +18,20 @@ import { EnvironmentType } from "@bosonprotocol/common/src/types";
 export function useIpfsMetadataStorage(
   envName: EnvironmentType,
   configId: ConfigId,
+  validateMetadata: (metadata: AnyMetadata) => void,
   url?: string,
   headers?: Headers | Record<string, string>
 ) {
   const [ipfsMetadataStorage, setIpfsMetadataStorage] =
     useState<IpfsMetadataStorage>(
-      initIpfsMetadataStorage(envName, configId, url, headers)
+      initIpfsMetadataStorage(envName, configId, validateMetadata, url, headers)
     );
 
   useEffect(() => {
     setIpfsMetadataStorage(
-      initIpfsMetadataStorage(envName, configId, url, headers)
+      initIpfsMetadataStorage(envName, configId, validateMetadata, url, headers)
     );
-  }, [envName, configId, url, headers]);
+  }, [envName, configId, validateMetadata, url, headers]);
 
   return ipfsMetadataStorage;
 }
@@ -38,6 +39,7 @@ export function useIpfsMetadataStorage(
 function initIpfsMetadataStorage(
   envName: EnvironmentType,
   configId: ConfigId,
+  validateMetadata: (metadata: AnyMetadata) => void,
   url?: string,
   headers?: Headers | Record<string, string>
 ) {

--- a/packages/react-kit/src/hooks/useIpfsStorage.ts
+++ b/packages/react-kit/src/hooks/useIpfsStorage.ts
@@ -1,6 +1,7 @@
 import { useIpfsMetadataStorage } from "./";
 import { useEnvContext } from "../components/environment/EnvironmentContext";
 import { useIpfsContext } from "../components/ipfs/IpfsContext";
+import { validateMetadata } from "@bosonprotocol/core-sdk";
 
 export function useIpfsStorage() {
   const { envName, configId } = useEnvContext();
@@ -9,6 +10,7 @@ export function useIpfsStorage() {
   const storage = useIpfsMetadataStorage(
     envName,
     configId,
+    validateMetadata,
     ipfsMetadataStorageUrl,
     ipfsMetadataStorageHeaders
   );

--- a/packages/react-kit/src/lib/const/chainInfo.ts
+++ b/packages/react-kit/src/lib/const/chainInfo.ts
@@ -5,7 +5,7 @@ import polygonMaticLogo from "../../assets/svg/polygon-matic-logo.svg";
 import polygonSquareLogoUrl from "../../assets/svg/polygon_square_logo.svg";
 import ms from "ms";
 
-import { SupportedL1ChainId, SupportedL2ChainId } from "./chains";
+import { LocalChainId, SupportedL1ChainId, SupportedL2ChainId } from "./chains";
 
 export const AVERAGE_L1_BLOCK_TIME = ms(`12s`);
 
@@ -113,6 +113,15 @@ const CHAIN_INFO: ChainInfoMap = {
       symbol: "aMATIC",
       decimals: 18
     }
+  },
+  [LocalChainId]: {
+    networkType: NetworkType.L1,
+    docs: "https://docs.uniswap.org/",
+    explorer: "https://etherscan.io/",
+    infoLink: "https://info.uniswap.org/#/",
+    label: "Local",
+    logoUrl: ethereumLogoUrl,
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 }
   }
 } as const;
 


### PR DESCRIPTION
## Description

externalize validateMetadata from react hook so that a different validateMetadata()  handler can be specified in Fermion compared to Boson

## How to test

N/A