### PR TITLE
chore: a few changes required to run the opensea flow on Fermion prot…

### DIFF
--- a/packages/core-sdk/src/erc20/handler.ts
+++ b/packages/core-sdk/src/erc20/handler.ts
@@ -1,4 +1,4 @@
-import { Web3LibAdapter } from "@bosonprotocol/common";
+import { Web3LibAdapter, TransactionRequest } from "@bosonprotocol/common";
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
 import { erc20Iface } from "./interface";
 
@@ -7,8 +7,10 @@ export async function approve(args: {
   spender: string;
   value: BigNumberish;
   web3Lib: Web3LibAdapter;
+  txRequest?: TransactionRequest;
 }) {
   return args.web3Lib.sendTransaction({
+    ...args.txRequest,
     to: args.contractAddress,
     data: erc20Iface.encodeFunctionData("approve", [args.spender, args.value])
   });
@@ -74,6 +76,7 @@ export async function ensureAllowance(args: {
   contractAddress: string;
   value: BigNumberish;
   web3Lib: Web3LibAdapter;
+  txRequest?: TransactionRequest;
 }) {
   const allowance = await getAllowance(args);
   if (BigNumber.from(allowance).lt(args.value)) {

--- a/packages/core-sdk/src/erc721/handler.ts
+++ b/packages/core-sdk/src/erc721/handler.ts
@@ -1,4 +1,4 @@
-import { Web3LibAdapter } from "@bosonprotocol/common";
+import { TransactionRequest, Web3LibAdapter } from "@bosonprotocol/common";
 import { BigNumberish } from "@ethersproject/bignumber";
 import { erc721Iface } from "./interface";
 
@@ -101,8 +101,10 @@ export async function setApprovalForAll(args: {
   operator: string;
   approved: boolean;
   web3Lib: Web3LibAdapter;
+  txRequest?: TransactionRequest;
 }) {
   return args.web3Lib.sendTransaction({
+    ...args.txRequest,
     to: args.contractAddress,
     data: erc721Iface.encodeFunctionData("setApprovalForAll", [
       args.operator,

--- a/packages/core-sdk/src/marketplaces/types.ts
+++ b/packages/core-sdk/src/marketplaces/types.ts
@@ -82,10 +82,13 @@ export abstract class Marketplace {
     },
     withWrapper?: boolean
   ): Promise<PriceDiscoveryStruct>;
-  public abstract buildAdvancedOrder(asset: {
-    contract: string;
-    tokenId: string;
-  }): Promise<AdvancedOrder>;
+  public abstract buildAdvancedOrder(
+    asset: {
+      contract: string;
+      tokenId: string;
+    },
+    withWrapper?: boolean
+  ): Promise<AdvancedOrder>;
   public abstract wrapVouchers(
     contract: string,
     tokenIds: string[]


### PR DESCRIPTION
…ocol

## Description

- add ability to set optional Transaction Request arguments (like gasPrice) on ERC20 and ERC721 handlers
- add `withWrapper` boolean argument to opensea buildAdvancedOrder() method

## How to test

N/A