### PR TITLE
refactor: make chain selector component config agnostic

### DIFF
--- a/packages/common/src/types/configs.ts
+++ b/packages/common/src/types/configs.ts
@@ -75,3 +75,8 @@ export type ProtocolConfig = {
   metaTx?: Partial<MetaTxConfig>;
   lens: Lens | undefined;
 };
+
+export type CoreProtocolConfig = Pick<
+  ProtocolConfig,
+  "envName" | "chainId" | "configId"
+>;

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -24,6 +24,7 @@ export {
   ConfigId,
   MetaTxConfig,
   ProtocolConfig,
+  CoreProtocolConfig,
   abis
 } from "@bosonprotocol/common";
 

--- a/packages/react-kit/src/stories/ConnectWallet.stories.tsx
+++ b/packages/react-kit/src/stories/ConnectWallet.stories.tsx
@@ -30,7 +30,8 @@ const errorButtonTheme = bosonButtonThemes({ withBosonStyle: false })[
 const envName =
   (process.env.STORYBOOK_DATA_ENV_NAME as EnvironmentType) || "testing";
 const envConfig = getEnvConfigs(envName);
-const configId = envConfig[0].configId;
+const config = envConfig[0];
+const configId = config.configId;
 const ColorGlobalStyle = createGlobalStyle<{ color: CSSProperties["color"] }>`
   html, body{
     color: ${({ color }) => color};
@@ -114,6 +115,7 @@ const Component = ({
                   <ChainSelector
                     leftAlign={true}
                     backgroundColor={chainSelectorBackgroundColor}
+                    config={config}
                   />
                   <ConnectWallet
                     successButtonTheme={{


### PR DESCRIPTION
this is to allow this component to be used by fermion with a different config object type