### PR TITLE
chore: upgrade opensea-js dep and change OrderSide enum type

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       context: ../.
       dockerfile: ./e2e/opensea-api-mock/Dockerfile
     user: "node:node"
-    image: opensea-api-mock:202518061227
+    image: opensea-api-mock:202410071017
     ports:
       - "3334:3334"
     environment:

--- a/e2e/opensea-api-mock/package.json
+++ b/e2e/opensea-api-mock/package.json
@@ -32,7 +32,7 @@
     "express": "^4.18.1",
     "express-validator": "^6.14.2",
     "morgan": "^1.10.0",
-    "opensea-js": "^7.1.3",
+    "opensea-js": "^7.1.13",
     "ts-command-line-args": "^2.3.1",
     "winston": "^3.8.2"
   },

--- a/e2e/opensea-api-mock/src/services/opensea.ts
+++ b/e2e/opensea-api-mock/src/services/opensea.ts
@@ -120,10 +120,10 @@ export async function computeFulfillmentData(
 function getOrderSide(sidePath: string): OrderSide {
   switch (sidePath) {
     case "listings": {
-      return OrderSide.ASK;
+      return OrderSide.LISTING;
     }
     case "offers": {
-      return OrderSide.BID;
+      return OrderSide.OFFER;
     }
     default:
       throw new Error(`Invalid sidePath '${sidePath}'`);
@@ -151,17 +151,17 @@ function extractOrderInfo(
     (c) => c.itemType === ItemType.ERC721
   );
   const nftAsk = parameters.offer.find((c) => c.itemType === ItemType.ERC721);
-  if (side === OrderSide.BID && !nftBid) {
+  if (side === OrderSide.OFFER && !nftBid) {
     throw new Error(`NFT not found in order consideration`);
   }
-  if (side === OrderSide.ASK && !nftAsk) {
+  if (side === OrderSide.LISTING && !nftAsk) {
     throw new Error(`NFT not found in order offer`);
   }
   if (!side) {
     if (nftBid && !nftAsk) {
-      side = OrderSide.BID;
+      side = OrderSide.OFFER;
     } else if (!nftBid && nftAsk) {
-      side = OrderSide.ASK;
+      side = OrderSide.LISTING;
     } else if (nftBid && nftAsk) {
       throw new Error(
         `NFT found in both consideration and offer. Unable to detect the order side`
@@ -172,7 +172,7 @@ function extractOrderInfo(
       );
     }
   }
-  if (side === OrderSide.BID) {
+  if (side === OrderSide.OFFER) {
     price = parameters.offer
       .filter((c) => c.itemType === ItemType.ERC20)
       .reduce(

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "graphql": "^16.8.1",
         "ipfs-utils": "^9.0.14",
         "lerna": "^5.5.1",
-        "opensea-js": "^7.1.5",
+        "opensea-js": "^7.1.13",
         "prettier": "^3.2.5",
         "run-script-os": "^1.1.6",
         "ts-jest": "29.1.1",
@@ -155,7 +155,7 @@
         "express": "^4.18.1",
         "express-validator": "^6.14.2",
         "morgan": "^1.10.0",
-        "opensea-js": "^7.1.3",
+        "opensea-js": "^7.1.13",
         "ts-command-line-args": "^2.3.1",
         "winston": "^3.8.2"
       },
@@ -31459,10 +31459,11 @@
       "link": true
     },
     "node_modules/opensea-js": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.5.tgz",
-      "integrity": "sha512-nR5AAqT+sK2CiG9iuvqbVuUlbrs4wMRG32514wtRL/mFlSUr9hkteIitG23R4zGrjjyTJbI6wIaEclnccbI76Q==",
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.13.tgz",
+      "integrity": "sha512-IwyBeGU/W6dBG3HCopzq1UdTXkxuIK9aWqucXFy6VUUxZQBKFbssX0OgkHl9RO6udHLC9Y9GG3HqSYDBfEiD7A==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@opensea/seaport-js": "^4.0.0",
         "ethers": "^6.9.0"
@@ -42918,7 +42919,7 @@
         "graphql": "^16.5.0",
         "graphql-request": "^4.3.0",
         "mustache": "^4.2.0",
-        "opensea-js": "^7.1.5",
+        "opensea-js": "^7.1.13",
         "schema-to-yup": "^1.11.11",
         "yup": "^0.32.11"
       },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "graphql": "^16.8.1",
     "ipfs-utils": "^9.0.14",
     "lerna": "^5.5.1",
-    "opensea-js": "^7.1.5",
+    "opensea-js": "^7.1.13",
     "prettier": "^3.2.5",
     "run-script-os": "^1.1.6",
     "ts-jest": "29.1.1",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -46,7 +46,7 @@
     "graphql": "^16.5.0",
     "graphql-request": "^4.3.0",
     "mustache": "^4.2.0",
-    "opensea-js": "^7.1.5",
+    "opensea-js": "^7.1.13",
     "schema-to-yup": "^1.11.11",
     "yup": "^0.32.11"
   },

--- a/packages/core-sdk/src/marketplaces/opensea.ts
+++ b/packages/core-sdk/src/marketplaces/opensea.ts
@@ -264,7 +264,7 @@ export class OpenSeaMarketplace extends Marketplace {
     const osOrder = await this._handler.api.postOrder(order, {
       protocol: "seaport",
       protocolAddress,
-      side: OrderSide.BID
+      side: OrderSide.OFFER
     });
     return this.convertOsOrder(osOrder);
   }
@@ -281,7 +281,7 @@ export class OpenSeaMarketplace extends Marketplace {
     const osOrder = await this._handler.api.getOrder({
       assetContractAddress: asset.contract,
       tokenId: asset.tokenId,
-      side: OrderSide.BID,
+      side: OrderSide.OFFER,
       ...filter
     });
     const fulfillerAddress = asset.withWrapper
@@ -316,7 +316,7 @@ export class OpenSeaMarketplace extends Marketplace {
     const osOrder = await this._handler.api.getOrder({
       assetContractAddress: withWrapper ? wrapper.address : asset.contract,
       tokenId: asset.tokenId,
-      side: OrderSide.BID
+      side: OrderSide.OFFER
     });
     const ffd = await this._handler.api.generateFulfillmentData(
       withWrapper
@@ -449,7 +449,7 @@ export class OpenSeaMarketplace extends Marketplace {
     const osOrder = await this._handler.api.getOrder({
       assetContractAddress: wrapper.address, // Bid Order must be for the wrapped token
       tokenId: asset.tokenId,
-      side: OrderSide.BID
+      side: OrderSide.OFFER
     });
     const ffd = await this._handler.api.generateFulfillmentData(
       this._contracts.priceDiscoveryClient, // the address of the PriceDiscoveryClient contract, which will call the fulfilment method
@@ -484,7 +484,7 @@ export class OpenSeaMarketplace extends Marketplace {
       return undefined;
     }
     const orderInfo = this.extractOrderInfo(osOrder.protocolData.parameters);
-    const side = orderInfo.side === OrderSide.ASK ? Side.Ask : Side.Bid;
+    const side = orderInfo.side === OrderSide.LISTING ? Side.Ask : Side.Bid;
     return {
       offerer: orderInfo.offerer,
       side,
@@ -524,17 +524,17 @@ export class OpenSeaMarketplace extends Marketplace {
       (c) => c.itemType === ItemType.ERC721
     );
     const nftAsk = parameters.offer.find((c) => c.itemType === ItemType.ERC721);
-    if (side === OrderSide.BID && !nftBid) {
+    if (side === OrderSide.OFFER && !nftBid) {
       console.warn(`NFT not found in order consideration`);
     }
-    if (side === OrderSide.ASK && !nftAsk) {
+    if (side === OrderSide.LISTING && !nftAsk) {
       console.warn(`NFT not found in order offer`);
     }
     if (!side) {
       if (nftBid && !nftAsk) {
-        side = OrderSide.BID;
+        side = OrderSide.OFFER;
       } else if (!nftBid && nftAsk) {
-        side = OrderSide.ASK;
+        side = OrderSide.LISTING;
       } else if (nftBid && nftAsk) {
         console.warn(
           `NFT found in both consideration and offer. Unable to detect the order side`
@@ -545,7 +545,7 @@ export class OpenSeaMarketplace extends Marketplace {
         );
       }
     }
-    if (side === OrderSide.BID) {
+    if (side === OrderSide.OFFER) {
       price = parameters.offer
         .filter((c) => c.itemType === ItemType.ERC20)
         .reduce(
@@ -600,7 +600,7 @@ export class OpenSeaMarketplace extends Marketplace {
     const osOrder = await this._handler.api.getOrder({
       assetContractAddress: asset.contract,
       tokenId: asset.tokenId,
-      side: side === Side.Ask ? OrderSide.ASK : OrderSide.BID,
+      side: side === Side.Ask ? OrderSide.LISTING : OrderSide.OFFER,
       ...filter
     });
     return osOrder
@@ -622,7 +622,7 @@ export class OpenSeaMarketplace extends Marketplace {
     const { orders } = await this._handler.api.getOrders({
       assetContractAddress: asset.contract,
       tokenIds: asset.tokenIds,
-      side: side === Side.Ask ? OrderSide.ASK : OrderSide.BID,
+      side: side === Side.Ask ? OrderSide.LISTING : OrderSide.OFFER,
       ...filter
     });
     return orders.map((osOrder) => ({

--- a/packages/core-sdk/src/marketplaces/types.ts
+++ b/packages/core-sdk/src/marketplaces/types.ts
@@ -17,8 +17,8 @@ export enum MarketplaceType {
 }
 
 export enum OrderSide {
-  ASK = "ask",
-  BID = "bid"
+  LISTING = "ask",
+  OFFER = "bid"
 }
 
 export type MarketplaceHandler = OpenSeaSDKHandler | DefaultHandler;

--- a/packages/core-sdk/src/marketplaces/types.ts
+++ b/packages/core-sdk/src/marketplaces/types.ts
@@ -16,10 +16,7 @@ export enum MarketplaceType {
   OPENSEA
 }
 
-export enum OrderSide {
-  LISTING = "ask",
-  OFFER = "bid"
-}
+export { OrderSide } from "opensea-js";
 
 export type MarketplaceHandler = OpenSeaSDKHandler | DefaultHandler;
 

--- a/packages/core-sdk/tests/marketplaces/opensea.test.ts
+++ b/packages/core-sdk/tests/marketplaces/opensea.test.ts
@@ -1,0 +1,219 @@
+import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
+import { OpenSeaMarketplace } from "../../src/marketplaces/opensea";
+import { MarketplaceType } from "../../src/marketplaces";
+import {
+  FulfillmentDataResponse,
+  GetNFTResponse,
+  NFT,
+  OrderV2
+} from "opensea-js";
+import {
+  AdvancedOrder,
+  CreateInputItem,
+  CreateOrderAction,
+  OrderUseCase
+} from "@opensea/seaport-js/lib/types";
+import { ContractAddresses, Side } from "@bosonprotocol/common";
+import { ItemType } from "@opensea/seaport-js/lib/constants";
+
+let openSeaSdkHandlerReturn: Record<string, unknown>;
+const mockOpenSeaSdkHandler = {
+  api: {
+    apiBaseUrl: "apiBaseUrl",
+    getOrder: async (): Promise<OrderV2> => {
+      return openSeaSdkHandlerReturn.getOrder as OrderV2;
+    },
+    getOrders: async (): Promise<{ orders: OrderV2[] }> => {
+      return openSeaSdkHandlerReturn.getOrders as { orders: OrderV2[] };
+    },
+    generateFulfillmentData: async (): Promise<FulfillmentDataResponse> => {
+      return openSeaSdkHandlerReturn.generateFulfillmentData as FulfillmentDataResponse;
+    },
+    getNFT: async (): Promise<GetNFTResponse> => {
+      return openSeaSdkHandlerReturn.getNFT as GetNFTResponse;
+    },
+    postOrder: async (): Promise<OrderV2> => {
+      return openSeaSdkHandlerReturn.postOrder as OrderV2;
+    }
+  },
+  seaport_v1_6: {
+    createOrder: async (): Promise<OrderUseCase<CreateOrderAction>> => {
+      return openSeaSdkHandlerReturn.createOrder as OrderUseCase<CreateOrderAction>;
+    }
+  },
+  createListing: async (): Promise<OrderV2> => {
+    return openSeaSdkHandlerReturn.createListing as OrderV2;
+  },
+  getNFTItems: (): CreateInputItem[] => {
+    return openSeaSdkHandlerReturn.getNFTItems as CreateInputItem[];
+  }
+};
+
+describe("", () => {
+  let openseaSdkMarketplace: OpenSeaMarketplace;
+  const asset = {
+    contract: "contract",
+    tokenId: "123"
+  };
+  beforeAll(async () => {
+    const web3lib = new MockWeb3LibAdapter();
+    openseaSdkMarketplace = new OpenSeaMarketplace(
+      MarketplaceType.OPENSEA,
+      mockOpenSeaSdkHandler,
+      {} as unknown as ContractAddresses,
+      "",
+      web3lib
+    );
+  });
+  test("createBidOrder() fails when the protocolAddress is not found", async () => {
+    openSeaSdkHandlerReturn = {
+      getNFT: {
+        nft: {} as NFT
+      },
+      getNFTItems: [
+        { itemType: ItemType.ERC721, token: "token", identifier: "123" }
+      ],
+      createOrder: {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        executeAllActions: () => {}
+      }
+    };
+    await expect(
+      openseaSdkMarketplace.createBidOrder({
+        asset,
+        offerer: "offerer",
+        price: "100000",
+        expirationTime: 0,
+        exchangeToken: { address: "address", decimals: 18 },
+        auction: true
+      })
+    ).rejects.toThrow(
+      `Seaport protocol address must be specified in Listing or CoreSDK config`
+    );
+  });
+  test("buildAdvancedOrder()", async () => {
+    const order = {
+      createdDate: Date.now().toString()
+    } as OrderV2;
+    const expectedAdvancedOrder = {
+      signature: "signature"
+    } as AdvancedOrder;
+    openSeaSdkHandlerReturn = {
+      getOrder: order,
+      generateFulfillmentData: {
+        fulfillment_data: {
+          transaction: {
+            input_data: {
+              orders: [expectedAdvancedOrder]
+            }
+          }
+        }
+      }
+    };
+    const advancedOrder = await openseaSdkMarketplace.buildAdvancedOrder(asset);
+    expect(advancedOrder.signature).toEqual(expectedAdvancedOrder.signature);
+  });
+  test("getOrder()", async () => {
+    openSeaSdkHandlerReturn = {
+      getOrder: null
+    };
+    const signedOrder = await openseaSdkMarketplace.getOrder(asset, Side.Ask);
+    expect(signedOrder).not.toBeTruthy();
+  });
+  test("getOrders()", async () => {
+    const order = {
+      createdDate: Date.now().toString(),
+      protocolData: {
+        parameters: {
+          consideration: [
+            {
+              itemType: ItemType.ERC721
+            }
+          ],
+          offer: [
+            {
+              itemType: ItemType.ERC20,
+              startAmount: "1"
+            }
+          ]
+        },
+        signature: "signature"
+      }
+    } as OrderV2;
+    openSeaSdkHandlerReturn = {
+      getOrders: { orders: [order] }
+    };
+    const signedOrders = await openseaSdkMarketplace.getOrders(
+      {
+        contract: asset.contract,
+        tokenIds: [asset.tokenId]
+      },
+      Side.Ask
+    );
+    expect(signedOrders.length).toEqual(1);
+  });
+  test("getOrders() failed #1", async () => {
+    const order = {
+      createdDate: Date.now().toString(),
+      protocolData: {
+        parameters: {
+          consideration: [
+            {
+              itemType: ItemType.ERC721
+            }
+          ],
+          offer: [
+            {
+              itemType: ItemType.ERC721
+            }
+          ]
+        },
+        signature: "signature"
+      }
+    } as OrderV2;
+    openSeaSdkHandlerReturn = {
+      getOrders: { orders: [order] }
+    };
+    const signedOrders = await openseaSdkMarketplace.getOrders(
+      {
+        contract: asset.contract,
+        tokenIds: [asset.tokenId]
+      },
+      Side.Ask
+    );
+    expect(signedOrders.length).toEqual(1);
+  });
+  test("getOrders() failed #2", async () => {
+    const order = {
+      createdDate: Date.now().toString(),
+      protocolData: {
+        parameters: {
+          consideration: [
+            {
+              itemType: ItemType.ERC20,
+              startAmount: "1"
+            }
+          ],
+          offer: [
+            {
+              itemType: ItemType.ERC20,
+              startAmount: "2"
+            }
+          ]
+        },
+        signature: "signature"
+      }
+    } as OrderV2;
+    openSeaSdkHandlerReturn = {
+      getOrders: { orders: [order] }
+    };
+    const signedOrders = await openseaSdkMarketplace.getOrders(
+      {
+        contract: asset.contract,
+        tokenIds: [asset.tokenId]
+      },
+      Side.Ask
+    );
+    expect(signedOrders.length).toEqual(1);
+  });
+});


### PR DESCRIPTION
## Description

related to https://github.com/fermionprotocol/core-components/issues/110
Issue comes from different opensea-js versions between Boson CC and Fermion CC.
OrderSide enum type has been redefined between these 2 versions.
Boson CC upgraded to the latest opensea-js version in order to match those used in Fermion


## How to test

unit test added to meet the coverage threshold