### PR TITLE
fix: hack waiting for Opensea API bug to be fixed

### DIFF
--- a/packages/core-sdk/src/marketplaces/opensea.ts
+++ b/packages/core-sdk/src/marketplaces/opensea.ts
@@ -291,7 +291,8 @@ export class OpenSeaMarketplace extends Marketplace {
       fulfillerAddress,
       osOrder.orderHash,
       osOrder.protocolAddress,
-      osOrder.side
+      // osOrder.side
+      OrderSide.LISTING // TODO: Hack waiting for Opensea API bug to be fixed. See https://github.com/fermionprotocol/ui/issues/358
     );
     const inputData = ffd.fulfillment_data.transaction
       .input_data as unknown as {


### PR DESCRIPTION
## Description

temporary, generateFulfillmentData() is called with forcing the order side to be LISTING (Ask) instead of OFFER (Bid).
Even if not semantically correct, the method returns the needed data to fulfil an offer (Bid), so it works around the issue raised on the Fermion dApp: https://github.com/fermionprotocol/ui/issues/358

## How to test

{{how can it be tested}}
