### PR TITLE
feat: add children prop to checkbox

### DIFF
--- a/packages/react-kit/src/components/form/BaseCheckbox.tsx
+++ b/packages/react-kit/src/components/form/BaseCheckbox.tsx
@@ -14,6 +14,7 @@ export function BaseCheckbox({
   hideError,
   className,
   iconProps,
+  children,
   ...props
 }: BaseCheckboxProps) {
   const [field, meta, helpers] = useField(name);
@@ -53,7 +54,7 @@ export function BaseCheckbox({
         <div>
           <Check size={16} width="100%" height="100%" {...iconProps} />
         </div>
-        <b>{text}</b>
+        {children || <b>{text}</b>}
       </CheckboxWrapper>
       <Error display={!hideError && displayError} message={errorMessage} />
     </>

--- a/packages/react-kit/src/stories/form/BaseCheckbox.stories.tsx
+++ b/packages/react-kit/src/stories/form/BaseCheckbox.stories.tsx
@@ -111,3 +111,10 @@ export const CustomThemeWithError = {
     } satisfies BaseCheckboxProps["theme"]
   }
 };
+
+export const SimpleWithChildren = {
+  args: {
+    ...BASE_ARGS,
+    children: <p>text in paragraph</p>
+  }
+};


### PR DESCRIPTION
right now if you set the text prop of a checkbox the text that appears is bold, with children it could be anything if it's set