### PR TITLE
chore: empty commit to force ci workflow

### DIFF
--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -12,6 +12,7 @@ Official [subgraph](https://api.thegraph.com/subgraphs/name/bosonprotocol/polygo
 \* The `testing` and `staging` subgraphs are used for development purposes.
 ## Local development
 If you haven't already, run in the root of this monorepo
+
 ```bash
 npm ci
 ```
@@ -21,11 +22,13 @@ npm ci
 We use [Matchstick](https://github.com/LimeChain/matchstick/blob/main/README.md) for unit testing the subgraph.
 
 Either run in the root of this monorepo
+
 ```bash
 npm run test -w @bosonprotocol/subgraph
 ```
 
 or in the `/packages/subgraph` folder
+
 ```bash
 npm run test
 ```


### PR DESCRIPTION
## Description

CI workflows are not started when PR #784 and PR #841  are merged

This may be the reason why 
![image](https://github.com/user-attachments/assets/ea53a0c4-3fee-42d2-86b2-0a7e37e508d9)


## How to test

{{how can it be tested}}
