### PR TITLE
ci: fix GITHUB_TOKEN variable name can't be used (reserved)

### DIFF
--- a/.github/workflows/deploy-testing-subgraph.yaml
+++ b/.github/workflows/deploy-testing-subgraph.yaml
@@ -6,7 +6,7 @@ on:
     secrets:
       ORMI_0x_GRAPH_API_KEY_TESTING:
         required: true
-      GITHUB_TOKEN:
+      GH_TOKEN:
         required: true
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
           ORMI_0x_GRAPH_API_KEY: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
       - name: Commit & Push
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git add .
           git commit -m "chore: deploy testing subgraphs [skip ci]"

--- a/.github/workflows/publish-alpha.yaml
+++ b/.github/workflows/publish-alpha.yaml
@@ -83,4 +83,4 @@ jobs:
     if: needs.publish.outputs.SUBGRAPH_CHANGES == 'true'
     secrets:
       ORMI_0x_GRAPH_API_KEY_TESTING: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

{{what was done}}

## How to test

{{how can it be tested}}
