### PR TITLE
ci: fix staging subgraph deployment workflow

### DIFF
--- a/.github/workflows/deploy-prod-subgraph.yaml
+++ b/.github/workflows/deploy-prod-subgraph.yaml
@@ -10,6 +10,8 @@ jobs:
     name: Deploy subgraph
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BSNORG_ACTIONS_SECRET }}
       - uses: actions/setup-node@v3
         with:
           node-version: "20"
@@ -46,4 +48,4 @@ jobs:
         run: |
           git add .
           git commit -m "chore: deploy production subgraphs [skip ci]"
-          git push
+          git push origin HEAD

--- a/.github/workflows/deploy-staging-subgraph.yaml
+++ b/.github/workflows/deploy-staging-subgraph.yaml
@@ -50,4 +50,4 @@ jobs:
         run: |
           git add .
           git commit -m "chore: deploy staging subgraphs [skip ci]"
-          git push
+          git push origin HEAD:main


### PR DESCRIPTION
## Description

As the staging workflow is run on a release (tag), the checkout is with detached HEAD, meaning it's not possible to just make change and push them.
==> We specify the main branch as the branch where to push in

In addition, some changes done in testing / staging wrokflow are reported in the production workflow as an ancipation before it being tested

## How to test

{{how can it be tested}}
