### PR TITLE
ci: force the production subgraph deployment to be on a release tag

### DIFF
--- a/.github/workflows/deploy-prod-subgraph.yaml
+++ b/.github/workflows/deploy-prod-subgraph.yaml
@@ -2,7 +2,10 @@ name: Deploy subgraph to production env
 
 on:
   workflow_dispatch:
-    branches: [main]
+    inputs:
+      version:
+        description: "The subgraph version to deploy. For example, 1.34.0. The given number should correspond to an existing tag @bosonprotocol/subgraph@<VERSION>"
+        required: true
 
 jobs:
   deploy:
@@ -12,6 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.BSNORG_ACTIONS_SECRET }}
+          ref: ref/tags/@bosonprotocol/subgraph@${{ inputs.version }}
       - uses: actions/setup-node@v3
         with:
           node-version: "20"
@@ -48,4 +52,4 @@ jobs:
         run: |
           git add .
           git commit -m "chore: deploy production subgraphs [skip ci]"
-          git push origin HEAD
+          git push origin HEAD:main

--- a/.github/workflows/deploy-prod-subgraph.yaml
+++ b/.github/workflows/deploy-prod-subgraph.yaml
@@ -51,6 +51,7 @@ jobs:
           GH_TOKEN: ${{ secrets.BSNORG_ACTIONS_SECRET }}
           GITHUB_TOKEN: ${{ secrets.BSNORG_ACTIONS_SECRET }}
         run: |
+          git pull origin main
           git add .
           git commit -m "chore: deploy production subgraphs [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/deploy-prod-subgraph.yaml
+++ b/.github/workflows/deploy-prod-subgraph.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.BSNORG_ACTIONS_SECRET }}
-          ref: @bosonprotocol/subgraph@${{ inputs.version }}
+          ref: "@bosonprotocol/subgraph@${{ inputs.version }}"
           fetch-depth: "0"
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/deploy-prod-subgraph.yaml
+++ b/.github/workflows/deploy-prod-subgraph.yaml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.BSNORG_ACTIONS_SECRET }}
-          ref: ref/tags/@bosonprotocol/subgraph@${{ inputs.version }}
+          ref: @bosonprotocol/subgraph@${{ inputs.version }}
+          fetch-depth: "0"
       - uses: actions/setup-node@v3
         with:
           node-version: "20"


### PR DESCRIPTION
## Description

{{what was done}}

## How to test

{{how can it be tested}}
