### PR TITLE
ci: force OS version to ubuntu-22.04 for CI GH workflow (to avoid sub…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-build-test:
     name: Lint, build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       JOB_LINT: ${{ steps.lint.outcome }}
       JOB_TEST: ${{ steps.test.outcome }}


### PR DESCRIPTION
…graph test failure)

## Description

Error when running the CI pipeline, in subgraph package test:
![image](https://github.com/user-attachments/assets/f3d2ac81-78bd-4e11-af03-e3c9b9573b49)

Solution is to set a fixed version for the pipeline OS

## How to test

GH pipeline
