### PR TITLE
fix: ipfs image race condition

### DIFF
--- a/packages/react-kit/src/components/ui/IpfsImage.tsx
+++ b/packages/react-kit/src/components/ui/IpfsImage.tsx
@@ -17,8 +17,7 @@ import { zIndex } from "./zIndex";
 
 type LoadingStatus = "loading" | "success" | "error";
 
-const ImageWrapper = styled.div<{ $hide?: boolean }>`
-  display: ${({ $hide }) => ($hide ? "none !important" : undefined)};
+const ImageWrapper = styled.div`
   overflow: hidden;
   position: relative;
   z-index: ${zIndex.OfferCard};
@@ -52,17 +51,25 @@ const ImageContainer = styled.img`
   object-fit: cover;
 `;
 
-const ImagePlaceholder = styled.div`
+const Overlay = styled.div<{ $visible: boolean }>`
+  display: ${({ $visible }) => ($visible ? "flex" : "none")};
   position: absolute;
   top: 0;
-  height: 100%;
+  left: 0;
   width: 100%;
+  height: 100%;
   background-color: ${colors.greyDark};
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 1;
+`;
+
+const ImagePlaceholder = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-
   span {
     ${buttonText}
     font-size: inherit;
@@ -115,33 +122,64 @@ export const IpfsImage: React.FC<IpfsImageProps> = ({
     if (src === currentSrc) {
       return;
     }
-    // reset all if src changes
-    setStatus(withLoading ? "loading" : "success");
+    setStatus((status) =>
+      status === "success" ? "success" : withLoading ? "loading" : "success"
+    );
     setCurrentSrc(
       getImageUrl(src, overrides?.ipfsGateway || ipfsGateway, optimizationOpts)
     );
     setDidOriginalSrcFail(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [src]);
+  }, [
+    src,
+    overrides?.ipfsGateway,
+    ipfsGateway,
+    optimizationOpts,
+    currentSrc,
+    withLoading
+  ]);
+
   const isError = status === "error";
   const isLoading = status === "loading";
   const isSuccess = status === "success";
 
   return (
-    <>
-      <ImageWrapper
-        {...rest}
-        $hide={!isLoading}
-        className={"loading-container " + rest.className}
-      >
+    <ImageWrapper {...rest} className={rest.className}>
+      <ImageContainer
+        data-testid={dataTestId}
+        src={currentSrc}
+        alt={alt}
+        onLoad={() => handleSetStatus("success")}
+        onError={() => {
+          if (didOriginalSrcFail) {
+            handleSetStatus("error");
+          } else {
+            setDidOriginalSrcFail(true);
+            const fallbackUrl = getFallbackImageUrl(
+              src,
+              ipfsGateway,
+              optimizationOpts
+            );
+            if (
+              fallbackUrl.startsWith("unsafe:") ||
+              fallbackUrl === currentSrc
+            ) {
+              handleSetStatus("error");
+            } else {
+              setCurrentSrc(fallbackUrl);
+            }
+          }
+        }}
+      />
+      {children}
+      <Overlay $visible={isLoading}>
         <ImagePlaceholder>
           <Typography tag="div">
             <Loading />
           </Typography>
         </ImagePlaceholder>
-      </ImageWrapper>
-      <ImageWrapper {...rest} $hide={!isError}>
-        <ImagePlaceholder data-image-placeholder>
+      </Overlay>
+      <Overlay $visible={!isLoading && (isError || !isSuccess)}>
+        <ImagePlaceholder>
           {showPlaceholderText ? (
             <ImageIcon size={50} color={colors.white} />
           ) : (
@@ -151,40 +189,7 @@ export const IpfsImage: React.FC<IpfsImageProps> = ({
             <Typography tag="span">IMAGE NOT AVAILABLE</Typography>
           )}
         </ImagePlaceholder>
-      </ImageWrapper>
-      <ImageWrapper
-        {...rest}
-        $hide={!isSuccess}
-        className={"image-container " + rest.className}
-      >
-        {children || ""}
-        <ImageContainer
-          data-testid={dataTestId}
-          src={currentSrc}
-          alt={alt}
-          onLoad={() => handleSetStatus("success")}
-          onError={() => {
-            if (didOriginalSrcFail) {
-              handleSetStatus("error");
-            } else {
-              setDidOriginalSrcFail(true);
-              const fallbackUrl = getFallbackImageUrl(
-                src,
-                ipfsGateway,
-                optimizationOpts
-              );
-              if (
-                fallbackUrl.startsWith("unsafe:") ||
-                fallbackUrl === currentSrc
-              ) {
-                handleSetStatus("error");
-              } else {
-                setCurrentSrc(fallbackUrl);
-              }
-            }
-          }}
-        />
-      </ImageWrapper>
-    </>
+      </Overlay>
+    </ImageWrapper>
   );
 };

--- a/packages/react-kit/src/components/widgets/finance/FinanceWidgetProviders.tsx
+++ b/packages/react-kit/src/components/widgets/finance/FinanceWidgetProviders.tsx
@@ -8,7 +8,6 @@ import {
 import { ModalProvider } from "../../modal/ModalProvider";
 import { withQueryClientProvider } from "../../queryClient/withQueryClientProvider";
 import { SignerProvider } from "../../signer/SignerProvider";
-import GlobalStyle from "../../styles/GlobalStyle";
 import { WithReduxProvider, WithReduxProviderProps } from "../ReduxProvider";
 import { getParentWindowOrigin } from "../common";
 import { CommonWidgetTypes } from "../types";

--- a/packages/react-kit/src/components/widgets/finance/FinanceWidgetProviders.tsx
+++ b/packages/react-kit/src/components/widgets/finance/FinanceWidgetProviders.tsx
@@ -65,7 +65,6 @@ export const FinanceWidgetProviders: React.FC<FinanceWidgetProvidersProps> =
             >
               <BlockNumberProvider>
                 <BosonProvider {...props}>
-                  <GlobalStyle />
                   <SignerProvider
                     parentOrigin={parentOrigin}
                     withExternalSigner={props.withExternalSigner}

--- a/packages/react-kit/src/components/widgets/redemption/RedemptionWidgetProviders.tsx
+++ b/packages/react-kit/src/components/widgets/redemption/RedemptionWidgetProviders.tsx
@@ -9,7 +9,6 @@ import { IpfsProvider, IpfsProviderProps } from "../../ipfs/IpfsProvider";
 import { ModalProvider } from "../../modal/ModalProvider";
 import { withQueryClientProvider } from "../../queryClient/withQueryClientProvider";
 import { SignerProvider } from "../../signer/SignerProvider";
-import GlobalStyle from "../../styles/GlobalStyle";
 import { WithReduxProvider, WithReduxProviderProps } from "../ReduxProvider";
 import { getParentWindowOrigin } from "../common";
 import ConvertionRateProvider, {

--- a/packages/react-kit/src/components/widgets/redemption/RedemptionWidgetProviders.tsx
+++ b/packages/react-kit/src/components/widgets/redemption/RedemptionWidgetProviders.tsx
@@ -78,7 +78,6 @@ export const RedemptionWidgetProviders: React.FC<RedemptionWidgetProvidersProps>
               <RobloxProvider>
                 <BlockNumberProvider>
                   <BosonProvider {...props}>
-                    <GlobalStyle />
                     <SignerProvider
                       parentOrigin={parentOrigin}
                       withExternalSigner={props.withExternalSigner}


### PR DESCRIPTION
sometimes the IpfsImage showed the loading spinner even if the image was already loaded...this is because the browser doesnt load images that are hidden behind "display: none" and there was a race condition that should be fixed now

the change is to basically show the loading and error states on top of the actual image so the img tag is never hidden by "display: none"