### PR TITLE
chore(release): publish latest [skip ci]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43847,7 +43847,7 @@
     },
     "packages/subgraph": {
       "name": "@bosonprotocol/subgraph",
-      "version": "1.34.2",
+      "version": "1.36.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphprotocol/graph-cli": "0.68.5",

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.36.0](https://github.com/bosonprotocol/core-components/compare/@bosonprotocol/subgraph@1.34.2...@bosonprotocol/subgraph@1.36.0) (2025-01-28)
+
+**Note:** Version bump only for package @bosonprotocol/subgraph
+
+
+
+
+
 ## [1.34.2](https://github.com/bosonprotocol/core-components/compare/@bosonprotocol/subgraph@1.34.1...@bosonprotocol/subgraph@1.34.2) (2024-11-22)
 
 **Note:** Version bump only for package @bosonprotocol/subgraph

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bosonprotocol/subgraph",
-  "version": "1.34.2",
+  "version": "1.36.0",
   "config": {
     "node": "https://api.0xgraph.xyz/deploy/",
     "ipfs": "https://api.0xgraph.xyz/ipfs",


### PR DESCRIPTION
 - @bosonprotocol/subgraph@1.36.0

## Description

{{what was done}}

## How to test

{{how can it be tested}}
