### PR TITLE
fix: add missing environment for post subgraph deployment with Ormi

### DIFF
--- a/packages/subgraph/scripts/post-deploy-on-ormi.ts
+++ b/packages/subgraph/scripts/post-deploy-on-ormi.ts
@@ -11,10 +11,13 @@ program
       .choices([
         "testing_amoy",
         "testing_sepolia",
+        "testing_base",
         "staging_amoy",
         "staging_sepolia",
+        "staging_base",
         "production_polygon",
-        "production_ethereum"
+        "production_ethereum",
+        "production_base"
       ])
   )
   .parse(process.argv);


### PR DESCRIPTION
## Description

{{what was done}}

## How to test

{{how can it be tested}}
