### PR TITLE
style: change select styles when disabled

### DIFF
--- a/packages/react-kit/src/components/form/Select.tsx
+++ b/packages/react-kit/src/components/form/Select.tsx
@@ -25,6 +25,8 @@ const customStyles = <Option extends Record<string, unknown> = SelectDataProps>(
           }
         }
       : null;
+    const defaultBorderColor =
+      customTheme?.control?.borderColor || colors.border;
     return {
       ...provided,
       borderRadius: 0,
@@ -32,22 +34,39 @@ const customStyles = <Option extends Record<string, unknown> = SelectDataProps>(
       boxShadow: "none",
       background: getCssVar("--background-color"),
       ...customTheme?.control,
-      border: state.isFocused
-        ? (customTheme?.control?.focus?.border ?? `1px solid ${colors.violet}`)
-        : !checkIfValueIsEmpty(error)
-          ? (customTheme?.control?.error?.border ??
-            `1px solid ${colors.orange}`)
-          : (customTheme?.control?.border ?? `1px solid ${colors.border}`),
-      ":hover": {
-        borderColor: colors.violet,
-        borderWidth: "1px",
-        ...customTheme?.control?.hover
-      },
+      cursor: state.isDisabled ? "not-allowed" : "default",
+      opacity: state.isDisabled
+        ? (customTheme?.control?.disabled?.opacity ?? "0.5")
+        : (customTheme?.control?.opacity ?? "1"),
+      border: state.isDisabled
+        ? `1px solid ${defaultBorderColor}`
+        : state.isFocused
+          ? (customTheme?.control?.focus?.border ??
+            `1px solid ${colors.violet}`)
+          : !checkIfValueIsEmpty(error)
+            ? (customTheme?.control?.error?.border ??
+              `1px solid ${colors.orange}`)
+            : (customTheme?.control?.border ??
+              `1px solid ${defaultBorderColor}`),
+      ...(state.isDisabled
+        ? {
+            ":hover": {
+              border: `1px solid ${defaultBorderColor}`
+            }
+          }
+        : {
+            ":hover": {
+              borderColor: colors.violet,
+              borderWidth: "1px",
+              ...customTheme?.control?.hover
+            }
+          }),
       ...before
     };
   },
   container: (provided, state: any) => ({
     ...provided,
+    pointerEvents: "initial",
     zIndex: state.isFocused ? zIndex.Select + 1 : zIndex.Select,
     position: "relative",
     width: "100%"
@@ -55,7 +74,7 @@ const customStyles = <Option extends Record<string, unknown> = SelectDataProps>(
   option: (provided, state: any) => {
     return {
       ...provided,
-      cursor: state.isDisabled ? "not-allowed" : "pointer",
+      cursor: state.isDisabled ? "not-allowed" : "default",
       opacity: state.isDisabled
         ? (customTheme?.option?.disabled?.opacity ?? "0.5")
         : (customTheme?.option?.opacity ?? "1"),
@@ -72,6 +91,14 @@ const customStyles = <Option extends Record<string, unknown> = SelectDataProps>(
         customTheme?.option?.selected),
       ...(state.isFocused && customTheme?.option?.focus),
       ...(!checkIfValueIsEmpty(error) && customTheme?.option?.error)
+    };
+  },
+  indicatorsContainer: (provided, state: any) => {
+    return {
+      ...provided,
+      ...(state.isDisabled && {
+        pointerEvents: "none"
+      })
     };
   },
   indicatorSeparator: () => ({
@@ -94,6 +121,16 @@ const customStyles = <Option extends Record<string, unknown> = SelectDataProps>(
       fontSize: "13.33px",
       ...customTheme?.singleValue,
       ...(!checkIfValueIsEmpty(error) && customTheme?.singleValue?.error)
+    };
+  },
+  multiValue: (provided, state: any) => {
+    return {
+      ...provided,
+      ...customTheme?.multiValue,
+      ...(state.isDisabled && {
+        pointerEvents: "none"
+      }),
+      ...(!checkIfValueIsEmpty(error) && customTheme?.multiValue?.error)
     };
   }
 });
@@ -129,6 +166,9 @@ export default function SelectComponent<
     option: Parameters<NonNullable<typeof onChange>>[0],
     actionMeta: Parameters<NonNullable<typeof onChange>>[1]
   ) => {
+    if (disabled) {
+      return;
+    }
     if (!meta.touched) {
       helpers.setTouched(true);
     }

--- a/packages/react-kit/src/components/form/types.ts
+++ b/packages/react-kit/src/components/form/types.ts
@@ -145,6 +145,7 @@ export type SelectProps<
   theme?: Partial<{
     control: Partial<CSSProperties> &
       Partial<{
+        disabled: Partial<CSSProperties>;
         hover: Partial<CSSProperties>;
         focus: Partial<CSSProperties>;
         error: Partial<CSSProperties>;
@@ -161,6 +162,7 @@ export type SelectProps<
     input: Partial<CSSProperties> & Partial<{ error: CSSObjectWithLabel }>;
     singleValue: Partial<CSSProperties> &
       Partial<{ error: CSSObjectWithLabel }>;
+    multiValue: Partial<CSSProperties> & Partial<{ error: CSSObjectWithLabel }>;
   }>;
 } & SupportedReactSelectProps<M, Option>;
 

--- a/packages/react-kit/src/stories/selects/Select.stories.tsx
+++ b/packages/react-kit/src/stories/selects/Select.stories.tsx
@@ -30,6 +30,9 @@ export default {
       }
     },
     disabled: { control: "boolean" },
+    isMulti: { control: "boolean" },
+    isClearable: { control: "boolean" },
+    isSearchable: { control: "boolean" },
     placeholder: { control: "text" }
   },
   decorators: [
@@ -58,7 +61,7 @@ const BASE_ARGS = {
   name: inputName,
   options: [
     { label: "first option", value: "1" },
-    { label: "second option", value: "2" },
+    { label: "second option", value: "2", disabled: true },
     { label: "third option", value: "3" }
   ]
 } as SelectProps;


### PR DESCRIPTION
if the select is disabled now:

- cursor should change to not-allowed
- border and caret down indicator should not change in color when hovered
- X buttons on selected options when select isMulti should not change in style when hovered