### PR TITLE
fix: props commit button view in stories

### DIFF
--- a/packages/react-kit/src/stories/buttons/CommitButtonView.stories.tsx
+++ b/packages/react-kit/src/stories/buttons/CommitButtonView.stories.tsx
@@ -6,6 +6,7 @@ import { BosonThemeProvider } from "../../components/widgets/BosonThemeProvider"
 import { withThemeFromJSXProvider } from "@storybook/addon-themes";
 import { getThemes } from "../../theme";
 import GlobalStyle from "../../components/styles/GlobalStyle";
+import { CommitButtonViewProps } from "../../components/buttons/commit/types";
 
 const themes = Object.keys({
   light: getThemes({ roundness: "min" })["light"]
@@ -51,10 +52,9 @@ export const Base = Template.bind({});
 Base.args = {
   disabled: false,
   onClick: () => console.log("click"),
-  onTaglineClick: () => console.log("tagline click"),
   minWidth: "200px",
-  minHeight: "300px",
+  minHeight: undefined,
   layout: "horizontal",
   color: "green",
   shape: "sharp"
-};
+} satisfies CommitButtonViewProps;


### PR DESCRIPTION
if we dont set the minHeight to undefined, then its value takes precedence over what's defined in the url and therefore it doesnt look good in the docs site:

![image](https://github.com/user-attachments/assets/3a23ff30-4d79-4b35-96b7-30584ada1ad7)
