### PR TITLE
chore: rationalize getOpenSeaUrl() implementation between Boson CC an…

### DIFF
--- a/packages/react-kit/src/components/modal/components/Commit/DetailView/RedeemWhatsNext.tsx
+++ b/packages/react-kit/src/components/modal/components/Commit/DetailView/RedeemWhatsNext.tsx
@@ -12,6 +12,7 @@ import { colors, getCssVar } from "../../../../../theme";
 import { useModal } from "../../../useModal";
 import { RequestShipmentModalProps } from "../../RequestShipment/RequestShipmentModal";
 import ThemedButton from "../../../../ui/ThemedButton";
+import { getExchangeTokenId } from "../../../../../lib/utils/exchange";
 
 const DividerWrapper = styled.div`
   width: 100%;
@@ -131,7 +132,8 @@ export const RedeemWhatsNext = ({
               href={getOpenSeaUrl({
                 configId: config.configId,
                 envName: config.envName,
-                exchange
+                tokenId: getExchangeTokenId(exchange, config.envName),
+                contractAddress: exchange.seller.voucherCloneAddress
               })}
               target="_blank"
               rel="noreferrer"

--- a/packages/react-kit/src/components/modal/components/common/DetailOpenSea.tsx
+++ b/packages/react-kit/src/components/modal/components/common/DetailOpenSea.tsx
@@ -6,6 +6,7 @@ import { useEnvContext } from "../../../environment/EnvironmentContext";
 
 import { OpenSeaButton } from "./detail/Detail.style";
 import { getOpenSeaUrl } from "../../../../lib/opensea/getOpenSeaUrl";
+import { getExchangeTokenId } from "../../../../lib/utils/exchange";
 
 interface Props {
   exchange?: Exchange;
@@ -22,11 +23,14 @@ export default function DetailOpenSea({ exchange }: Props) {
     !exchangeStatus || exchangeStatus === subgraph.ExchangeState.COMMITTED;
 
   const openSeaUrl = useMemo(() => {
-    return getOpenSeaUrl({
-      exchange,
-      envName,
-      configId
-    });
+    return exchange
+      ? getOpenSeaUrl({
+          envName,
+          configId,
+          tokenId: getExchangeTokenId(exchange, envName),
+          contractAddress: exchange.seller.voucherCloneAddress
+        })
+      : "";
   }, [exchange, envName, configId]);
 
   if (!isToRedeem) {

--- a/packages/react-kit/src/lib/opensea/getOpenSeaUrl.ts
+++ b/packages/react-kit/src/lib/opensea/getOpenSeaUrl.ts
@@ -98,17 +98,15 @@ const openSeaUrlMap = new Map([
 export const getOpenSeaUrl = ({
   configId,
   envName,
-  exchange
+  tokenId,
+  contractAddress
 }: {
   envName: EnvironmentType;
   configId: ConfigId;
-  exchange: Exchange | undefined;
+  tokenId: string;
+  contractAddress: string;
 }): string => {
-  if (!exchange) {
-    return "";
-  }
-  const tokenId = getExchangeTokenId(exchange, envName);
   const urlFn = openSeaUrlMap.get(envName)?.get(configId);
 
-  return urlFn?.(tokenId, exchange.seller.voucherCloneAddress) || "";
+  return urlFn?.(tokenId, contractAddress) || "";
 };

--- a/packages/react-kit/src/stories/opensea/DetailOpenSea.stories.tsx
+++ b/packages/react-kit/src/stories/opensea/DetailOpenSea.stories.tsx
@@ -1,0 +1,109 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { ArrowSquareOut } from "phosphor-react";
+
+import { Exchange } from "../../types/exchange";
+import { EnvironmentProvider } from "../../components/environment/EnvironmentProvider";
+import { OpenSeaButton } from "../../components/modal/components/common/detail/Detail.style";
+import { getOpenSeaUrl } from "../../lib/opensea/getOpenSeaUrl";
+import { getExchangeTokenId } from "../../lib/utils/exchange";
+
+const meta = {
+  title: "Visual Components/Opensea/DetailOpenSea",
+  component: OpenSeaButton,
+  decorators: [
+    (Story, { args }) => {
+      const exchange = {
+        id: args.exchangeId,
+        committedDate: Math.floor(Date.now() / 1000),
+        offer: {
+          id: args.offerId
+        },
+        seller: {
+          voucherCloneAddress: args.voucherCloneAddress
+        }
+      } as unknown as Exchange;
+      const openSeaUrl = getOpenSeaUrl({
+        envName: args.envName,
+        configId: args.configId,
+        tokenId: getExchangeTokenId(exchange, args.envName),
+        contractAddress: exchange.seller.voucherCloneAddress
+      });
+      return (
+        <EnvironmentProvider envName={args.envName} configId={args.configId}>
+          <OpenSeaButton
+            href={openSeaUrl}
+            $disabled={!openSeaUrl}
+            target="_blank"
+          >
+            View on OpenSea
+            <ArrowSquareOut size={18} />
+          </OpenSeaButton>
+        </EnvironmentProvider>
+      );
+    }
+  ]
+} as ComponentMeta<typeof OpenSeaButton>;
+
+export default meta;
+
+const Template: ComponentStory<typeof OpenSeaButton> = (args) => (
+  <OpenSeaButton {...args} />
+);
+
+export const TestingAmoy: ComponentStory<typeof OpenSeaButton> = Template.bind(
+  {}
+);
+TestingAmoy.args = {
+  disabled: false,
+  envName: "testing",
+  configId: "testing-80002-0",
+  exchangeId: "1100",
+  offerId: "228",
+  voucherCloneAddress: "0xf79c7b5745ba851cda7c6e17fc3fc72b75166836"
+};
+
+export const TestingSepolia: ComponentStory<typeof OpenSeaButton> =
+  Template.bind({});
+TestingSepolia.args = {
+  disabled: false,
+  envName: "testing",
+  configId: "testing-11155111-0",
+  exchangeId: "12",
+  offerId: "8",
+  voucherCloneAddress: "0xf79c7b5745ba851cda7c6e17fc3fc72b75166836"
+};
+
+export const TestingOptimism: ComponentStory<typeof OpenSeaButton> =
+  Template.bind({});
+TestingOptimism.args = {
+  disabled: false,
+  envName: "testing",
+  configId: "testing-11155420-0",
+  exchangeId: "3",
+  offerId: "4",
+  voucherCloneAddress: "0x041f56fe77ac1558cc415de46f7777234d9d141a"
+};
+
+export const TestingArbitrum: ComponentStory<typeof OpenSeaButton> =
+  Template.bind({});
+TestingArbitrum.args = {
+  disabled: false,
+  envName: "testing",
+  configId: "testing-421614-0",
+  exchangeId: "3",
+  offerId: "4",
+  voucherCloneAddress: "0x041f56fe77ac1558cc415de46f7777234d9d141a"
+};
+
+export const TestingBase: ComponentStory<typeof OpenSeaButton> = Template.bind(
+  {}
+);
+TestingBase.args = {
+  disabled: false,
+  envName: "testing",
+  configId: "testing-84532-0",
+  exchangeId: "6",
+  offerId: "10",
+  voucherCloneAddress: "0x041f56fe77ac1558cc415de46f7777234d9d141a"
+};


### PR DESCRIPTION
…d Fermion UI

## Description

Initially we have 2 different implementation of getOpenSeaUrl():
- in Boson CC: `getOpenSeaUrl = ({configId,envName,exchange}): string`
- in Fermion UI: `getOpenSeaUrl = ({configId,envName,tokenId,contractAddress}): string`

Fermion UI can't use the Boson implementation because the exchange type is not used the same way.
In order to use the same method in both projects, we change the method signature in Boson CC

NOTE: Boson dApp doesn't currently use the react-kit component, instead it reimplements DetailOpenSea.
https://github.com/bosonprotocol/interface/blob/dc70b2f8c56f764d227ed90ccaade4ec74868d7e/src/components/detail/DetailOpenSea.tsx#L62
This will be changed as well

## How to test

Check the DetailOpenSea story in Storybook
![image](https://github.com/user-attachments/assets/3f6e14db-b363-49a8-b2b0-7a56db3d5be9)

