### PR TITLE
fix: improve style of the offer overview in case of a bundle

### DIFF
--- a/packages/react-kit/src/components/modal/components/common/OfferFullDescription/Overview.tsx
+++ b/packages/react-kit/src/components/modal/components/common/OfferFullDescription/Overview.tsx
@@ -56,7 +56,7 @@ export const Overview: React.FC<OverviewProps> = ({ offer }) => {
         style={{ alignItems: "center", width: "100%" }}
       >
         <Typography tag="h3">Phygital description</Typography>
-        <Typography tag="p" style={{ whiteSpace: "pre-wrap" }}>
+        <Typography style={{ whiteSpace: "pre-wrap" }}>
           {offer.metadata?.description}
         </Typography>
       </ResponsiveGridContainer>


### PR DESCRIPTION
## Description

fixes https://github.com/bosonprotocol/interface/issues/1174

## How to test

use storybook

BEFORE
<img width="1546" height="694" alt="image" src="https://github.com/user-attachments/assets/2ca27481-9487-475e-9ccb-e660ad9a034f" />

AFTER
<img width="1524" height="790" alt="image" src="https://github.com/user-attachments/assets/3f8102c2-54cf-49da-b53b-435498ef326b" />
