### PR TITLE
docs: add documentation for buyer-initiated offers and createOfferAnd…

### DIFF
--- a/docs/details/buyerInitiatedOffers.md
+++ b/docs/details/buyerInitiatedOffers.md
@@ -1,0 +1,131 @@
+# Synthesis: Buyer-Initiated Offers — `core-sdk-offers.test.ts`
+
+## Overview
+
+In a **buyer-initiated offer**, the buyer creates and signs the offer; the seller is the one who "commits" to it (i.e. accepts the deal). This is the reverse of the standard flow.
+
+Key constraint: `quantityAvailable` **must be 1** — buyer-initiated offers are always single-unit.
+
+---
+
+## Method Involved
+
+`sellerCoreSDK.commitToBuyerOffer(offerId, sellerParams?)` — the seller-side equivalent of `commitToOffer`. Takes an optional `sellerParams` to customise collection, mutualizer, and royalty info at commit time.
+
+The symmetric error guards are also tested:
+- `commitToOffer()` (seller-offer method) called on a buyer-initiated offer → `"Offer with id X is not seller initiated"`
+- `commitToBuyerOffer()` (buyer-offer method) called on a seller-initiated offer → `"Offer with id X is not buyer initiated"`
+
+---
+
+## Prerequisites
+
+### 1. Dispute resolver with a non-zero fee — created once (`beforeAll`)
+A dedicated dispute resolver is created via `createDisputeResolver()` with:
+- A fee of `0.0123 ETH` on the native token (`AddressZero`)
+- An open seller allow-list (`[]`)
+
+This DR is shared across all tests in the suite.
+
+### 2. Fresh buyer + seller SDKs — created per test (`beforeEach`)
+`initSellerAndBuyerSDKs(seedWallet)` produces two independent funded wallets and `CoreSDK` instances.
+
+### 3. Buyer-initiated offer already on-chain (`beforeEach`)
+`createOffer(buyerCoreSDK, { creator: OfferCreator.Buyer, quantityAvailable: 1, disputeResolverId, exchangeToken })` creates the offer as the buyer. The resulting `buyerInitiatedOffer` has:
+- `offer.buyer` set (buyer's account)
+- `offer.seller` **not set** yet (seller is assigned at commit time)
+- `offer.creator === OfferCreator.Buyer`
+
+### 4. Seller account registered (`beforeEach`)
+`createSeller(sellerCoreSDK, sellerWallet.address)` — mandatory before committing.
+
+### 5. Both parties deposit funds (`beforeEach`)
+- **Buyer** deposits the offer price into their buyer account (`buyerCoreSDK.depositFunds(buyerInitiatedOffer.buyerId, price, token)`)
+- **Seller** deposits the DR fee amount (`sellerCoreSDK.depositFunds(seller.id, drFeeAmount, token)`)
+
+Both deposits are moved to escrow when the seller commits.
+
+---
+
+## Test Cases
+
+### Happy path — basic commit
+
+**"Seller commits to the offer, no seller param"**
+
+The seller calls `commitToBuyerOffer(offerId)` with no extra params.
+
+Verifications:
+- Before commit: buyer's available funds = offer price; seller's available funds = DR fee
+- After commit:
+  - `exchange.state === ExchangeState.COMMITTED`
+  - `exchange.seller.id` === seller's id; `exchange.buyer.id` === buyer's id
+  - Buyer's available funds drop to `"0"` (moved to escrow)
+  - Seller's available funds drop to `"0"` (moved to escrow)
+  - `offer.seller` is now assigned to the committing seller
+
+---
+
+### Happy path — optional `sellerParams`
+
+Three tests cover the optional parameters the seller can pass at commit time:
+
+| Test | `sellerParams` field | What is verified |
+|---|---|---|
+| "set offer collection" | `{ collectionIndex: 1 }` | `exchange.offer.collectionIndex === "1"` and collection's `externalId` matches |
+| "set mutualizerAddress" | `{ mutualizerAddress }` | `exchange.mutualizerAddress` matches the mutualizer contract address |
+| "set royaltyInfo" | `{ royaltyInfo: { recipients, bps } }` | `exchange.offer.royaltyInfos[0]` contains the expected recipient + bps |
+
+For the mutualizer test, an agreement must be created and its premium paid before committing (`newAgreementToDRFeeMutualizer` + `payPremiumToDRFeeMutualizer`).
+
+For the collection test, the collection must be created first (`sellerCoreSDK.createNewCollection({ collectionId, contractUri })`).
+
+---
+
+### Error cases
+
+| Test | Scenario | Error message |
+|---|---|---|
+| "commitToOffer() fails on buyer initiated offer" | Wrong commit method used on a buyer-initiated offer | `"Offer with id X is not seller initiated"` |
+| "commitToBuyerOffer() fails on seller initiated offer" | Wrong commit method used on a standard offer | `"Offer with id X is not buyer initiated"` |
+| "Quantity must be 1 for buyer initiated offers" | `createOffer` with `OfferCreator.Buyer` and `quantityAvailable: 2` | `"Quantity must be 1 for buyer initiated offers"` |
+
+---
+
+## Fund Flow Summary
+
+```
+beforeEach:  buyer deposits price  →  buyer account (available)
+             seller deposits drFee  →  seller account (available)
+
+commitToBuyerOffer():
+             buyer available  → 0  (moved to escrow)
+             seller available → 0  (moved to escrow)
+```
+
+---
+
+## Key Assertions Checklist (successful commit)
+
+- `exchange.state === ExchangeState.COMMITTED`
+- `exchange.offer.id` matches `buyerInitiatedOffer.id`
+- `exchange.seller.id` matches the committing seller's id
+- `exchange.seller.assistant` matches `sellerWallet.address` (lowercase)
+- `exchange.buyer.id` matches `buyerInitiatedOffer.buyerId`
+- `exchange.buyer.wallet` matches `buyerWallet.address` (lowercase)
+- Buyer funds `availableAmount === "0"` after commit
+- Seller funds `availableAmount === "0"` after commit
+- `offer.seller` is populated after commit (was falsy before)
+
+---
+
+## Files
+
+- Test file: `e2e/tests/core-sdk-offers.test.ts`
+- Helpers: `e2e/tests/utils.ts`
+  - `commitToBuyerOffer` — `utils.ts:1272`
+  - `commitToOffer` — `utils.ts:1252`
+  - `createOffer` — `utils.ts:478`
+  - `createSeller` — `utils.ts:954`
+  - `createDisputeResolver` — `utils.ts:446`
+  - `initSellerAndBuyerSDKs` — `utils.ts:263`

--- a/docs/details/buyerInitiatedOffers.md
+++ b/docs/details/buyerInitiatedOffers.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In a **buyer-initiated offer**, the buyer creates and signs the offer; the seller is the one who "commits" to it (i.e. accepts the deal). This is the reverse of the standard flow.
+In a **buyer-initiated offer**, the buyer creates the offer on-chain; the seller is the one who "commits" to it (i.e. accepts the deal). This is the reverse of the standard flow.
 
 Key constraint: `quantityAvailable` **must be 1** — buyer-initiated offers are always single-unit.
 
@@ -123,9 +123,9 @@ commitToBuyerOffer():
 
 - Test file: `e2e/tests/core-sdk-offers.test.ts`
 - Helpers: `e2e/tests/utils.ts`
-  - `commitToBuyerOffer` — `utils.ts:1272`
-  - `commitToOffer` — `utils.ts:1252`
-  - `createOffer` — `utils.ts:478`
-  - `createSeller` — `utils.ts:954`
-  - `createDisputeResolver` — `utils.ts:446`
-  - `initSellerAndBuyerSDKs` — `utils.ts:263`
+  - `commitToBuyerOffer`
+  - `commitToOffer`
+  - `createOffer`
+  - `createSeller`
+  - `createDisputeResolver`
+  - `initSellerAndBuyerSDKs`

--- a/docs/details/createOfferAndCommit.md
+++ b/docs/details/createOfferAndCommit.md
@@ -2,7 +2,7 @@
 
 ## What the method does
 
-`createOfferAndCommit` (helper in `e2e/tests/utils.ts:660`) atomically:
+`createOfferAndCommit` (helper in `e2e/tests/utils.ts`) atomically:
 1. Has the **offer creator** sign the offer (`signFullOffer`)
 2. Has the **committer** broadcast a single blockchain transaction that both *creates* the offer and *commits* to it
 3. Waits for the tx receipt, extracts `offerId` and `exchangeId` from logs
@@ -46,7 +46,7 @@ The underlying SDK method `CoreSDK.createOfferAndCommit()` also accepts `{ retur
 `initSellerAndBuyerSDKs` (`utils.ts:263`) creates two fresh wallets (seller + buyer), each funded with ETH from a seed wallet. Both parties must have enough native ETH to pay for gas (and for the commit price in native-ETH offers).
 
 ### 2. Seller account registered on-chain — `createSeller` is mandatory
-`createSeller` (`utils.ts:954`) must be called before any `createOfferAndCommit`. It:
+`createSeller` (`utils.ts`) must be called before any `createOfferAndCommit`. It:
 - Stores seller metadata on IPFS
 - Calls `coreSDK.createSeller()` on-chain (registering `assistant`, `admin`, `treasury` addresses)
 - Returns the `sellerId` that is embedded in `fullOfferArgsUnsigned`

--- a/docs/details/createOfferAndCommit.md
+++ b/docs/details/createOfferAndCommit.md
@@ -1,0 +1,120 @@
+# Synthesis: `createOfferAndCommit` in core-sdk.test.ts
+
+## What the method does
+
+`createOfferAndCommit` (helper in `e2e/tests/utils.ts:660`) atomically:
+1. Has the **offer creator** sign the offer (`signFullOffer`)
+2. Has the **committer** broadcast a single blockchain transaction that both *creates* the offer and *commits* to it
+3. Waits for the tx receipt, extracts `offerId` and `exchangeId` from logs
+4. Waits for the graph node to index the transaction
+5. Returns `{ offer, exchange }` fetched from the subgraph
+
+Signature:
+```ts
+createOfferAndCommit(
+  committerCoreSDK: CoreSDK,   // the party who sends the tx and commits
+  offerCreatorCoreSDK: CoreSDK, // the party who signs the offer
+  fullOfferArgsUnsigned: Omit<FullOfferArgs, "signature">
+): Promise<{ offer, exchange }>
+```
+
+The underlying SDK method `CoreSDK.createOfferAndCommit()` also accepts `{ returnTxInfo: true }` to return raw tx data instead of broadcasting.
+
+---
+
+## Two Main Use-Cases
+
+### 1. Seller-Initiated Offers (`describe("seller-initiated offers")`)
+- **Offer creator** = seller (`sellerCoreSDK`)
+- **Committer** = buyer (`buyerCoreSDK`)
+- The seller pre-signs the offer; the buyer calls the combined tx
+- `quantityInitial` > 1 → multiple buyers can commit sequentially
+- After first commit: `quantityAvailable = quantityInitial - 1`
+
+### 2. Buyer-Initiated Offers (`describe("buyer-initiated offers")`)
+- **Offer creator** = buyer (`buyerCoreSDK`)
+- **Committer** = seller (`sellerCoreSDK`)
+- The buyer pre-signs the offer; the seller calls the combined tx
+- `quantityAvailable` is always **1** → offer is sold out immediately after one commit
+- A second buyer attempting to commit gets: `"Offer with id X is sold out"`
+
+---
+
+## Prerequisites
+
+### 1. Funded wallets for both parties
+`initSellerAndBuyerSDKs` (`utils.ts:263`) creates two fresh wallets (seller + buyer), each funded with ETH from a seed wallet. Both parties must have enough native ETH to pay for gas (and for the commit price in native-ETH offers).
+
+### 2. Seller account registered on-chain — `createSeller` is mandatory
+`createSeller` (`utils.ts:954`) must be called before any `createOfferAndCommit`. It:
+- Stores seller metadata on IPFS
+- Calls `coreSDK.createSeller()` on-chain (registering `assistant`, `admin`, `treasury` addresses)
+- Returns the `sellerId` that is embedded in `fullOfferArgsUnsigned`
+
+Without a registered seller, there is no `sellerId` to reference and the offer cannot be created.
+
+### 3. Dispute resolver must exist and be active
+`checkDisputeResolver` (`core-sdk.test.ts:2215`) asserts that:
+- Dispute resolver #1 exists on-chain
+- `dr.active === true`
+- The seller is either on its allow-list or the allow-list is open (length = 0)
+
+This is a protocol-level requirement: every offer must reference a valid, active dispute resolver that accepts the seller.
+
+### 4. ERC20 tokens minted and approved (ERC20 offers only)
+For ERC20-token offers, `ensureMintedAndAllowedTokens` must be called for both wallets before committing.
+
+### 5. `fullOfferArgsUnsigned` correctly built
+`buildFullOfferArgs` must receive the correct `committer`/`offerCreator` addresses, `sellerId`, `creator` enum (`OfferCreator.Seller` or `OfferCreator.Buyer`), and `quantityAvailable` (> 1 for seller-initiated, = 1 for buyer-initiated).
+
+### Summary table
+
+| Prerequisite | Seller-initiated | Buyer-initiated |
+|---|---|---|
+| Both wallets funded with ETH | ✅ | ✅ |
+| `createSeller` called → `sellerId` obtained | ✅ | ✅ |
+| Dispute resolver active & accepts seller | ✅ | ✅ |
+| ERC20 minted + approved (ERC20 tests only) | ✅ | ✅ |
+| `fullOfferArgsUnsigned` built with correct roles | ✅ | ✅ |
+| `quantityAvailable` > 1 | ✅ | ❌ (= 1) |
+
+---
+
+## Test Scenarios Covered
+
+### Happy paths
+| Test | Committer | Creator | Token |
+|---|---|---|---|
+| Buyer commits to native offer | buyer | seller | ETH |
+| Buyer commits to ERC20 offer | buyer | seller | ERC20 |
+| Seller commits to native offer | seller | buyer | ETH |
+| Seller commits to ERC20 offer | seller | buyer | ERC20 |
+| Another buyer commits to same seller offer | buyer #2 | seller | ETH |
+
+### Error / void paths
+| Test | Who voids | When | Error |
+|---|---|---|---|
+| `voidOffer` after first commit | seller (or buyer) | after commit | `offer.voided = true`, next commit fails |
+| `voidNonListedOffer` before first commit | seller (or buyer) | before commit | `"The offer has been voided"` |
+| `voidNonListedOfferBatch` (3 offers) | seller (or buyer) | before commit | `"The offer has been voided"` |
+| Buyer-initiated, second commit | n/a | after first commit | `"Offer with id X is sold out"` |
+
+### Utility / inspection
+| Test | Purpose |
+|---|---|
+| `returnTxInfo: true` | Returns `{ data, to, value }` without broadcasting |
+
+---
+
+## Key Assertions (successful path)
+- `offer` is truthy and `offer.voided` is falsy
+- `offer.seller.id` matches the seller's id
+- `offer.quantityAvailable = quantityInitial - 1` (seller-initiated) or `0` (buyer-initiated)
+- `exchange.state === ExchangeState.COMMITTED`
+- `exchange.buyer.wallet` matches the buyer's address
+
+---
+
+## Files
+- Helper definition: `e2e/tests/utils.ts:660`
+- Test file: `e2e/tests/core-sdk.test.ts` (seller-initiated ~L245–430, buyer-initiated ~L534–680)


### PR DESCRIPTION
This pull request adds detailed documentation for two important flows in the offer and commit process of the core SDK: buyer-initiated offers and the atomic `createOfferAndCommit` helper. These docs provide clear overviews, prerequisites, test scenarios, and key assertions for both flows, helping developers understand and test these mechanisms more effectively.

**Buyer-Initiated Offers Documentation** (`docs/details/buyerInitiatedOffers.md`):

- Explains the reversed flow where the buyer creates the offer and the seller commits, with strict enforcement that `quantityAvailable` must be 1.
- Details the `commitToBuyerOffer` method, its parameters, and error handling, including symmetric error guards for incorrect usage of commit methods.
- Lists all prerequisites for tests, including dispute resolver setup, SDK initialization, offer creation, seller registration, and funding requirements.
- Outlines happy path and error case test scenarios, including optional seller parameters at commit time and expected error messages for invalid operations.
- Summarizes fund flow and provides a checklist of key assertions for successful commits, referencing relevant helper methods and test files.

**Atomic Offer Creation and Commit Documentation** (`docs/details/createOfferAndCommit.md`):

- Describes the `createOfferAndCommit` helper, which allows atomic creation and commitment to an offer in a single transaction, with detailed signature and step-by-step breakdown.
- Differentiates between seller-initiated and buyer-initiated use-cases, specifying roles, quantity rules, and expected behaviors after commit.
- Lists all prerequisites, including wallet funding, seller registration, dispute resolver checks, ERC20 token setup, and correct offer argument construction, with a summary table for both flows.
- Details covered test scenarios for both happy and error/void paths, including utility tests for transaction info retrieval.
- Provides key assertions for successful operations and references to helper definitions and test file locations.…Commit method

## Description

{{what was done}}

## How to test

{{how can it be tested}}
