### PR TITLE
feat: enhance meta-tx handler tests with comprehensive coverage for s…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,159 @@
+{
+  "permissions": {
+    "allow": [
+      // ========== WEB FETCH ==========
+      "WebFetch(*)",
+
+      // ========== FILE OPERATIONS (read-only & safe writes) ==========
+      "Bash(ls:*)",
+      "Bash(pwd:*)",
+      "Bash(cat:*)",
+      "Bash(mkdir:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(sed:*)",
+      "Bash(awk:*)",
+      "Bash(sort:*)",
+      "Bash(uniq:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(touch:*)",
+      "Bash(tree:*)",
+      "Bash(du:*)",
+      "Bash(df:*)",
+
+      // ========== NODE.JS / PACKAGE MANAGEMENT ==========
+      "Bash(node:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(yarn:*)",
+      "Bash(pnpm:*)",
+
+      // ========== TYPESCRIPT / BUILD ==========
+      "Bash(tsc:*)",
+      "Bash(ts-node:*)",
+
+      // ========== TESTING ==========
+      "Bash(jest:*)",
+
+      // ========== LINTING / FORMATTING ==========
+      "Bash(eslint:*)",
+      "Bash(prettier:*)",
+
+      // ========== SAFE GIT OPERATIONS ==========
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git stash list:*)",
+      "Bash(git tag:*)",
+      "Bash(git remote -v:*)",
+      "Bash(git fetch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)",
+
+      // ========== TEXT PROCESSING & UTILITIES ==========
+      "Bash(echo:*)",
+      "Bash(printf:*)",
+      "Bash(tr:*)",
+      "Bash(cut:*)",
+      "Bash(xargs:*)",
+      "Bash(jq:*)",
+      "Bash(base64:*)",
+
+      // ========== PROCESS INFO (read-only) ==========
+      "Bash(ps:*)",
+      "Bash(whoami:*)",
+      "Bash(which:*)",
+      "Bash(where:*)",
+
+      // ========== MISC UTILITIES ==========
+      "Bash(date:*)",
+      "Bash(sleep:*)",
+      "Bash(test:*)",
+      "Bash(zip:*)",
+      "Bash(unzip:*)"
+    ],
+
+    "deny": [
+      // ========== DESTRUCTIVE FILESYSTEM OPERATIONS ==========
+      "Bash(rm -rf /)",
+      "Bash(rm -rf *)",
+      "Bash(rm -rf ./*)",
+      "Bash(rm -rf ../*)",
+      "Bash(dd if=/dev/zero*)",
+      "Bash(mkfs.*)",
+      "Bash(format:*)",
+
+      // ========== DESTRUCTIVE GIT OPERATIONS ==========
+      "Bash(git push:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -f:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git checkout -- .:*)",
+      "Bash(git branch -D:*)",
+      "Bash(git restore .:*)",
+
+      // ========== PRIVILEGE ESCALATION ==========
+      "Bash(sudo:*)",
+      "Bash(su:*)",
+      "Bash(doas:*)",
+
+      // ========== FORK BOMBS ==========
+      "Bash(:(){:|:&};:)",
+
+      // ========== REVERSE SHELLS ==========
+      "Bash(/dev/tcp/*)",
+      "Bash(/dev/udp/*)",
+      "Bash(nc -e /bin/bash*)",
+      "Bash(bash -c 'exec 1<>/dev/tcp/*')",
+
+      // ========== PIPE-EXEC FROM REMOTE ==========
+      "Bash(curl * | bash*)",
+      "Bash(curl * | sh*)",
+      "Bash(wget * | bash*)",
+      "Bash(wget * | sh*)",
+      "Bash(source <(curl*)",
+      "Bash(bash <(curl*)",
+
+      // ========== CREDENTIAL THEFT ==========
+      "Bash(cat /etc/shadow*)",
+      "Bash(cat /etc/passwd*)",
+      "Bash(cat ~/.ssh/id_rsa*)",
+      "Bash(cat ~/.aws/credentials*)",
+      "Bash(cat ~/.docker/config.json*)",
+      "Bash(cat ~/.kube/config*)",
+
+      // ========== PROCESS KILLING ==========
+      "Bash(kill -9:*)",
+      "Bash(killall:*)",
+
+      // ========== LOG & AUDIT DELETION ==========
+      "Bash(history -c*)",
+      "Bash(cat /dev/null > ~/.bash_history*)",
+
+      // ========== CLOUD METADATA EXPLOITS ==========
+      "Bash(curl http://169.254.169.254/*)",
+      "Bash(curl http://metadata.google.internal/*)",
+
+      // ========== DANGEROUS EVAL / INJECTION ==========
+      "Bash(eval:*)",
+
+      // ========== KERNEL / SYSTEM MODIFICATION ==========
+      "Bash(sysctl -w*)",
+      "Bash(modprobe:*)",
+      "Bash(insmod:*)",
+      "Bash(rmmod:*)",
+      "Bash(iptables -F*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ storybook-static
 .env
 
 # claude
-.claude
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ scripts/abi-signatures.csv
 storybook-static
 .qodo
 .env
+
+# claude
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,5 @@ npm run lint:fix
 ```
 
 This fixes linting issues introduced by the changes before considering the task done.
+
+Run it **without a `cd &&` prefix** — use `npm run lint:fix` directly so it matches the `Bash(npm:*)` allow rule and does not prompt for authorisation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Claude Code Instructions
+
+## Post-task linting
+
+After completing any task (once code and test changes have been functionally validated), always run:
+
+```bash
+npm run lint:fix
+```
+
+This fixes linting issues introduced by the changes before considering the task done.

--- a/e2e/tests/meta-tx.test.ts
+++ b/e2e/tests/meta-tx.test.ts
@@ -31,12 +31,27 @@ import {
   createDisputeResolver,
   deployerWallet,
   initSellerAndBuyerSDKs,
-  buildFullOfferArgs
+  buildFullOfferArgs,
+  provider,
+  ipfsMetadataStorage,
+  graphMetadataStorage,
+  META_TX_API_KEY,
+  META_TX_API_ID_BOSON,
+  META_TX_API_ID_ERC20s,
+  defaultConfig
 } from "./utils";
 import { CoreSDK, forwarder } from "../../packages/core-sdk/src";
+import { getSignatureParameters } from "../../packages/core-sdk/src/utils/signature";
+import { UnsignedMetaTx } from "../../packages/core-sdk/src/meta-tx/handler";
+import { AgentAdapter } from "../../packages/ethers-sdk/src";
 import EvaluationMethod from "../../contracts/protocol-contracts/scripts/domain/EvaluationMethod";
 import TokenType from "../../contracts/protocol-contracts/scripts/domain/TokenType";
-import { AuthTokenType, GatingType, OfferCreator, FullOfferArgs } from "../../packages/common";
+import {
+  AuthTokenType,
+  GatingType,
+  OfferCreator,
+  FullOfferArgs
+} from "../../packages/common";
 import {
   MSEC_PER_DAY,
   MSEC_PER_SEC
@@ -752,8 +767,7 @@ describe("meta-tx", () => {
           admin: drAddress,
           treasury: drAddress,
           metadataUri: "",
-          escalationResponsePeriodInMS:
-            90 * MSEC_PER_DAY - 1 * MSEC_PER_SEC,
+          escalationResponsePeriodInMS: 90 * MSEC_PER_DAY - 1 * MSEC_PER_SEC,
           fees: [
             {
               feeAmount: drFeeAmount,
@@ -834,8 +848,7 @@ describe("meta-tx", () => {
           admin: drAddress,
           treasury: drAddress,
           metadataUri: "",
-          escalationResponsePeriodInMS:
-            90 * MSEC_PER_DAY - 1 * MSEC_PER_SEC,
+          escalationResponsePeriodInMS: 90 * MSEC_PER_DAY - 1 * MSEC_PER_SEC,
           fees: [
             {
               feeAmount: drFeeAmount,
@@ -1014,7 +1027,10 @@ describe("meta-tx", () => {
       const { signature } = await buyerCoreSDKNew.signFullOffer({
         fullOfferArgsUnsigned
       });
-      const fullOfferArgs: FullOfferArgs = { ...fullOfferArgsUnsigned, signature };
+      const fullOfferArgs: FullOfferArgs = {
+        ...fullOfferArgsUnsigned,
+        signature
+      };
 
       const nonce = Date.now();
 
@@ -1124,7 +1140,10 @@ describe("meta-tx", () => {
       const { signature } = await buyerCoreSDKNew.signFullOffer({
         fullOfferArgsUnsigned
       });
-      const fullOfferArgs: FullOfferArgs = { ...fullOfferArgsUnsigned, signature };
+      const fullOfferArgs: FullOfferArgs = {
+        ...fullOfferArgsUnsigned,
+        signature
+      };
 
       const nonce = Date.now();
 
@@ -1228,7 +1247,10 @@ describe("meta-tx", () => {
       const { signature } = await sellerCoreSDKNew.signFullOffer({
         fullOfferArgsUnsigned
       });
-      const fullOfferArgs: FullOfferArgs = { ...fullOfferArgsUnsigned, signature };
+      const fullOfferArgs: FullOfferArgs = {
+        ...fullOfferArgsUnsigned,
+        signature
+      };
 
       const nonce = Date.now();
 
@@ -1337,7 +1359,10 @@ describe("meta-tx", () => {
       const { signature } = await sellerCoreSDKNew.signFullOffer({
         fullOfferArgsUnsigned
       });
-      const fullOfferArgs: FullOfferArgs = { ...fullOfferArgsUnsigned, signature };
+      const fullOfferArgs: FullOfferArgs = {
+        ...fullOfferArgsUnsigned,
+        signature
+      };
 
       // Buyer (committer) pre-approves ERC20 token for price amount
       await approveErc20Token(
@@ -1367,6 +1392,253 @@ describe("meta-tx", () => {
       const metaTxReceipt = await metaTx.wait();
       expect(metaTxReceipt.transactionHash).toBeTruthy();
       expect(BigNumber.from(metaTxReceipt.effectiveGasPrice).gt(0)).toBe(true);
+    });
+  });
+
+  describe("open-boson-buyer-flow", () => {
+    test("seller-initiated offer with AgentAdapter and returnTypedDataToSign", async () => {
+      const exchangeToken = MOCK_ERC20_ADDRESS;
+      const sellerDeposit = "0";
+      const drFeeAmount = "0";
+
+      // Create a dispute resolver with zero ERC20 fee
+      const { fundedWallet: drFundedWallet } =
+        await initCoreSDKWithFundedWallet(sellerWallet);
+      const drAddress = drFundedWallet.address.toLowerCase();
+      const { disputeResolver } = await createDisputeResolver(
+        drFundedWallet,
+        deployerWallet,
+        {
+          assistant: drAddress,
+          admin: drAddress,
+          treasury: drAddress,
+          metadataUri: "",
+          escalationResponsePeriodInMS: 90 * MSEC_PER_DAY - 1 * MSEC_PER_SEC,
+          fees: [
+            {
+              feeAmount: drFeeAmount,
+              tokenAddress: exchangeToken,
+              tokenName: "ERC20"
+            }
+          ],
+          sellerAllowList: []
+        }
+      );
+
+      // Create fresh buyer/seller wallets
+      const {
+        sellerCoreSDK: sellerCoreSDKNew,
+        buyerWallet: buyerFundedWallet,
+        sellerWallet: sellerFundedWallet
+      } = await initSellerAndBuyerSDKs(sellerWallet);
+
+      // Mint ERC20 tokens to fresh wallets (they start with 0 ERC20 balance)
+      await ensureMintedAndAllowedTokens(
+        [buyerFundedWallet, sellerFundedWallet],
+        undefined,
+        false
+      );
+
+      // Create seller account
+      const seller = await createSeller(
+        sellerCoreSDKNew,
+        sellerFundedWallet.address
+      );
+
+      // Create buyer CoreSDK with AgentAdapter (no signer — all signing done externally)
+      const apiIds = {
+        [defaultConfig.contracts.protocolDiamond.toLowerCase()]: {
+          executeMetaTransaction: META_TX_API_ID_BOSON
+        },
+        [(defaultConfig.contracts.testErc20 as string).toLowerCase()]: {
+          executeMetaTransaction: META_TX_API_ID_ERC20s
+        }
+      };
+      const buyerCoreSdk = CoreSDK.fromDefaultConfig({
+        envName: "local",
+        configId: "local-31337-0",
+        web3Lib: new AgentAdapter(provider, {
+          signerAddress: buyerFundedWallet.address
+        }),
+        metadataStorage: ipfsMetadataStorage,
+        theGraphStorage: graphMetadataStorage,
+        metaTx: {
+          apiKey: META_TX_API_KEY,
+          apiIds
+        }
+      });
+
+      const noCondition = {
+        method: EvaluationMethod.None,
+        tokenType: TokenType.MultiToken,
+        tokenAddress: constants.AddressZero,
+        gatingType: GatingType.PerAddress,
+        minTokenId: 0,
+        maxTokenId: 0,
+        threshold: 0,
+        maxCommits: 0
+      };
+
+      // Build full offer args for seller-initiated offer with ERC20 exchange token:
+      // seller is offer creator (deposits sellerDeposit=0), buyer is committer (pays price in ERC20)
+      const fullOfferArgsUnsigned = await buildFullOfferArgs(
+        buyerCoreSdk,
+        sellerCoreSDKNew,
+        noCondition,
+        {
+          committer: buyerFundedWallet.address,
+          offerCreator: sellerFundedWallet.address,
+          sellerId: seller.id,
+          sellerOfferParams: {
+            collectionIndex: 0,
+            mutualizerAddress: constants.AddressZero,
+            royaltyInfo: { recipients: [], bps: [] }
+          },
+          useDepositedFunds: true,
+          creator: OfferCreator.Seller,
+          feeLimit: parseEther("0.1")
+        },
+        {
+          offerParams: {
+            disputeResolverId: disputeResolver.id,
+            exchangeToken,
+            sellerDeposit
+          }
+        }
+      );
+
+      // Seller (offer creator) signs the full offer
+      const { signature } = await sellerCoreSDKNew.signFullOffer({
+        fullOfferArgsUnsigned
+      });
+      const fullOfferArgs: FullOfferArgs = {
+        ...fullOfferArgsUnsigned,
+        signature
+      };
+
+      // Buyer pre-approves ERC20 token via native meta tx with returnTypedDataToSign
+      const approveStructuredData =
+        await buyerCoreSdk.signNativeMetaTxApproveExchangeToken(
+          exchangeToken,
+          fullOfferArgsUnsigned.price,
+          { returnTypedDataToSign: true }
+        );
+      const { EIP712Domain: _approveDomain, ...approveTypesWithoutDomain } =
+        approveStructuredData.types;
+      const approveRawSignature = await buyerFundedWallet._signTypedData(
+        approveStructuredData.domain,
+        approveTypesWithoutDomain,
+        approveStructuredData.message
+      );
+      const {
+        r: approveR,
+        s: approveS,
+        v: approveV
+      } = getSignatureParameters(approveRawSignature);
+      console.log(
+        "DEBUG approveStructuredData.message:",
+        JSON.stringify(approveStructuredData.message)
+      );
+      console.log(
+        "DEBUG approveStructuredData.domain:",
+        JSON.stringify(approveStructuredData.domain)
+      );
+      console.log("DEBUG approveR:", approveR);
+      console.log("DEBUG approveS:", approveS);
+      console.log("DEBUG approveV:", approveV);
+      console.log("DEBUG exchangeToken:", exchangeToken);
+      const nativeMetaTx = await buyerCoreSdk.relayNativeMetaTransaction(
+        exchangeToken,
+        {
+          functionSignature: approveStructuredData.functionSignature,
+          sigR: approveR,
+          sigS: approveS,
+          sigV: approveV
+        }
+      );
+      const nativeMetaTxReceipt = await nativeMetaTx.wait();
+      expect(nativeMetaTxReceipt.transactionHash).toBeTruthy();
+      expect(BigNumber.from(nativeMetaTxReceipt.effectiveGasPrice).gt(0)).toBe(
+        true
+      );
+
+      // Buyer signs meta-tx for createOfferAndCommit with returnTypedDataToSign
+      const commitNonce = Date.now();
+      const signCommit =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        buyerCoreSdk.signMetaTxCreateOfferAndCommit.bind(buyerCoreSdk) as any;
+      const commitStructuredData = (await signCommit({
+        createOfferAndCommitArgs: fullOfferArgs,
+        nonce: commitNonce,
+        returnTypedDataToSign: true
+      })) as UnsignedMetaTx;
+      const { EIP712Domain: _commitDomain, ...commitTypesWithoutDomain } =
+        commitStructuredData.types;
+      const commitRawSignature = await buyerFundedWallet._signTypedData(
+        commitStructuredData.domain,
+        commitTypesWithoutDomain,
+        commitStructuredData.message
+      );
+      const {
+        r: commitR,
+        s: commitS,
+        v: commitV
+      } = getSignatureParameters(commitRawSignature);
+      const commitMetaTx = await buyerCoreSdk.relayMetaTransaction({
+        functionName: commitStructuredData.functionName,
+        functionSignature: commitStructuredData.functionSignature,
+        nonce: commitNonce,
+        sigR: commitR,
+        sigS: commitS,
+        sigV: commitV
+      });
+      const commitMetaTxReceipt = await commitMetaTx.wait();
+      expect(commitMetaTxReceipt.transactionHash).toBeTruthy();
+      expect(BigNumber.from(commitMetaTxReceipt.effectiveGasPrice).gt(0)).toBe(
+        true
+      );
+
+      // Get the exchange ID from the commit receipt
+      const exchangeId = buyerCoreSdk.getCommittedExchangeIdFromLogs(
+        commitMetaTxReceipt.logs
+      );
+      expect(exchangeId).toBeTruthy();
+
+      // Buyer redeems the voucher via meta-tx with returnTypedDataToSign
+      const redeemNonce = Date.now();
+      const signRedeem =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        buyerCoreSdk.signMetaTxRedeemVoucher.bind(buyerCoreSdk) as any;
+      const redeemStructuredData = (await signRedeem({
+        exchangeId: Number(exchangeId),
+        nonce: redeemNonce,
+        returnTypedDataToSign: true
+      })) as UnsignedMetaTx;
+      const { EIP712Domain: _redeemDomain, ...redeemTypesWithoutDomain } =
+        redeemStructuredData.types;
+      const redeemRawSignature = await buyerFundedWallet._signTypedData(
+        redeemStructuredData.domain,
+        redeemTypesWithoutDomain,
+        redeemStructuredData.message
+      );
+      const {
+        r: redeemR,
+        s: redeemS,
+        v: redeemV
+      } = getSignatureParameters(redeemRawSignature);
+      const redeemMetaTx = await buyerCoreSdk.relayMetaTransaction({
+        functionName: redeemStructuredData.functionName,
+        functionSignature: redeemStructuredData.functionSignature,
+        nonce: redeemNonce,
+        sigR: redeemR,
+        sigS: redeemS,
+        sigV: redeemV
+      });
+      const redeemMetaTxReceipt = await redeemMetaTx.wait();
+      expect(redeemMetaTxReceipt.transactionHash).toBeTruthy();
+      expect(BigNumber.from(redeemMetaTxReceipt.effectiveGasPrice).gt(0)).toBe(
+        true
+      );
     });
   });
 

--- a/e2e/tests/meta-tx.test.ts
+++ b/e2e/tests/meta-tx.test.ts
@@ -1535,18 +1535,6 @@ describe("meta-tx", () => {
         s: approveS,
         v: approveV
       } = getSignatureParameters(approveRawSignature);
-      console.log(
-        "DEBUG approveStructuredData.message:",
-        JSON.stringify(approveStructuredData.message)
-      );
-      console.log(
-        "DEBUG approveStructuredData.domain:",
-        JSON.stringify(approveStructuredData.domain)
-      );
-      console.log("DEBUG approveR:", approveR);
-      console.log("DEBUG approveS:", approveS);
-      console.log("DEBUG approveV:", approveV);
-      console.log("DEBUG exchangeToken:", exchangeToken);
       const nativeMetaTx = await buyerCoreSdk.relayNativeMetaTransaction(
         exchangeToken,
         {

--- a/packages/core-sdk/src/meta-tx/handler.ts
+++ b/packages/core-sdk/src/meta-tx/handler.ts
@@ -135,7 +135,7 @@ export async function signMetaTx(
   const signerAddress = await args.web3Lib.getSignerAddress();
 
   const message = {
-    nonce: args.nonce,
+    nonce: args.nonce.toString(),
     from: signerAddress,
     contractAddress: args.metaTxHandlerAddress,
     functionName: args.functionName,

--- a/packages/core-sdk/src/meta-tx/handler.ts
+++ b/packages/core-sdk/src/meta-tx/handler.ts
@@ -68,6 +68,11 @@ import { isTrustedForwarder } from "../voucher/handler";
 import { findCollectionSalt } from "../accounts/handler";
 import { storeMetadataItems } from "../metadata/storeMetadataItems";
 
+export type UnsignedMetaTx = StructuredData & {
+  functionName: string;
+  functionSignature: string;
+};
+
 export type BaseMetaTxArgs = {
   web3Lib: Web3LibAdapter;
   nonce: BigNumberish;
@@ -96,14 +101,14 @@ export type SignedVoucherMetaTx = Omit<SignedMetaTx, "functionName"> & {
   domainSeparator?: string;
 };
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTx(
   args: BaseMetaTxArgs & {
     functionName: string;
     functionSignature: string;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTx(
   args: BaseMetaTxArgs & {
@@ -119,7 +124,7 @@ export async function signMetaTx(
     functionSignature: string;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const metaTransactionType = [
     { name: "nonce", type: "uint256" },
     { name: "from", type: "address" },
@@ -143,7 +148,7 @@ export async function signMetaTx(
   };
 
   if (args.returnTypedDataToSign) {
-    return prepareDataSignatureParameters({
+    const structuredData = await prepareDataSignatureParameters({
       ...args,
       verifyingContractAddress: args.metaTxHandlerAddress,
       customSignatureType,
@@ -151,6 +156,11 @@ export async function signMetaTx(
       message,
       returnTypedDataToSign: true
     });
+    return {
+      ...structuredData,
+      functionName: args.functionName,
+      functionSignature: args.functionSignature
+    };
   }
 
   const signature = await prepareDataSignatureParameters({
@@ -430,7 +440,7 @@ export async function relayBiconomyMetaTransaction(args: {
   };
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCreateSeller(
   args: BaseMetaTxArgs & {
     createSellerArgs: CreateSellerArgs;
@@ -438,7 +448,7 @@ export async function signMetaTxCreateSeller(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCreateSeller(
   args: BaseMetaTxArgs & {
@@ -456,7 +466,7 @@ export async function signMetaTxCreateSeller(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   await Promise.all(
     [args.createSellerArgs.contractUri, args.createSellerArgs.metadataUri].map(
       (metadataUri) =>
@@ -484,7 +494,7 @@ export async function signMetaTxCreateSeller(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxUpdateSeller(
   args: BaseMetaTxArgs & {
     updateSellerArgs: UpdateSellerArgs;
@@ -492,7 +502,7 @@ export async function signMetaTxUpdateSeller(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxUpdateSeller(
   args: BaseMetaTxArgs & {
@@ -510,7 +520,7 @@ export async function signMetaTxUpdateSeller(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   await storeMetadataOnTheGraph({
     metadataUriOrHash: args.updateSellerArgs.metadataUri,
     metadataStorage: args.metadataStorage,
@@ -528,13 +538,13 @@ export async function signMetaTxUpdateSeller(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxOptInToSellerUpdate(
   args: BaseMetaTxArgs & {
     optInToSellerUpdateArgs: OptInToSellerUpdateArgs;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxOptInToSellerUpdate(
   args: BaseMetaTxArgs & {
@@ -548,7 +558,7 @@ export async function signMetaTxOptInToSellerUpdate(
     optInToSellerUpdateArgs: OptInToSellerUpdateArgs;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "optInToSellerUpdate(uint256,uint8[])",
@@ -560,7 +570,7 @@ export async function signMetaTxOptInToSellerUpdate(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCreateOffer(
   args: BaseMetaTxArgs & {
     createOfferArgs: CreateOfferArgs;
@@ -568,7 +578,7 @@ export async function signMetaTxCreateOffer(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCreateOffer(
   args: BaseMetaTxArgs & {
@@ -586,7 +596,7 @@ export async function signMetaTxCreateOffer(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   utils.validation.createOfferArgsSchema.validateSync(args.createOfferArgs, {
     abortEarly: false
   });
@@ -613,7 +623,7 @@ export async function signMetaTxCreateOffer(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCreateOfferBatch(
   args: BaseMetaTxArgs & {
     createOffersArgs: CreateOfferArgs[];
@@ -621,7 +631,7 @@ export async function signMetaTxCreateOfferBatch(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCreateOfferBatch(
   args: BaseMetaTxArgs & {
@@ -639,7 +649,7 @@ export async function signMetaTxCreateOfferBatch(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   for (const offerToCreate of args.createOffersArgs) {
     utils.validation.createOfferArgsSchema.validateSync(offerToCreate, {
       abortEarly: false
@@ -669,13 +679,13 @@ export async function signMetaTxCreateOfferBatch(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxVoidOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxVoidOffer(
   args: BaseMetaTxArgs & {
@@ -689,7 +699,7 @@ export async function signMetaTxVoidOffer(
     offerId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "voidOffer(uint256)",
@@ -703,13 +713,13 @@ export async function signMetaTxVoidOffer(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxVoidOfferBatch(
   args: BaseMetaTxArgs & {
     offerIds: BigNumberish[];
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxVoidOfferBatch(
   args: BaseMetaTxArgs & {
@@ -723,7 +733,7 @@ export async function signMetaTxVoidOfferBatch(
     offerIds: BigNumberish[];
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "voidOfferBatch(uint256[])",
@@ -738,14 +748,14 @@ export async function signMetaTxVoidOfferBatch(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxExtendOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     validUntil: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxExtendOffer(
   args: BaseMetaTxArgs & {
@@ -761,7 +771,7 @@ export async function signMetaTxExtendOffer(
     validUntil: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "extendOffer(uint256,uint256)",
@@ -776,14 +786,14 @@ export async function signMetaTxExtendOffer(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxExtendOfferBatch(
   args: BaseMetaTxArgs & {
     offerIds: BigNumberish[];
     validUntil: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxExtendOfferBatch(
   args: BaseMetaTxArgs & {
@@ -799,7 +809,7 @@ export async function signMetaTxExtendOfferBatch(
     validUntil: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "extendOfferBatch(uint256[],uint256)",
@@ -814,13 +824,13 @@ export async function signMetaTxExtendOfferBatch(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCompleteExchangeBatch(
   args: BaseMetaTxArgs & {
     exchangeIds: BigNumberish[];
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCompleteExchangeBatch(
   args: BaseMetaTxArgs & {
@@ -834,7 +844,7 @@ export async function signMetaTxCompleteExchangeBatch(
     exchangeIds: BigNumberish[];
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "completeExchangeBatch(uint256[])",
@@ -849,13 +859,13 @@ export async function signMetaTxCompleteExchangeBatch(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxExpireVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxExpireVoucher(
   args: BaseMetaTxArgs & {
@@ -869,7 +879,7 @@ export async function signMetaTxExpireVoucher(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "expireVoucher(uint256)",
@@ -884,13 +894,13 @@ export async function signMetaTxExpireVoucher(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxRevokeVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxRevokeVoucher(
   args: BaseMetaTxArgs & {
@@ -904,7 +914,7 @@ export async function signMetaTxRevokeVoucher(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "revokeVoucher(uint256)",
@@ -919,13 +929,13 @@ export async function signMetaTxRevokeVoucher(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCreateGroup(
   args: BaseMetaTxArgs & {
     createGroupArgs: CreateGroupArgs;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCreateGroup(
   args: BaseMetaTxArgs & {
@@ -939,7 +949,7 @@ export async function signMetaTxCreateGroup(
     createGroupArgs: CreateGroupArgs;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName:
@@ -952,7 +962,7 @@ export async function signMetaTxCreateGroup(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxReserveRange(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
@@ -960,7 +970,7 @@ export async function signMetaTxReserveRange(
     to: string;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxReserveRange(
   args: BaseMetaTxArgs & {
@@ -978,7 +988,7 @@ export async function signMetaTxReserveRange(
     to: string;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "reserveRange(uint256,uint256,address)",
@@ -1131,7 +1141,7 @@ export async function signMetaTxCallExternalContract(
   });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCreateOfferWithCondition(
   args: BaseMetaTxArgs & {
     offerToCreate: CreateOfferArgs;
@@ -1140,7 +1150,7 @@ export async function signMetaTxCreateOfferWithCondition(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCreateOfferWithCondition(
   args: BaseMetaTxArgs & {
@@ -1160,7 +1170,7 @@ export async function signMetaTxCreateOfferWithCondition(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   utils.validation.createOfferArgsSchema.validateSync(args.offerToCreate, {
     abortEarly: false
   });
@@ -1191,13 +1201,13 @@ export async function signMetaTxCreateOfferWithCondition(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCommitToOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCommitToOffer(
   args: BaseMetaTxArgs & {
@@ -1211,7 +1221,7 @@ export async function signMetaTxCommitToOffer(
     offerId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const functionName = "commitToOffer(address,uint256)";
 
   const offerType = [
@@ -1245,8 +1255,13 @@ export async function signMetaTxCommitToOffer(
     }
   };
 
+  const functionSignature = bosonExchangeCommitHandlerIface.encodeFunctionData(
+    "commitToOffer",
+    [buyerAddress, args.offerId]
+  );
+
   if (args.returnTypedDataToSign) {
-    return prepareDataSignatureParameters({
+    const structuredData = await prepareDataSignatureParameters({
       ...args,
       verifyingContractAddress: args.metaTxHandlerAddress,
       customSignatureType,
@@ -1254,6 +1269,7 @@ export async function signMetaTxCommitToOffer(
       message,
       returnTypedDataToSign: true
     });
+    return { ...structuredData, functionName, functionSignature };
   }
 
   const signatureParams = await prepareDataSignatureParameters({
@@ -1268,21 +1284,18 @@ export async function signMetaTxCommitToOffer(
   return {
     ...signatureParams,
     functionName,
-    functionSignature: bosonExchangeCommitHandlerIface.encodeFunctionData(
-      "commitToOffer",
-      [buyerAddress, args.offerId]
-    )
+    functionSignature
   };
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCommitToConditionalOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     tokenId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCommitToConditionalOffer(
   args: BaseMetaTxArgs & {
@@ -1298,7 +1311,7 @@ export async function signMetaTxCommitToConditionalOffer(
     tokenId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const functionName = "commitToConditionalOffer(address,uint256,uint256)";
 
   const offerType = [
@@ -1334,8 +1347,13 @@ export async function signMetaTxCommitToConditionalOffer(
     }
   };
 
+  const functionSignature = bosonExchangeCommitHandlerIface.encodeFunctionData(
+    "commitToConditionalOffer",
+    [buyerAddress, args.offerId, args.tokenId]
+  );
+
   if (args.returnTypedDataToSign) {
-    return prepareDataSignatureParameters({
+    const structuredData = await prepareDataSignatureParameters({
       ...args,
       verifyingContractAddress: args.metaTxHandlerAddress,
       customSignatureType,
@@ -1343,6 +1361,7 @@ export async function signMetaTxCommitToConditionalOffer(
       message,
       returnTypedDataToSign: true
     });
+    return { ...structuredData, functionName, functionSignature };
   }
 
   const signatureParams = await prepareDataSignatureParameters({
@@ -1357,21 +1376,18 @@ export async function signMetaTxCommitToConditionalOffer(
   return {
     ...signatureParams,
     functionName,
-    functionSignature: bosonExchangeCommitHandlerIface.encodeFunctionData(
-      "commitToConditionalOffer",
-      [buyerAddress, args.offerId, args.tokenId]
-    )
+    functionSignature
   };
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCommitToBuyerOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     sellerParams: SellerOfferArgs;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCommitToBuyerOffer(
   args: BaseMetaTxArgs & {
@@ -1387,7 +1403,7 @@ export async function signMetaTxCommitToBuyerOffer(
     sellerParams: SellerOfferArgs;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const functionName =
     "commitToBuyerOffer(uint256,(uint256,(address[],uint256[]),address))";
 
@@ -1402,7 +1418,7 @@ export async function signMetaTxCommitToBuyerOffer(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCreateOfferAndCommit(
   args: BaseMetaTxArgs & {
     createOfferAndCommitArgs: FullOfferArgs;
@@ -1410,7 +1426,7 @@ export async function signMetaTxCreateOfferAndCommit(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCreateOfferAndCommit(
   args: BaseMetaTxArgs & {
@@ -1428,7 +1444,7 @@ export async function signMetaTxCreateOfferAndCommit(
     theGraphStorage?: MetadataStorage;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   utils.validation.createOfferAndCommitArgsSchema.validateSync(
     args.createOfferAndCommitArgs,
     { abortEarly: false }
@@ -1457,13 +1473,13 @@ export async function signMetaTxCreateOfferAndCommit(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCancelVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCancelVoucher(
   args: BaseMetaTxArgs & {
@@ -1477,17 +1493,17 @@ export async function signMetaTxCancelVoucher(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   return makeExchangeMetaTxSigner("cancelVoucher(uint256)")(args);
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxRedeemVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxRedeemVoucher(
   args: BaseMetaTxArgs & {
@@ -1501,17 +1517,17 @@ export async function signMetaTxRedeemVoucher(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   return makeExchangeMetaTxSigner("redeemVoucher(uint256)")(args);
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxCompleteExchange(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxCompleteExchange(
   args: BaseMetaTxArgs & {
@@ -1525,17 +1541,17 @@ export async function signMetaTxCompleteExchange(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   return makeExchangeMetaTxSigner("completeExchange(uint256)")(args);
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxRetractDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxRetractDispute(
   args: BaseMetaTxArgs & {
@@ -1549,20 +1565,20 @@ export async function signMetaTxRetractDispute(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   return makeExchangeMetaTxSigner(
     "retractDispute(uint256)",
     bosonDisputeHandlerIface
   )(args);
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxEscalateDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxEscalateDispute(
   args: BaseMetaTxArgs & {
@@ -1576,20 +1592,20 @@ export async function signMetaTxEscalateDispute(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   return makeExchangeMetaTxSigner(
     "escalateDispute(uint256)",
     bosonDisputeHandlerIface
   )(args);
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxRaiseDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxRaiseDispute(
   args: BaseMetaTxArgs & {
@@ -1603,14 +1619,14 @@ export async function signMetaTxRaiseDispute(
     exchangeId: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   return makeExchangeMetaTxSigner(
     "raiseDispute(uint256)",
     bosonDisputeHandlerIface
   )(args);
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxResolveDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
@@ -1624,7 +1640,7 @@ export async function signMetaTxResolveDispute(
       | string;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxResolveDispute(
   args: BaseMetaTxArgs & {
@@ -1654,7 +1670,7 @@ export async function signMetaTxResolveDispute(
       | string;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const functionName = "resolveDispute(uint256,uint256,bytes)";
   const counterpartySig =
     typeof args.counterpartySig === "string"
@@ -1692,8 +1708,14 @@ export async function signMetaTxResolveDispute(
     }
   };
 
+  const functionSignature = bosonDisputeHandlerIface.encodeFunctionData(
+    // remove params in brackets from string
+    functionName.replace(/\(([^)]*)\)[^(]*$/, ""),
+    [args.exchangeId, args.buyerPercent, counterpartySig]
+  );
+
   if (args.returnTypedDataToSign) {
-    return prepareDataSignatureParameters({
+    const structuredData = await prepareDataSignatureParameters({
       ...args,
       verifyingContractAddress: args.metaTxHandlerAddress,
       customSignatureType,
@@ -1701,6 +1723,7 @@ export async function signMetaTxResolveDispute(
       message,
       returnTypedDataToSign: true
     });
+    return { ...structuredData, functionName, functionSignature };
   }
 
   const signatureParams = await prepareDataSignatureParameters({
@@ -1715,22 +1738,18 @@ export async function signMetaTxResolveDispute(
   return {
     ...signatureParams,
     functionName,
-    functionSignature: bosonDisputeHandlerIface.encodeFunctionData(
-      // remove params in brackets from string
-      functionName.replace(/\(([^)]*)\)[^(]*$/, ""),
-      [args.exchangeId, args.buyerPercent, counterpartySig]
-    )
+    functionSignature
   };
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxExtendDisputeTimeout(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     newTimeout: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxExtendDisputeTimeout(
   args: BaseMetaTxArgs & {
@@ -1746,7 +1765,7 @@ export async function signMetaTxExtendDisputeTimeout(
     newTimeout: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const signMetaTxArgs = {
     ...args,
     functionName: "extendDisputeTimeout(uint256,uint256)",
@@ -1761,7 +1780,7 @@ export async function signMetaTxExtendDisputeTimeout(
   return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxWithdrawFunds(
   args: BaseMetaTxArgs & {
     entityId: BigNumberish;
@@ -1769,7 +1788,7 @@ export async function signMetaTxWithdrawFunds(
     tokenAmounts: BigNumberish[];
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxWithdrawFunds(
   args: BaseMetaTxArgs & {
@@ -1787,7 +1806,7 @@ export async function signMetaTxWithdrawFunds(
     tokenAmounts: BigNumberish[];
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const functionName = "withdrawFunds(uint256,address[],uint256[])";
 
   const fundType = [
@@ -1821,8 +1840,14 @@ export async function signMetaTxWithdrawFunds(
     }
   };
 
+  const functionSignature = encodeWithdrawFunds(
+    args.entityId,
+    args.tokenList,
+    args.tokenAmounts
+  );
+
   if (args.returnTypedDataToSign) {
-    return prepareDataSignatureParameters({
+    const structuredData = await prepareDataSignatureParameters({
       ...args,
       verifyingContractAddress: args.metaTxHandlerAddress,
       customSignatureType,
@@ -1830,6 +1855,7 @@ export async function signMetaTxWithdrawFunds(
       message,
       returnTypedDataToSign: true
     });
+    return { ...structuredData, functionName, functionSignature };
   }
 
   const signatureParams = await prepareDataSignatureParameters({
@@ -1844,15 +1870,11 @@ export async function signMetaTxWithdrawFunds(
   return {
     ...signatureParams,
     functionName,
-    functionSignature: encodeWithdrawFunds(
-      args.entityId,
-      args.tokenList,
-      args.tokenAmounts
-    )
+    functionSignature
   };
 }
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signMetaTxDepositFunds(
   args: BaseMetaTxArgs & {
     entityId: BigNumberish;
@@ -1860,7 +1882,7 @@ export async function signMetaTxDepositFunds(
     fundsAmount: BigNumberish;
     returnTypedDataToSign: true;
   }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signMetaTxDepositFunds(
   args: BaseMetaTxArgs & {
@@ -1878,7 +1900,7 @@ export async function signMetaTxDepositFunds(
     fundsAmount: BigNumberish;
     returnTypedDataToSign?: boolean;
   }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   if (!isAddress(args.fundsTokenAddress)) {
     throw new Error(`Invalid fundsTokenAddress: ${args.fundsTokenAddress}`);
   }
@@ -1919,7 +1941,7 @@ function makeExchangeMetaTxSigner(
       exchangeId: BigNumberish;
       returnTypedDataToSign?: boolean;
     }
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     const exchangeType = [{ name: "exchangeId", type: "uint256" }];
 
     const metaTransactionType = [
@@ -1947,8 +1969,14 @@ function makeExchangeMetaTxSigner(
       }
     };
 
+    const functionSignature = handlerIface.encodeFunctionData(
+      // remove params in brackets from string
+      functionName.replace(/\(([^)]*)\)[^(]*$/, ""),
+      [args.exchangeId]
+    );
+
     if (args.returnTypedDataToSign) {
-      return prepareDataSignatureParameters({
+      const structuredData = await prepareDataSignatureParameters({
         ...args,
         verifyingContractAddress: args.metaTxHandlerAddress,
         customSignatureType,
@@ -1956,6 +1984,7 @@ function makeExchangeMetaTxSigner(
         message,
         returnTypedDataToSign: true
       });
+      return { ...structuredData, functionName, functionSignature };
     }
 
     const signatureParams = await prepareDataSignatureParameters({
@@ -1970,11 +1999,7 @@ function makeExchangeMetaTxSigner(
     return {
       ...signatureParams,
       functionName,
-      functionSignature: handlerIface.encodeFunctionData(
-        // remove params in brackets from string
-        functionName.replace(/\(([^)]*)\)[^(]*$/, ""),
-        [args.exchangeId]
-      )
+      functionSignature
     };
   };
 }

--- a/packages/core-sdk/src/meta-tx/handler.ts
+++ b/packages/core-sdk/src/meta-tx/handler.ts
@@ -38,6 +38,7 @@ import {
 } from "../offers/interface";
 import {
   prepareDataSignatureParameters,
+  StructuredData,
   rebuildSignature
 } from "../utils/signature";
 import {
@@ -95,12 +96,30 @@ export type SignedVoucherMetaTx = Omit<SignedMetaTx, "functionName"> & {
   domainSeparator?: string;
 };
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTx(
   args: BaseMetaTxArgs & {
     functionName: string;
     functionSignature: string;
+    returnTypedDataToSign: true;
   }
-): Promise<SignedMetaTx> {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTx(
+  args: BaseMetaTxArgs & {
+    functionName: string;
+    functionSignature: string;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTx(
+  args: BaseMetaTxArgs & {
+    functionName: string;
+    functionSignature: string;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   const metaTransactionType = [
     { name: "nonce", type: "uint256" },
     { name: "from", type: "address" },
@@ -122,6 +141,17 @@ export async function signMetaTx(
     functionName: args.functionName,
     functionSignature: args.functionSignature
   };
+
+  if (args.returnTypedDataToSign) {
+    return prepareDataSignatureParameters({
+      ...args,
+      verifyingContractAddress: args.metaTxHandlerAddress,
+      customSignatureType,
+      primaryType: "MetaTransaction",
+      message,
+      returnTypedDataToSign: true
+    });
+  }
 
   const signature = await prepareDataSignatureParameters({
     ...args,
@@ -400,13 +430,33 @@ export async function relayBiconomyMetaTransaction(args: {
   };
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCreateSeller(
   args: BaseMetaTxArgs & {
     createSellerArgs: CreateSellerArgs;
     metadataStorage?: MetadataStorage;
     theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCreateSeller(
+  args: BaseMetaTxArgs & {
+    createSellerArgs: CreateSellerArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCreateSeller(
+  args: BaseMetaTxArgs & {
+    createSellerArgs: CreateSellerArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   await Promise.all(
     [args.createSellerArgs.contractUri, args.createSellerArgs.metadataUri].map(
       (metadataUri) =>
@@ -422,53 +472,121 @@ export async function signMetaTxCreateSeller(
     contractAddress: args.metaTxHandlerAddress,
     ...args
   });
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName:
       "createSeller((uint256,address,address,address,address,bool,string),(uint256,uint8),(string,uint256,bytes32))",
     functionSignature: encodeCreateSeller(args.createSellerArgs, collectionSalt)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxUpdateSeller(
   args: BaseMetaTxArgs & {
     updateSellerArgs: UpdateSellerArgs;
     metadataStorage?: MetadataStorage;
     theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxUpdateSeller(
+  args: BaseMetaTxArgs & {
+    updateSellerArgs: UpdateSellerArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxUpdateSeller(
+  args: BaseMetaTxArgs & {
+    updateSellerArgs: UpdateSellerArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   await storeMetadataOnTheGraph({
     metadataUriOrHash: args.updateSellerArgs.metadataUri,
     metadataStorage: args.metadataStorage,
     theGraphStorage: args.theGraphStorage
   });
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName:
       "updateSeller((uint256,address,address,address,address,bool,string),(uint256,uint8))",
     functionSignature: encodeUpdateSeller(args.updateSellerArgs)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxOptInToSellerUpdate(
   args: BaseMetaTxArgs & {
     optInToSellerUpdateArgs: OptInToSellerUpdateArgs;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxOptInToSellerUpdate(
+  args: BaseMetaTxArgs & {
+    optInToSellerUpdateArgs: OptInToSellerUpdateArgs;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxOptInToSellerUpdate(
+  args: BaseMetaTxArgs & {
+    optInToSellerUpdateArgs: OptInToSellerUpdateArgs;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "optInToSellerUpdate(uint256,uint8[])",
     functionSignature: encodeOptInToSellerUpdate(args.optInToSellerUpdateArgs)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCreateOffer(
   args: BaseMetaTxArgs & {
     createOfferArgs: CreateOfferArgs;
     metadataStorage?: MetadataStorage;
     theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCreateOffer(
+  args: BaseMetaTxArgs & {
+    createOfferArgs: CreateOfferArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCreateOffer(
+  args: BaseMetaTxArgs & {
+    createOfferArgs: CreateOfferArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   utils.validation.createOfferArgsSchema.validateSync(args.createOfferArgs, {
     abortEarly: false
   });
@@ -483,21 +601,45 @@ export async function signMetaTxCreateOffer(
     createOffersArgs: [args.createOfferArgs]
   });
 
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName:
       "createOffer((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),uint256,uint256)",
     functionSignature: encodeCreateOffer(args.createOfferArgs)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCreateOfferBatch(
   args: BaseMetaTxArgs & {
     createOffersArgs: CreateOfferArgs[];
     metadataStorage?: MetadataStorage;
     theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCreateOfferBatch(
+  args: BaseMetaTxArgs & {
+    createOffersArgs: CreateOfferArgs[];
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCreateOfferBatch(
+  args: BaseMetaTxArgs & {
+    createOffersArgs: CreateOfferArgs[];
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   for (const offerToCreate of args.createOffersArgs) {
     utils.validation.createOfferArgsSchema.validateSync(offerToCreate, {
       abortEarly: false
@@ -515,145 +657,337 @@ export async function signMetaTxCreateOfferBatch(
   );
   await storeMetadataItems(args);
 
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName:
       "createOfferBatch((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256)[],(uint256,uint256,uint256,uint256)[],(uint256,uint256,uint256)[],(uint256,address)[],uint256[],uint256[])",
     functionSignature: encodeCreateOfferBatch(args.createOffersArgs)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxVoidOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxVoidOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxVoidOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "voidOffer(uint256)",
     functionSignature: bosonOfferHandlerIface.encodeFunctionData("voidOffer", [
       args.offerId
     ])
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxVoidOfferBatch(
   args: BaseMetaTxArgs & {
     offerIds: BigNumberish[];
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxVoidOfferBatch(
+  args: BaseMetaTxArgs & {
+    offerIds: BigNumberish[];
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxVoidOfferBatch(
+  args: BaseMetaTxArgs & {
+    offerIds: BigNumberish[];
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "voidOfferBatch(uint256[])",
     functionSignature: bosonOfferHandlerIface.encodeFunctionData(
       "voidOfferBatch",
       [args.offerIds]
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxExtendOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     validUntil: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxExtendOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    validUntil: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxExtendOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    validUntil: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "extendOffer(uint256,uint256)",
     functionSignature: bosonOfferHandlerIface.encodeFunctionData(
       "extendOffer",
       [args.offerId, args.validUntil]
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxExtendOfferBatch(
   args: BaseMetaTxArgs & {
     offerIds: BigNumberish[];
     validUntil: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxExtendOfferBatch(
+  args: BaseMetaTxArgs & {
+    offerIds: BigNumberish[];
+    validUntil: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxExtendOfferBatch(
+  args: BaseMetaTxArgs & {
+    offerIds: BigNumberish[];
+    validUntil: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "extendOfferBatch(uint256[],uint256)",
     functionSignature: bosonOfferHandlerIface.encodeFunctionData(
       "extendOfferBatch",
       [args.offerIds, args.validUntil]
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCompleteExchangeBatch(
   args: BaseMetaTxArgs & {
     exchangeIds: BigNumberish[];
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCompleteExchangeBatch(
+  args: BaseMetaTxArgs & {
+    exchangeIds: BigNumberish[];
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCompleteExchangeBatch(
+  args: BaseMetaTxArgs & {
+    exchangeIds: BigNumberish[];
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "completeExchangeBatch(uint256[])",
     functionSignature: bosonExchangeHandlerIface.encodeFunctionData(
       "completeExchangeBatch",
       [args.exchangeIds]
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxExpireVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxExpireVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxExpireVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "expireVoucher(uint256)",
     functionSignature: bosonExchangeHandlerIface.encodeFunctionData(
       "expireVoucher",
       [args.exchangeId]
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxRevokeVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxRevokeVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxRevokeVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "revokeVoucher(uint256)",
     functionSignature: bosonExchangeHandlerIface.encodeFunctionData(
       "revokeVoucher",
       [args.exchangeId]
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCreateGroup(
   args: BaseMetaTxArgs & {
     createGroupArgs: CreateGroupArgs;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCreateGroup(
+  args: BaseMetaTxArgs & {
+    createGroupArgs: CreateGroupArgs;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCreateGroup(
+  args: BaseMetaTxArgs & {
+    createGroupArgs: CreateGroupArgs;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName:
       "createGroup((uint256,uint256,uint256[]),(uint8,uint8,address,uint8,uint256,uint256,uint256,uint256))",
     functionSignature: encodeCreateGroup(args.createGroupArgs)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxReserveRange(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     length: BigNumberish;
     to: string;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxReserveRange(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    length: BigNumberish;
+    to: string;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxReserveRange(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    length: BigNumberish;
+    to: string;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "reserveRange(uint256,uint256,address)",
     functionSignature: encodeReserveRange(args.offerId, args.length, args.to)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
 function isLocal(chainId: number): boolean {
@@ -797,14 +1131,36 @@ export async function signMetaTxCallExternalContract(
   });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCreateOfferWithCondition(
   args: BaseMetaTxArgs & {
     offerToCreate: CreateOfferArgs;
     condition: ConditionStruct;
     metadataStorage?: MetadataStorage;
     theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCreateOfferWithCondition(
+  args: BaseMetaTxArgs & {
+    offerToCreate: CreateOfferArgs;
+    condition: ConditionStruct;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCreateOfferWithCondition(
+  args: BaseMetaTxArgs & {
+    offerToCreate: CreateOfferArgs;
+    condition: ConditionStruct;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   utils.validation.createOfferArgsSchema.validateSync(args.offerToCreate, {
     abortEarly: false
   });
@@ -820,7 +1176,7 @@ export async function signMetaTxCreateOfferWithCondition(
     createOffersArgs: [args.offerToCreate]
   });
 
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName:
       "createOfferWithCondition((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),(uint8,uint8,address,uint8,uint256,uint256,uint256,uint256),uint256,uint256)",
@@ -828,14 +1184,34 @@ export async function signMetaTxCreateOfferWithCondition(
       args.offerToCreate,
       args.condition
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCommitToOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-): Promise<SignedMetaTx> {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCommitToOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCommitToOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   const functionName = "commitToOffer(address,uint256)";
 
   const offerType = [
@@ -869,6 +1245,17 @@ export async function signMetaTxCommitToOffer(
     }
   };
 
+  if (args.returnTypedDataToSign) {
+    return prepareDataSignatureParameters({
+      ...args,
+      verifyingContractAddress: args.metaTxHandlerAddress,
+      customSignatureType,
+      primaryType: "MetaTxCommitToOffer",
+      message,
+      returnTypedDataToSign: true
+    });
+  }
+
   const signatureParams = await prepareDataSignatureParameters({
     ...args,
     verifyingContractAddress: args.metaTxHandlerAddress,
@@ -888,12 +1275,30 @@ export async function signMetaTxCommitToOffer(
   };
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCommitToConditionalOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     tokenId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-): Promise<SignedMetaTx> {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCommitToConditionalOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    tokenId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCommitToConditionalOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    tokenId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   const functionName = "commitToConditionalOffer(address,uint256,uint256)";
 
   const offerType = [
@@ -929,6 +1334,17 @@ export async function signMetaTxCommitToConditionalOffer(
     }
   };
 
+  if (args.returnTypedDataToSign) {
+    return prepareDataSignatureParameters({
+      ...args,
+      verifyingContractAddress: args.metaTxHandlerAddress,
+      customSignatureType,
+      primaryType: "MetaTxCommitToConditionalOffer",
+      message,
+      returnTypedDataToSign: true
+    });
+  }
+
   const signatureParams = await prepareDataSignatureParameters({
     ...args,
     verifyingContractAddress: args.metaTxHandlerAddress,
@@ -948,29 +1364,71 @@ export async function signMetaTxCommitToConditionalOffer(
   };
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCommitToBuyerOffer(
   args: BaseMetaTxArgs & {
     offerId: BigNumberish;
     sellerParams: SellerOfferArgs;
+    returnTypedDataToSign: true;
   }
-): Promise<SignedMetaTx> {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCommitToBuyerOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    sellerParams: SellerOfferArgs;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCommitToBuyerOffer(
+  args: BaseMetaTxArgs & {
+    offerId: BigNumberish;
+    sellerParams: SellerOfferArgs;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   const functionName =
     "commitToBuyerOffer(uint256,(uint256,(address[],uint256[]),address))";
 
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName,
     functionSignature: encodeCommitToBuyerOffer(args.offerId, args.sellerParams)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCreateOfferAndCommit(
   args: BaseMetaTxArgs & {
     createOfferAndCommitArgs: FullOfferArgs;
     metadataStorage?: MetadataStorage;
     theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign: true;
   }
-): Promise<SignedMetaTx> {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCreateOfferAndCommit(
+  args: BaseMetaTxArgs & {
+    createOfferAndCommitArgs: FullOfferArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCreateOfferAndCommit(
+  args: BaseMetaTxArgs & {
+    createOfferAndCommitArgs: FullOfferArgs;
+    metadataStorage?: MetadataStorage;
+    theGraphStorage?: MetadataStorage;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   utils.validation.createOfferAndCommitArgsSchema.validateSync(
     args.createOfferAndCommitArgs,
     { abortEarly: false }
@@ -987,71 +1445,172 @@ export async function signMetaTxCreateOfferAndCommit(
     createOffersArgs: [args.createOfferAndCommitArgs]
   });
 
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName:
       "createOfferAndCommit(((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),(uint8,uint8,address,uint8,uint256,uint256,uint256,uint256),uint256,uint256,bool),address,address,bytes,uint256,(uint256,(address[],uint256[]),address))",
     functionSignature: encodeCreateOfferAndCommit(args.createOfferAndCommitArgs)
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCancelVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCancelVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCancelVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   return makeExchangeMetaTxSigner("cancelVoucher(uint256)")(args);
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxRedeemVoucher(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxRedeemVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxRedeemVoucher(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   return makeExchangeMetaTxSigner("redeemVoucher(uint256)")(args);
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxCompleteExchange(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxCompleteExchange(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxCompleteExchange(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   return makeExchangeMetaTxSigner("completeExchange(uint256)")(args);
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxRetractDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxRetractDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxRetractDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   return makeExchangeMetaTxSigner(
     "retractDispute(uint256)",
     bosonDisputeHandlerIface
   )(args);
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxEscalateDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxEscalateDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxEscalateDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   return makeExchangeMetaTxSigner(
     "escalateDispute(uint256)",
     bosonDisputeHandlerIface
   )(args);
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxRaiseDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxRaiseDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxRaiseDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   return makeExchangeMetaTxSigner(
     "raiseDispute(uint256)",
     bosonDisputeHandlerIface
   )(args);
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxResolveDispute(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
@@ -1063,8 +1622,39 @@ export async function signMetaTxResolveDispute(
           v: number;
         }
       | string;
+    returnTypedDataToSign: true;
   }
-): Promise<SignedMetaTx> {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxResolveDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    buyerPercent: BigNumberish;
+    counterpartySig:
+      | {
+          r: string;
+          s: string;
+          v: number;
+        }
+      | string;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxResolveDispute(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    buyerPercent: BigNumberish;
+    counterpartySig:
+      | {
+          r: string;
+          s: string;
+          v: number;
+        }
+      | string;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   const functionName = "resolveDispute(uint256,uint256,bytes)";
   const counterpartySig =
     typeof args.counterpartySig === "string"
@@ -1102,6 +1692,17 @@ export async function signMetaTxResolveDispute(
     }
   };
 
+  if (args.returnTypedDataToSign) {
+    return prepareDataSignatureParameters({
+      ...args,
+      verifyingContractAddress: args.metaTxHandlerAddress,
+      customSignatureType,
+      primaryType: "MetaTxDisputeResolution",
+      message,
+      returnTypedDataToSign: true
+    });
+  }
+
   const signatureParams = await prepareDataSignatureParameters({
     ...args,
     verifyingContractAddress: args.metaTxHandlerAddress,
@@ -1122,29 +1723,71 @@ export async function signMetaTxResolveDispute(
   };
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxExtendDisputeTimeout(
   args: BaseMetaTxArgs & {
     exchangeId: BigNumberish;
     newTimeout: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
-  return signMetaTx({
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxExtendDisputeTimeout(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    newTimeout: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxExtendDisputeTimeout(
+  args: BaseMetaTxArgs & {
+    exchangeId: BigNumberish;
+    newTimeout: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
+  const signMetaTxArgs = {
     ...args,
     functionName: "extendDisputeTimeout(uint256,uint256)",
     functionSignature: bosonDisputeHandlerIface.encodeFunctionData(
       "extendDisputeTimeout",
       [args.exchangeId, args.newTimeout]
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxWithdrawFunds(
   args: BaseMetaTxArgs & {
     entityId: BigNumberish;
     tokenList: string[];
     tokenAmounts: BigNumberish[];
+    returnTypedDataToSign: true;
   }
-): Promise<SignedMetaTx> {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxWithdrawFunds(
+  args: BaseMetaTxArgs & {
+    entityId: BigNumberish;
+    tokenList: string[];
+    tokenAmounts: BigNumberish[];
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxWithdrawFunds(
+  args: BaseMetaTxArgs & {
+    entityId: BigNumberish;
+    tokenList: string[];
+    tokenAmounts: BigNumberish[];
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   const functionName = "withdrawFunds(uint256,address[],uint256[])";
 
   const fundType = [
@@ -1178,6 +1821,17 @@ export async function signMetaTxWithdrawFunds(
     }
   };
 
+  if (args.returnTypedDataToSign) {
+    return prepareDataSignatureParameters({
+      ...args,
+      verifyingContractAddress: args.metaTxHandlerAddress,
+      customSignatureType,
+      primaryType: "MetaTxFund",
+      message,
+      returnTypedDataToSign: true
+    });
+  }
+
   const signatureParams = await prepareDataSignatureParameters({
     ...args,
     verifyingContractAddress: args.metaTxHandlerAddress,
@@ -1198,13 +1852,33 @@ export async function signMetaTxWithdrawFunds(
   };
 }
 
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signMetaTxDepositFunds(
   args: BaseMetaTxArgs & {
     entityId: BigNumberish;
     fundsTokenAddress: string;
     fundsAmount: BigNumberish;
+    returnTypedDataToSign: true;
   }
-) {
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signMetaTxDepositFunds(
+  args: BaseMetaTxArgs & {
+    entityId: BigNumberish;
+    fundsTokenAddress: string;
+    fundsAmount: BigNumberish;
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signMetaTxDepositFunds(
+  args: BaseMetaTxArgs & {
+    entityId: BigNumberish;
+    fundsTokenAddress: string;
+    fundsAmount: BigNumberish;
+    returnTypedDataToSign?: boolean;
+  }
+): Promise<SignedMetaTx | StructuredData> {
   if (!isAddress(args.fundsTokenAddress)) {
     throw new Error(`Invalid fundsTokenAddress: ${args.fundsTokenAddress}`);
   }
@@ -1215,7 +1889,7 @@ export async function signMetaTxDepositFunds(
     );
   }
 
-  return signMetaTx({
+  const signMetaTxArgs = {
     ...args,
     functionName: "depositFunds(uint256,address,uint256)",
     functionSignature: encodeDepositFunds(
@@ -1223,7 +1897,11 @@ export async function signMetaTxDepositFunds(
       args.fundsTokenAddress,
       args.fundsAmount
     )
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: true });
+  }
+  return signMetaTx({ ...signMetaTxArgs, returnTypedDataToSign: false });
 }
 
 function makeExchangeMetaTxSigner(
@@ -1239,8 +1917,9 @@ function makeExchangeMetaTxSigner(
   return async function signExchangeMetaTx(
     args: BaseMetaTxArgs & {
       exchangeId: BigNumberish;
+      returnTypedDataToSign?: boolean;
     }
-  ): Promise<SignedMetaTx> {
+  ): Promise<SignedMetaTx | StructuredData> {
     const exchangeType = [{ name: "exchangeId", type: "uint256" }];
 
     const metaTransactionType = [
@@ -1267,6 +1946,17 @@ function makeExchangeMetaTxSigner(
         exchangeId: args.exchangeId.toString()
       }
     };
+
+    if (args.returnTypedDataToSign) {
+      return prepareDataSignatureParameters({
+        ...args,
+        verifyingContractAddress: args.metaTxHandlerAddress,
+        customSignatureType,
+        primaryType: "MetaTxExchange",
+        message,
+        returnTypedDataToSign: true
+      });
+    }
 
     const signatureParams = await prepareDataSignatureParameters({
       ...args,

--- a/packages/core-sdk/src/meta-tx/mixin.ts
+++ b/packages/core-sdk/src/meta-tx/mixin.ts
@@ -13,8 +13,7 @@ import { GetRetriedHashesData } from "./biconomy";
 import { accounts } from "..";
 import { AccountsMixin } from "../accounts/mixin";
 import { SellerFieldsFragment } from "../subgraph";
-import { SignedMetaTx } from "./handler";
-import { StructuredData } from "../utils/signature";
+import { SignedMetaTx, UnsignedMetaTx } from "./handler";
 export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
   /* -------------------------------------------------------------------------- */
   /*                           Meta Tx related methods                          */
@@ -25,13 +24,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTx(
     args: Omit<
       Parameters<typeof handler.signMetaTx>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTx(
     args: Omit<
@@ -45,7 +44,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTx>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTx({
         web3Lib: this._web3Lib,
@@ -69,13 +68,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCreateSeller(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateSeller>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCreateSeller(
     args: Omit<
@@ -89,7 +88,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCreateSeller>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCreateSeller({
         web3Lib: this._web3Lib,
@@ -112,13 +111,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
     });
   }
 
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxUpdateSeller(
     args: Omit<
       Parameters<typeof handler.signMetaTxUpdateSeller>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxUpdateSeller(
     args: Omit<
@@ -132,7 +131,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxUpdateSeller>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxUpdateSeller({
         web3Lib: this._web3Lib,
@@ -155,13 +154,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
     });
   }
 
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxOptInToSellerUpdate(
     args: Omit<
       Parameters<typeof handler.signMetaTxOptInToSellerUpdate>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxOptInToSellerUpdate(
     args: Omit<
@@ -175,7 +174,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxOptInToSellerUpdate>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxOptInToSellerUpdate({
         web3Lib: this._web3Lib,
@@ -280,13 +279,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCreateOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCreateOffer(
     args: Omit<
@@ -300,7 +299,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCreateOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCreateOffer({
         web3Lib: this._web3Lib,
@@ -328,13 +327,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCreateOfferBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCreateOfferBatch(
     args: Omit<
@@ -348,7 +347,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCreateOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCreateOfferBatch({
         web3Lib: this._web3Lib,
@@ -376,13 +375,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCreateGroup(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateGroup>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCreateGroup(
     args: Omit<
@@ -396,7 +395,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCreateGroup>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCreateGroup({
         web3Lib: this._web3Lib,
@@ -415,13 +414,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
     });
   }
 
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxReserveRange(
     args: Omit<
       Parameters<typeof handler.signMetaTxReserveRange>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId" | "to"
     > & { to: "seller" | "contract"; returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxReserveRange(
     args: Omit<
@@ -435,7 +434,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxReserveRange>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId" | "to"
     > & { to: "seller" | "contract" }
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     const offer = await getOfferById(this._subgraphUrl, args.offerId);
 
     if (args.returnTypedDataToSign) {
@@ -670,13 +669,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCreateOfferWithCondition(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOfferWithCondition>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCreateOfferWithCondition(
     args: Omit<
@@ -690,7 +689,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCreateOfferWithCondition>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCreateOfferWithCondition({
         web3Lib: this._web3Lib,
@@ -718,13 +717,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxVoidOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxVoidOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxVoidOffer(
     args: Omit<
@@ -738,7 +737,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxVoidOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxVoidOffer({
         web3Lib: this._web3Lib,
@@ -762,13 +761,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxVoidOfferBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxVoidOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxVoidOfferBatch(
     args: Omit<
@@ -782,7 +781,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxVoidOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxVoidOfferBatch({
         web3Lib: this._web3Lib,
@@ -806,13 +805,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxExtendOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxExtendOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxExtendOffer(
     args: Omit<
@@ -826,7 +825,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxExtendOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxExtendOffer({
         web3Lib: this._web3Lib,
@@ -850,13 +849,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxExtendOfferBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxExtendOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxExtendOfferBatch(
     args: Omit<
@@ -870,7 +869,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxExtendOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxExtendOfferBatch({
         web3Lib: this._web3Lib,
@@ -894,13 +893,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCompleteExchange(
     args: Omit<
       Parameters<typeof handler.signMetaTxCompleteExchange>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCompleteExchange(
     args: Omit<
@@ -914,7 +913,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCompleteExchange>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCompleteExchange({
         web3Lib: this._web3Lib,
@@ -938,13 +937,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCompleteExchangeBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxCompleteExchangeBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCompleteExchangeBatch(
     args: Omit<
@@ -958,7 +957,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCompleteExchangeBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCompleteExchangeBatch({
         web3Lib: this._web3Lib,
@@ -982,13 +981,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCommitToOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCommitToOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCommitToOffer(
     args: Omit<
@@ -1002,7 +1001,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCommitToOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     const offer = await getOfferById(this._subgraphUrl, args.offerId);
 
     if (offer.condition) {
@@ -1012,7 +1011,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       const self = this as {
         signMetaTxCommitToConditionalOffer: (
           args: Record<string, unknown>
-        ) => Promise<SignedMetaTx | StructuredData>;
+        ) => Promise<SignedMetaTx | UnsignedMetaTx>;
       };
       const conditionalArgs = {
         ...(args as Record<string, unknown>),
@@ -1044,13 +1043,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCommitToConditionalOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCommitToConditionalOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCommitToConditionalOffer(
     args: Omit<
@@ -1064,7 +1063,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCommitToConditionalOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCommitToConditionalOffer({
         web3Lib: this._web3Lib,
@@ -1088,13 +1087,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCommitToBuyerOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCommitToBuyerOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCommitToBuyerOffer(
     args: Omit<
@@ -1108,7 +1107,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCommitToBuyerOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCommitToBuyerOffer({
         web3Lib: this._web3Lib,
@@ -1132,13 +1131,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCreateOfferAndCommit(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOfferAndCommit>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCreateOfferAndCommit(
     args: Omit<
@@ -1152,7 +1151,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCreateOfferAndCommit>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCreateOfferAndCommit({
         web3Lib: this._web3Lib,
@@ -1180,13 +1179,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxCancelVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxCancelVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxCancelVoucher(
     args: Omit<
@@ -1200,7 +1199,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxCancelVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxCancelVoucher({
         web3Lib: this._web3Lib,
@@ -1224,13 +1223,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxRedeemVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxRedeemVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxRedeemVoucher(
     args: Omit<
@@ -1244,7 +1243,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxRedeemVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxRedeemVoucher({
         web3Lib: this._web3Lib,
@@ -1268,13 +1267,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxExpireVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxExpireVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxExpireVoucher(
     args: Omit<
@@ -1288,7 +1287,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxExpireVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxExpireVoucher({
         web3Lib: this._web3Lib,
@@ -1312,13 +1311,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxRevokeVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxRevokeVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxRevokeVoucher(
     args: Omit<
@@ -1332,7 +1331,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxRevokeVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxRevokeVoucher({
         web3Lib: this._web3Lib,
@@ -1356,13 +1355,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxRetractDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxRetractDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxRetractDispute(
     args: Omit<
@@ -1376,7 +1375,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxRetractDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxRetractDispute({
         web3Lib: this._web3Lib,
@@ -1400,13 +1399,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxEscalateDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxEscalateDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxEscalateDispute(
     args: Omit<
@@ -1420,7 +1419,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxEscalateDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxEscalateDispute({
         web3Lib: this._web3Lib,
@@ -1444,13 +1443,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxRaiseDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxRaiseDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxRaiseDispute(
     args: Omit<
@@ -1464,7 +1463,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxRaiseDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxRaiseDispute({
         web3Lib: this._web3Lib,
@@ -1488,13 +1487,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxResolveDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxResolveDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxResolveDispute(
     args: Omit<
@@ -1508,7 +1507,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxResolveDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxResolveDispute({
         web3Lib: this._web3Lib,
@@ -1532,13 +1531,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxExtendDisputeTimeout(
     args: Omit<
       Parameters<typeof handler.signMetaTxExtendDisputeTimeout>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxExtendDisputeTimeout(
     args: Omit<
@@ -1552,7 +1551,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxExtendDisputeTimeout>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxExtendDisputeTimeout({
         web3Lib: this._web3Lib,
@@ -1576,13 +1575,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxWithdrawFunds(
     args: Omit<
       Parameters<typeof handler.signMetaTxWithdrawFunds>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxWithdrawFunds(
     args: Omit<
@@ -1596,7 +1595,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxWithdrawFunds>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxWithdrawFunds({
         web3Lib: this._web3Lib,
@@ -1620,13 +1619,13 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signMetaTxDepositFunds(
     args: Omit<
       Parameters<typeof handler.signMetaTxDepositFunds>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     > & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signMetaTxDepositFunds(
     args: Omit<
@@ -1640,7 +1639,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       Parameters<typeof handler.signMetaTxDepositFunds>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     if (args.returnTypedDataToSign) {
       return handler.signMetaTxDepositFunds({
         web3Lib: this._web3Lib,

--- a/packages/core-sdk/src/meta-tx/mixin.ts
+++ b/packages/core-sdk/src/meta-tx/mixin.ts
@@ -13,6 +13,8 @@ import { GetRetriedHashesData } from "./biconomy";
 import { accounts } from "..";
 import { AccountsMixin } from "../accounts/mixin";
 import { SellerFieldsFragment } from "../subgraph";
+import { SignedMetaTx } from "./handler";
+import { StructuredData } from "../utils/signature";
 export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
   /* -------------------------------------------------------------------------- */
   /*                           Meta Tx related methods                          */
@@ -23,17 +25,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTx(
+    args: Omit<
+      Parameters<typeof handler.signMetaTx>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTx(
+    args: Omit<
+      Parameters<typeof handler.signMetaTx>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTx(
     args: Omit<
       Parameters<typeof handler.signMetaTx>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTx({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTx({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -42,49 +69,128 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCreateSeller(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateSeller>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCreateSeller(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateSeller>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCreateSeller(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateSeller>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCreateSeller({
+        web3Lib: this._web3Lib,
+        theGraphStorage: this._theGraphStorage,
+        metadataStorage: this._metadataStorage,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCreateSeller({
       web3Lib: this._web3Lib,
       theGraphStorage: this._theGraphStorage,
       metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxUpdateSeller(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxUpdateSeller>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxUpdateSeller(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxUpdateSeller>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxUpdateSeller(
     args: Omit<
       Parameters<typeof handler.signMetaTxUpdateSeller>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxUpdateSeller({
+        web3Lib: this._web3Lib,
+        theGraphStorage: this._theGraphStorage,
+        metadataStorage: this._metadataStorage,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxUpdateSeller({
       web3Lib: this._web3Lib,
       theGraphStorage: this._theGraphStorage,
       metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxOptInToSellerUpdate(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxOptInToSellerUpdate>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxOptInToSellerUpdate(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxOptInToSellerUpdate>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxOptInToSellerUpdate(
     args: Omit<
       Parameters<typeof handler.signMetaTxOptInToSellerUpdate>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxOptInToSellerUpdate({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxOptInToSellerUpdate({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -174,19 +280,46 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCreateOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCreateOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCreateOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCreateOffer({
+        web3Lib: this._web3Lib,
+        theGraphStorage: this._theGraphStorage,
+        metadataStorage: this._metadataStorage,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCreateOffer({
       web3Lib: this._web3Lib,
       theGraphStorage: this._theGraphStorage,
       metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -195,19 +328,46 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCreateOfferBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOfferBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCreateOfferBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOfferBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCreateOfferBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCreateOfferBatch({
+        web3Lib: this._web3Lib,
+        theGraphStorage: this._theGraphStorage,
+        metadataStorage: this._metadataStorage,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCreateOfferBatch({
       web3Lib: this._web3Lib,
       theGraphStorage: this._theGraphStorage,
       metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -216,28 +376,81 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCreateGroup(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateGroup>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCreateGroup(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateGroup>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCreateGroup(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateGroup>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCreateGroup({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCreateGroup({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxReserveRange(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxReserveRange>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId" | "to"
+    > & { to: "seller" | "contract"; returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxReserveRange(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxReserveRange>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId" | "to"
+    > & { to: "seller" | "contract"; returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxReserveRange(
     args: Omit<
       Parameters<typeof handler.signMetaTxReserveRange>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId" | "to"
     > & { to: "seller" | "contract" }
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
     const offer = await getOfferById(this._subgraphUrl, args.offerId);
 
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxReserveRange({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        to:
+          args.to === "contract"
+            ? offer.seller.voucherCloneAddress
+            : offer.seller.assistant,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxReserveRange({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
@@ -246,7 +459,8 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
       to:
         args.to === "contract"
           ? offer.seller.voucherCloneAddress
-          : offer.seller.assistant
+          : offer.seller.assistant,
+      returnTypedDataToSign: false
     });
   }
 
@@ -456,19 +670,46 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCreateOfferWithCondition(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOfferWithCondition>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCreateOfferWithCondition(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOfferWithCondition>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCreateOfferWithCondition(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOfferWithCondition>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCreateOfferWithCondition({
+        web3Lib: this._web3Lib,
+        theGraphStorage: this._theGraphStorage,
+        metadataStorage: this._metadataStorage,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCreateOfferWithCondition({
       web3Lib: this._web3Lib,
       theGraphStorage: this._theGraphStorage,
       metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -477,17 +718,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxVoidOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxVoidOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxVoidOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxVoidOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxVoidOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxVoidOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxVoidOffer({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxVoidOffer({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -496,17 +762,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxVoidOfferBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxVoidOfferBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxVoidOfferBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxVoidOfferBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxVoidOfferBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxVoidOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxVoidOfferBatch({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxVoidOfferBatch({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -515,17 +806,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxExtendOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExtendOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxExtendOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExtendOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxExtendOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxExtendOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxExtendOffer({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxExtendOffer({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -534,17 +850,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxExtendOfferBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExtendOfferBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxExtendOfferBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExtendOfferBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxExtendOfferBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxExtendOfferBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxExtendOfferBatch({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxExtendOfferBatch({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -553,17 +894,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCompleteExchange(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCompleteExchange>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCompleteExchange(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCompleteExchange>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCompleteExchange(
     args: Omit<
       Parameters<typeof handler.signMetaTxCompleteExchange>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCompleteExchange({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCompleteExchange({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -572,17 +938,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCompleteExchangeBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCompleteExchangeBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCompleteExchangeBatch(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCompleteExchangeBatch>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCompleteExchangeBatch(
     args: Omit<
       Parameters<typeof handler.signMetaTxCompleteExchangeBatch>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCompleteExchangeBatch({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCompleteExchangeBatch({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -591,27 +982,60 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCommitToOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCommitToOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCommitToOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCommitToOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCommitToOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCommitToOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
     const offer = await getOfferById(this._subgraphUrl, args.offerId);
 
     if (offer.condition) {
       // keep compatibility with previous version
-      return this.signMetaTxCommitToConditionalOffer({
-        ...args,
+      // Using type assertion because TypeScript can't resolve overloads inside the implementation body
+      // when the args type comes from a complex Omit<Parameters<...>[0], ...> expression
+      const self = this as {
+        signMetaTxCommitToConditionalOffer: (
+          args: Record<string, unknown>
+        ) => Promise<SignedMetaTx | StructuredData>;
+      };
+      const conditionalArgs = {
+        ...(args as Record<string, unknown>),
         tokenId: offer.condition.minTokenId
-      });
+      };
+      return self.signMetaTxCommitToConditionalOffer(conditionalArgs);
     }
 
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCommitToOffer({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCommitToOffer({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -620,17 +1044,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCommitToConditionalOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCommitToConditionalOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCommitToConditionalOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCommitToConditionalOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCommitToConditionalOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCommitToConditionalOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCommitToConditionalOffer({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCommitToConditionalOffer({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -639,17 +1088,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCommitToBuyerOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCommitToBuyerOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCommitToBuyerOffer(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCommitToBuyerOffer>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCommitToBuyerOffer(
     args: Omit<
       Parameters<typeof handler.signMetaTxCommitToBuyerOffer>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCommitToBuyerOffer({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCommitToBuyerOffer({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -658,19 +1132,46 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCreateOfferAndCommit(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOfferAndCommit>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCreateOfferAndCommit(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCreateOfferAndCommit>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCreateOfferAndCommit(
     args: Omit<
       Parameters<typeof handler.signMetaTxCreateOfferAndCommit>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCreateOfferAndCommit({
+        web3Lib: this._web3Lib,
+        theGraphStorage: this._theGraphStorage,
+        metadataStorage: this._metadataStorage,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCreateOfferAndCommit({
       web3Lib: this._web3Lib,
       theGraphStorage: this._theGraphStorage,
       metadataStorage: this._metadataStorage,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -679,17 +1180,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxCancelVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCancelVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxCancelVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxCancelVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxCancelVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxCancelVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxCancelVoucher({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxCancelVoucher({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -698,17 +1224,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxRedeemVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRedeemVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxRedeemVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRedeemVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxRedeemVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxRedeemVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxRedeemVoucher({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxRedeemVoucher({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -717,17 +1268,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxExpireVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExpireVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxExpireVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExpireVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxExpireVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxExpireVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxExpireVoucher({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxExpireVoucher({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -736,17 +1312,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxRevokeVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRevokeVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxRevokeVoucher(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRevokeVoucher>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxRevokeVoucher(
     args: Omit<
       Parameters<typeof handler.signMetaTxRevokeVoucher>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxRevokeVoucher({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxRevokeVoucher({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -755,17 +1356,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxRetractDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRetractDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxRetractDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRetractDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxRetractDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxRetractDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxRetractDispute({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxRetractDispute({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -774,17 +1400,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxEscalateDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxEscalateDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxEscalateDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxEscalateDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxEscalateDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxEscalateDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxEscalateDispute({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxEscalateDispute({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -793,17 +1444,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxRaiseDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRaiseDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxRaiseDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxRaiseDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxRaiseDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxRaiseDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxRaiseDispute({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxRaiseDispute({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -812,17 +1488,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxResolveDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxResolveDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxResolveDispute(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxResolveDispute>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxResolveDispute(
     args: Omit<
       Parameters<typeof handler.signMetaTxResolveDispute>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxResolveDispute({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxResolveDispute({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -831,17 +1532,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxExtendDisputeTimeout(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExtendDisputeTimeout>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxExtendDisputeTimeout(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxExtendDisputeTimeout>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxExtendDisputeTimeout(
     args: Omit<
       Parameters<typeof handler.signMetaTxExtendDisputeTimeout>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxExtendDisputeTimeout({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxExtendDisputeTimeout({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -850,17 +1576,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxWithdrawFunds(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxWithdrawFunds>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxWithdrawFunds(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxWithdrawFunds>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxWithdrawFunds(
     args: Omit<
       Parameters<typeof handler.signMetaTxWithdrawFunds>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxWithdrawFunds({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxWithdrawFunds({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 
@@ -869,17 +1620,42 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
    * @param args - Meta transaction args.
    * @returns Signature.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signMetaTxDepositFunds(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxDepositFunds>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signMetaTxDepositFunds(
+    args: Omit<
+      Parameters<typeof handler.signMetaTxDepositFunds>[0],
+      "web3Lib" | "metaTxHandlerAddress" | "chainId"
+    > & { returnTypedDataToSign?: false | undefined }
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signMetaTxDepositFunds(
     args: Omit<
       Parameters<typeof handler.signMetaTxDepositFunds>[0],
       "web3Lib" | "metaTxHandlerAddress" | "chainId"
     >
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
+    if (args.returnTypedDataToSign) {
+      return handler.signMetaTxDepositFunds({
+        web3Lib: this._web3Lib,
+        metaTxHandlerAddress: this._protocolDiamond,
+        chainId: this._chainId,
+        ...args,
+        returnTypedDataToSign: true
+      });
+    }
     return handler.signMetaTxDepositFunds({
       web3Lib: this._web3Lib,
       metaTxHandlerAddress: this._protocolDiamond,
       chainId: this._chainId,
-      ...args
+      ...args,
+      returnTypedDataToSign: false
     });
   }
 

--- a/packages/core-sdk/src/meta-tx/mixin.ts
+++ b/packages/core-sdk/src/meta-tx/mixin.ts
@@ -890,7 +890,7 @@ export class MetaTxMixin<T extends Web3LibAdapter> extends BaseCoreSDK<T> {
   }
 
   /**
-   * Encodes and signs a meta transaction for `completeExchangeBatch` that can be relayed.
+   * Encodes and signs a meta transaction for `completeExchange` that can be relayed.
    * @param args - Meta transaction args.
    * @returns Signature.
    */

--- a/packages/core-sdk/src/native-meta-tx/handler.ts
+++ b/packages/core-sdk/src/native-meta-tx/handler.ts
@@ -8,7 +8,10 @@ import { BigNumberish, BigNumber } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 import { Biconomy } from "../meta-tx/biconomy";
 import { BaseMetaTxArgs, SignedMetaTx } from "../meta-tx/handler";
-import { prepareDataSignatureParameters } from "../utils/signature";
+import {
+  prepareDataSignatureParameters,
+  StructuredData
+} from "../utils/signature";
 import {
   nativeMetaTransactionsIface,
   alternativeNonceIface
@@ -52,16 +55,27 @@ export async function getNonce(args: {
   }
 }
 
+type NativeMetaTxArgs = BaseMetaTxArgs & {
+  functionName: string;
+  functionSignature: string;
+  domain: {
+    name: string;
+    version: string;
+  };
+};
+
+// Overload: returnTypedDataToSign is true → returns StructuredData
 export async function signNativeMetaTx(
-  args: BaseMetaTxArgs & {
-    functionName: string;
-    functionSignature: string;
-    domain: {
-      name: string;
-      version: string;
-    };
-  }
-): Promise<SignedMetaTx> {
+  args: NativeMetaTxArgs & { returnTypedDataToSign: true }
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signNativeMetaTx(
+  args: NativeMetaTxArgs & { returnTypedDataToSign?: false | undefined }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signNativeMetaTx(
+  args: NativeMetaTxArgs & { returnTypedDataToSign?: boolean }
+): Promise<SignedMetaTx | StructuredData> {
   const metaTransactionType = [
     { name: "nonce", type: "uint256" },
     { name: "from", type: "address" },
@@ -80,13 +94,24 @@ export async function signNativeMetaTx(
     functionSignature: args.functionSignature
   };
 
-  const signature = await prepareDataSignatureParameters({
+  const baseParams = {
     ...args,
     verifyingContractAddress: args.metaTxHandlerAddress,
     customSignatureType,
     customDomainData: args.domain,
     primaryType: "MetaTransaction",
-    message,
+    message
+  };
+
+  if (args.returnTypedDataToSign) {
+    return prepareDataSignatureParameters({
+      ...baseParams,
+      returnTypedDataToSign: true
+    });
+  }
+
+  const signature = await prepareDataSignatureParameters({
+    ...baseParams,
     returnTypedDataToSign: false
   });
 
@@ -97,14 +122,29 @@ export async function signNativeMetaTx(
   };
 }
 
-export async function signNativeMetaTxApproveExchangeToken(args: {
+type ApproveExchangeTokenBaseArgs = {
   web3Lib: Web3LibAdapter;
   chainId: number;
   user: string;
   exchangeToken: string;
   spender: string;
   value: BigNumberish;
-}) {
+};
+
+// Overload: returnTypedDataToSign is true → returns StructuredData
+export async function signNativeMetaTxApproveExchangeToken(
+  args: ApproveExchangeTokenBaseArgs & { returnTypedDataToSign: true }
+): Promise<StructuredData>;
+// Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+export async function signNativeMetaTxApproveExchangeToken(
+  args: ApproveExchangeTokenBaseArgs & {
+    returnTypedDataToSign?: false | undefined;
+  }
+): Promise<SignedMetaTx>;
+// Implementation
+export async function signNativeMetaTxApproveExchangeToken(
+  args: ApproveExchangeTokenBaseArgs & { returnTypedDataToSign?: boolean }
+): Promise<SignedMetaTx | StructuredData> {
   const domain = {
     name: await getERC20Name({
       contractAddress: args.exchangeToken,
@@ -124,15 +164,19 @@ export async function signNativeMetaTxApproveExchangeToken(args: {
     args.spender,
     args.value
   ]);
-  return signNativeMetaTx({
+  const baseArgs = {
     web3Lib: args.web3Lib,
     metaTxHandlerAddress: args.exchangeToken,
     chainId: args.chainId,
-    nonce: nonce,
+    nonce,
     functionName,
     functionSignature,
     domain
-  });
+  };
+  if (args.returnTypedDataToSign) {
+    return signNativeMetaTx({ ...baseArgs, returnTypedDataToSign: true });
+  }
+  return signNativeMetaTx({ ...baseArgs, returnTypedDataToSign: false });
 }
 
 export async function relayNativeMetaTransaction(args: {

--- a/packages/core-sdk/src/native-meta-tx/handler.ts
+++ b/packages/core-sdk/src/native-meta-tx/handler.ts
@@ -90,7 +90,7 @@ export async function signNativeMetaTx(
   const signerAddress = await args.web3Lib.getSignerAddress();
 
   const message = {
-    nonce: args.nonce,
+    nonce: args.nonce.toString(),
     from: signerAddress,
     functionSignature: args.functionSignature
   };

--- a/packages/core-sdk/src/native-meta-tx/handler.ts
+++ b/packages/core-sdk/src/native-meta-tx/handler.ts
@@ -7,11 +7,12 @@ import {
 import { BigNumberish, BigNumber } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 import { Biconomy } from "../meta-tx/biconomy";
-import { BaseMetaTxArgs, SignedMetaTx } from "../meta-tx/handler";
 import {
-  prepareDataSignatureParameters,
-  StructuredData
-} from "../utils/signature";
+  BaseMetaTxArgs,
+  SignedMetaTx,
+  UnsignedMetaTx
+} from "../meta-tx/handler";
+import { prepareDataSignatureParameters } from "../utils/signature";
 import {
   nativeMetaTransactionsIface,
   alternativeNonceIface
@@ -64,10 +65,10 @@ type NativeMetaTxArgs = BaseMetaTxArgs & {
   };
 };
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signNativeMetaTx(
   args: NativeMetaTxArgs & { returnTypedDataToSign: true }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signNativeMetaTx(
   args: NativeMetaTxArgs & { returnTypedDataToSign?: false | undefined }
@@ -75,7 +76,7 @@ export async function signNativeMetaTx(
 // Implementation
 export async function signNativeMetaTx(
   args: NativeMetaTxArgs & { returnTypedDataToSign?: boolean }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const metaTransactionType = [
     { name: "nonce", type: "uint256" },
     { name: "from", type: "address" },
@@ -104,10 +105,15 @@ export async function signNativeMetaTx(
   };
 
   if (args.returnTypedDataToSign) {
-    return prepareDataSignatureParameters({
+    const structuredData = await prepareDataSignatureParameters({
       ...baseParams,
       returnTypedDataToSign: true
     });
+    return {
+      ...structuredData,
+      functionName: args.functionName,
+      functionSignature: args.functionSignature
+    };
   }
 
   const signature = await prepareDataSignatureParameters({
@@ -131,10 +137,10 @@ type ApproveExchangeTokenBaseArgs = {
   value: BigNumberish;
 };
 
-// Overload: returnTypedDataToSign is true → returns StructuredData
+// Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
 export async function signNativeMetaTxApproveExchangeToken(
   args: ApproveExchangeTokenBaseArgs & { returnTypedDataToSign: true }
-): Promise<StructuredData>;
+): Promise<UnsignedMetaTx>;
 // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
 export async function signNativeMetaTxApproveExchangeToken(
   args: ApproveExchangeTokenBaseArgs & {
@@ -144,7 +150,7 @@ export async function signNativeMetaTxApproveExchangeToken(
 // Implementation
 export async function signNativeMetaTxApproveExchangeToken(
   args: ApproveExchangeTokenBaseArgs & { returnTypedDataToSign?: boolean }
-): Promise<SignedMetaTx | StructuredData> {
+): Promise<SignedMetaTx | UnsignedMetaTx> {
   const domain = {
     name: await getERC20Name({
       contractAddress: args.exchangeToken,

--- a/packages/core-sdk/src/native-meta-tx/mixin.ts
+++ b/packages/core-sdk/src/native-meta-tx/mixin.ts
@@ -6,7 +6,9 @@ import {
 import { BigNumberish } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 import { handler } from ".";
+import { SignedMetaTx } from "../meta-tx/handler";
 import { BaseCoreSDK } from "./../mixins/base-core-sdk";
+import { StructuredData } from "../utils/signature";
 
 export class NativeMetaTxMixin<
   T extends Web3LibAdapter
@@ -15,24 +17,49 @@ export class NativeMetaTxMixin<
    * Encodes and signs a native "token.approve()" meta transaction that can be relayed.
    * @param exchangeToken - The address of the token contract.
    * @param value - The value to be approved.
-   * @param overrides - Optionally specify a spender address (default is the protocol contract address).
-   * @returns Signature.
+   * @param overrides - Optionally specify a spender address (default is the protocol contract address)
+   *                    and/or set returnTypedDataToSign to control the return type.
+   * @returns Signature or structured typed data.
    */
+  // Overload: returnTypedDataToSign is true → returns StructuredData
+  public async signNativeMetaTxApproveExchangeToken(
+    exchangeToken: string,
+    value: BigNumberish,
+    overrides: Partial<{ spender: string }> & { returnTypedDataToSign: true }
+  ): Promise<StructuredData>;
+  // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
+  public async signNativeMetaTxApproveExchangeToken(
+    exchangeToken: string,
+    value: BigNumberish,
+    overrides?: Partial<{ spender: string; returnTypedDataToSign?: false }>
+  ): Promise<SignedMetaTx>;
+  // Implementation
   public async signNativeMetaTxApproveExchangeToken(
     exchangeToken: string,
     value: BigNumberish,
     overrides: Partial<{
       spender: string;
+      returnTypedDataToSign: boolean;
     }> = {}
-  ) {
+  ): Promise<SignedMetaTx | StructuredData> {
     const user = await this._web3Lib.getSignerAddress();
-    return handler.signNativeMetaTxApproveExchangeToken({
+    const baseArgs = {
       web3Lib: this._web3Lib,
       chainId: this._chainId,
       user,
       exchangeToken,
       spender: overrides.spender || this._protocolDiamond,
       value
+    };
+    if (overrides.returnTypedDataToSign) {
+      return handler.signNativeMetaTxApproveExchangeToken({
+        ...baseArgs,
+        returnTypedDataToSign: true
+      });
+    }
+    return handler.signNativeMetaTxApproveExchangeToken({
+      ...baseArgs,
+      returnTypedDataToSign: false
     });
   }
 

--- a/packages/core-sdk/src/native-meta-tx/mixin.ts
+++ b/packages/core-sdk/src/native-meta-tx/mixin.ts
@@ -6,9 +6,8 @@ import {
 import { BigNumberish } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 import { handler } from ".";
-import { SignedMetaTx } from "../meta-tx/handler";
+import { SignedMetaTx, UnsignedMetaTx } from "../meta-tx/handler";
 import { BaseCoreSDK } from "./../mixins/base-core-sdk";
-import { StructuredData } from "../utils/signature";
 
 export class NativeMetaTxMixin<
   T extends Web3LibAdapter
@@ -21,12 +20,12 @@ export class NativeMetaTxMixin<
    *                    and/or set returnTypedDataToSign to control the return type.
    * @returns Signature or structured typed data.
    */
-  // Overload: returnTypedDataToSign is true → returns StructuredData
+  // Overload: returnTypedDataToSign is true → returns UnsignedMetaTx
   public async signNativeMetaTxApproveExchangeToken(
     exchangeToken: string,
     value: BigNumberish,
     overrides: Partial<{ spender: string }> & { returnTypedDataToSign: true }
-  ): Promise<StructuredData>;
+  ): Promise<UnsignedMetaTx>;
   // Overload: returnTypedDataToSign is false or undefined → returns SignedMetaTx
   public async signNativeMetaTxApproveExchangeToken(
     exchangeToken: string,
@@ -41,7 +40,7 @@ export class NativeMetaTxMixin<
       spender: string;
       returnTypedDataToSign: boolean;
     }> = {}
-  ): Promise<SignedMetaTx | StructuredData> {
+  ): Promise<SignedMetaTx | UnsignedMetaTx> {
     const user = await this._web3Lib.getSignerAddress();
     const baseArgs = {
       web3Lib: this._web3Lib,

--- a/packages/core-sdk/tests/meta-tx/handler.test.ts
+++ b/packages/core-sdk/tests/meta-tx/handler.test.ts
@@ -41,7 +41,12 @@ import * as mockInterface from "../../src/forwarder/mock-interface";
 import { StructuredData } from "../../src/utils/signature";
 import nock from "nock";
 import { AddressZero } from "@ethersproject/constants";
-import { AuthTokenType, EvaluationMethod, GatingType, TokenType } from "@bosonprotocol/common";
+import {
+  AuthTokenType,
+  EvaluationMethod,
+  GatingType,
+  TokenType
+} from "@bosonprotocol/common";
 
 jest.setTimeout(60_000);
 
@@ -98,10 +103,7 @@ function assertSignedMetaTx(result: unknown) {
   expect(typeof r.functionSignature).toBe("string");
 }
 
-function assertStructuredData(
-  result: unknown,
-  expectedPrimaryType: string
-) {
+function assertStructuredData(result: unknown, expectedPrimaryType: string) {
   const d = result as StructuredData;
   expect(d.primaryType).toBe(expectedPrimaryType);
   expect(d.domain.name).toBe("Boson Protocol");
@@ -164,7 +166,10 @@ const createGroupArgs = {
 describe("meta-tx handler", () => {
   // ── signMetaTx (base) ──────────────────────────────────────────────────────
   describe("#signMetaTx()", () => {
-    const extraArgs = { functionName: "testFn()", functionSignature: "0xdeadbeef" };
+    const extraArgs = {
+      functionName: "testFn()",
+      functionSignature: "0xdeadbeef"
+    };
 
     test("returns SignedMetaTx without returnTypedDataToSign", async () => {
       const result = await signMetaTx({ ...base(), ...extraArgs });
@@ -172,7 +177,11 @@ describe("meta-tx handler", () => {
     });
 
     test("returns StructuredData with returnTypedDataToSign: true", async () => {
-      const result = await signMetaTx({ ...base(), ...extraArgs, returnTypedDataToSign: true });
+      const result = await signMetaTx({
+        ...base(),
+        ...extraArgs,
+        returnTypedDataToSign: true
+      });
       assertStructuredData(result, "MetaTransaction");
       expect((result as StructuredData).message).toMatchObject({
         functionName: extraArgs.functionName,
@@ -184,7 +193,10 @@ describe("meta-tx handler", () => {
   // ── signMetaTxCreateSeller ─────────────────────────────────────────────────
   describe("#signMetaTxCreateSeller()", () => {
     test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-      const result = await signMetaTxCreateSeller({ ...base(), createSellerArgs });
+      const result = await signMetaTxCreateSeller({
+        ...base(),
+        createSellerArgs
+      });
       assertSignedMetaTx(result);
       expect(result.functionName).toContain("createSeller");
     });
@@ -202,7 +214,10 @@ describe("meta-tx handler", () => {
   // ── signMetaTxUpdateSeller ─────────────────────────────────────────────────
   describe("#signMetaTxUpdateSeller()", () => {
     test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-      const result = await signMetaTxUpdateSeller({ ...base(), updateSellerArgs });
+      const result = await signMetaTxUpdateSeller({
+        ...base(),
+        updateSellerArgs
+      });
       assertSignedMetaTx(result);
       expect(result.functionName).toContain("updateSeller");
     });
@@ -289,7 +304,11 @@ describe("meta-tx handler", () => {
     });
 
     test("returns StructuredData with returnTypedDataToSign: true", async () => {
-      const result = await signMetaTxVoidOffer({ ...base(), offerId: "1", returnTypedDataToSign: true });
+      const result = await signMetaTxVoidOffer({
+        ...base(),
+        offerId: "1",
+        returnTypedDataToSign: true
+      });
       assertStructuredData(result, "MetaTransaction");
     });
   });
@@ -297,7 +316,10 @@ describe("meta-tx handler", () => {
   // ── signMetaTxVoidOfferBatch ───────────────────────────────────────────────
   describe("#signMetaTxVoidOfferBatch()", () => {
     test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-      const result = await signMetaTxVoidOfferBatch({ ...base(), offerIds: ["1", "2"] });
+      const result = await signMetaTxVoidOfferBatch({
+        ...base(),
+        offerIds: ["1", "2"]
+      });
       assertSignedMetaTx(result);
       expect(result.functionName).toBe("voidOfferBatch(uint256[])");
     });
@@ -382,7 +404,10 @@ describe("meta-tx handler", () => {
   // ── signMetaTxExpireVoucher ────────────────────────────────────────────────
   describe("#signMetaTxExpireVoucher()", () => {
     test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-      const result = await signMetaTxExpireVoucher({ ...base(), exchangeId: "1" });
+      const result = await signMetaTxExpireVoucher({
+        ...base(),
+        exchangeId: "1"
+      });
       assertSignedMetaTx(result);
       expect(result.functionName).toBe("expireVoucher(uint256)");
     });
@@ -400,7 +425,10 @@ describe("meta-tx handler", () => {
   // ── signMetaTxRevokeVoucher ────────────────────────────────────────────────
   describe("#signMetaTxRevokeVoucher()", () => {
     test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-      const result = await signMetaTxRevokeVoucher({ ...base(), exchangeId: "1" });
+      const result = await signMetaTxRevokeVoucher({
+        ...base(),
+        exchangeId: "1"
+      });
       assertSignedMetaTx(result);
       expect(result.functionName).toBe("revokeVoucher(uint256)");
     });
@@ -418,7 +446,10 @@ describe("meta-tx handler", () => {
   // ── signMetaTxCreateGroup ──────────────────────────────────────────────────
   describe("#signMetaTxCreateGroup()", () => {
     test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-      const result = await signMetaTxCreateGroup({ ...base(), createGroupArgs });
+      const result = await signMetaTxCreateGroup({
+        ...base(),
+        createGroupArgs
+      });
       assertSignedMetaTx(result);
       expect(result.functionName).toContain("createGroup");
     });
@@ -598,30 +629,55 @@ describe("meta-tx handler", () => {
 
   // ── Exchange meta-tx functions (via makeExchangeMetaTxSigner) ──────────────
   describe.each([
-    ["#signMetaTxCancelVoucher()", signMetaTxCancelVoucher, "cancelVoucher(uint256)"],
-    ["#signMetaTxRedeemVoucher()", signMetaTxRedeemVoucher, "redeemVoucher(uint256)"],
-    ["#signMetaTxCompleteExchange()", signMetaTxCompleteExchange, "completeExchange(uint256)"],
-    ["#signMetaTxRetractDispute()", signMetaTxRetractDispute, "retractDispute(uint256)"],
-    ["#signMetaTxEscalateDispute()", signMetaTxEscalateDispute, "escalateDispute(uint256)"],
-    ["#signMetaTxRaiseDispute()", signMetaTxRaiseDispute, "raiseDispute(uint256)"]
-  ] as const)(
-    "%s",
-    (_name, fn, expectedFunctionName) => {
-      test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-        const result = await fn({ ...base(), exchangeId: "1" });
-        assertSignedMetaTx(result);
-        expect(result.functionName).toBe(expectedFunctionName);
-      });
+    [
+      "#signMetaTxCancelVoucher()",
+      signMetaTxCancelVoucher,
+      "cancelVoucher(uint256)"
+    ],
+    [
+      "#signMetaTxRedeemVoucher()",
+      signMetaTxRedeemVoucher,
+      "redeemVoucher(uint256)"
+    ],
+    [
+      "#signMetaTxCompleteExchange()",
+      signMetaTxCompleteExchange,
+      "completeExchange(uint256)"
+    ],
+    [
+      "#signMetaTxRetractDispute()",
+      signMetaTxRetractDispute,
+      "retractDispute(uint256)"
+    ],
+    [
+      "#signMetaTxEscalateDispute()",
+      signMetaTxEscalateDispute,
+      "escalateDispute(uint256)"
+    ],
+    [
+      "#signMetaTxRaiseDispute()",
+      signMetaTxRaiseDispute,
+      "raiseDispute(uint256)"
+    ]
+  ] as const)("%s", (_name, fn, expectedFunctionName) => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await fn({ ...base(), exchangeId: "1" });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe(expectedFunctionName);
+    });
 
-      test("returns StructuredData with returnTypedDataToSign: true", async () => {
-        const result = await fn({ ...base(), exchangeId: "1", returnTypedDataToSign: true });
-        assertStructuredData(result, "MetaTxExchange");
-        expect((result as StructuredData).message).toMatchObject({
-          functionName: expectedFunctionName
-        });
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await fn({
+        ...base(),
+        exchangeId: "1",
+        returnTypedDataToSign: true
       });
-    }
-  );
+      assertStructuredData(result, "MetaTxExchange");
+      expect((result as StructuredData).message).toMatchObject({
+        functionName: expectedFunctionName
+      });
+    });
+  });
 
   // ── signMetaTxResolveDispute ───────────────────────────────────────────────
   describe("#signMetaTxResolveDispute()", () => {
@@ -650,7 +706,11 @@ describe("meta-tx handler", () => {
         ...base(),
         exchangeId: 1,
         buyerPercent: 10,
-        counterpartySig: { r: counterpartySig.r, s: counterpartySig.s, v: counterpartySig.v }
+        counterpartySig: {
+          r: counterpartySig.r,
+          s: counterpartySig.s,
+          v: counterpartySig.v
+        }
       });
       expect(signedMetaTx.r).toEqual(EXPECTED_R);
       expect(signedMetaTx.s).toEqual(EXPECTED_S);
@@ -705,7 +765,9 @@ describe("meta-tx handler", () => {
         tokenAmounts: ["1000000000000000000"]
       });
       assertSignedMetaTx(result);
-      expect(result.functionName).toBe("withdrawFunds(uint256,address[],uint256[])");
+      expect(result.functionName).toBe(
+        "withdrawFunds(uint256,address[],uint256[])"
+      );
     });
 
     test("returns StructuredData with returnTypedDataToSign: true", async () => {

--- a/packages/core-sdk/tests/meta-tx/handler.test.ts
+++ b/packages/core-sdk/tests/meta-tx/handler.test.ts
@@ -1,81 +1,760 @@
-import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
 import {
-  getResubmitted,
+  MockWeb3LibAdapter,
+  mockCreateOfferArgs
+} from "@bosonprotocol/common/tests/mocks";
+import {
+  signMetaTx,
+  signMetaTxCreateSeller,
+  signMetaTxUpdateSeller,
+  signMetaTxOptInToSellerUpdate,
+  signMetaTxCreateOffer,
+  signMetaTxCreateOfferBatch,
+  signMetaTxVoidOffer,
+  signMetaTxVoidOfferBatch,
+  signMetaTxExtendOffer,
+  signMetaTxExtendOfferBatch,
+  signMetaTxCompleteExchangeBatch,
+  signMetaTxExpireVoucher,
+  signMetaTxRevokeVoucher,
+  signMetaTxCreateGroup,
+  signMetaTxReserveRange,
   signMetaTxPreMint,
+  signMetaTxSetApprovalForAll,
+  signMetaTxCreateOfferWithCondition,
+  signMetaTxCommitToOffer,
+  signMetaTxCommitToConditionalOffer,
+  signMetaTxCommitToBuyerOffer,
+  signMetaTxCreateOfferAndCommit,
+  signMetaTxCancelVoucher,
+  signMetaTxRedeemVoucher,
+  signMetaTxCompleteExchange,
+  signMetaTxRetractDispute,
+  signMetaTxEscalateDispute,
+  signMetaTxRaiseDispute,
   signMetaTxResolveDispute,
-  signMetaTxSetApprovalForAll
+  signMetaTxExtendDisputeTimeout,
+  signMetaTxWithdrawFunds,
+  signMetaTxDepositFunds,
+  getResubmitted
 } from "../../src/meta-tx/handler";
 import * as mockInterface from "../../src/forwarder/mock-interface";
+import { StructuredData } from "../../src/utils/signature";
 import nock from "nock";
+import { AddressZero } from "@ethersproject/constants";
+import { AuthTokenType, EvaluationMethod, GatingType, TokenType } from "@bosonprotocol/common";
 
 jest.setTimeout(60_000);
 
+// ─── Shared constants ────────────────────────────────────────────────────────
+
+const CHAIN_ID = 31337; // local chain → avoids Biconomy paths
+const META_TX_HANDLER = "0x0000000000000000000000000000000000000000";
+const SIGNER = "0x0000000000000000000000000000000000000001";
+const TOKEN = "0x0000000000000000000000000000000000000002";
+// A real-looking signature produced by the mock adapter
+const MOCK_SIG =
+  "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b";
+const EXPECTED_R =
+  "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd";
+const EXPECTED_S =
+  "0x72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a";
+const EXPECTED_V = 27;
+const NONCE = 1;
+// ABI-encoded `true` (bool) – returned by isSellerSaltAvailable mock
+const ABI_BOOL_TRUE =
+  "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeWeb3Lib() {
+  return new MockWeb3LibAdapter({
+    getSignerAddress: SIGNER,
+    send: MOCK_SIG,
+    call: ABI_BOOL_TRUE
+  });
+}
+
+function base() {
+  return {
+    chainId: CHAIN_ID,
+    metaTxHandlerAddress: META_TX_HANDLER,
+    nonce: NONCE,
+    web3Lib: makeWeb3Lib()
+  };
+}
+
+function assertSignedMetaTx(result: unknown) {
+  const r = result as {
+    r: string;
+    s: string;
+    v: number;
+    functionName: string;
+    functionSignature: string;
+  };
+  expect(r.r).toBe(EXPECTED_R);
+  expect(r.s).toBe(EXPECTED_S);
+  expect(r.v).toBe(EXPECTED_V);
+  expect(typeof r.functionName).toBe("string");
+  expect(typeof r.functionSignature).toBe("string");
+}
+
+function assertStructuredData(
+  result: unknown,
+  expectedPrimaryType: string
+) {
+  const d = result as StructuredData;
+  expect(d.primaryType).toBe(expectedPrimaryType);
+  expect(d.domain.name).toBe("Boson Protocol");
+  expect(d.domain.verifyingContract).toBe(META_TX_HANDLER);
+  expect(Array.isArray(d.types.EIP712Domain)).toBe(true);
+  expect(typeof d.message).toBe("object");
+  // Confirm it is NOT a SignedMetaTx
+  expect((d as unknown as { r?: unknown }).r).toBeUndefined();
+}
+
+// ─── Shared arg fixtures ─────────────────────────────────────────────────────
+
+const createSellerArgs = {
+  assistant: SIGNER,
+  admin: SIGNER,
+  treasury: SIGNER,
+  contractUri: "ipfs://contract-uri",
+  royaltyPercentage: "0",
+  authTokenId: "0",
+  authTokenType: AuthTokenType.NONE,
+  metadataUri: "ipfs://seller-metadata"
+};
+
+const updateSellerArgs = {
+  id: "1",
+  assistant: SIGNER,
+  admin: SIGNER,
+  treasury: SIGNER,
+  authTokenId: "0",
+  authTokenType: AuthTokenType.NONE,
+  metadataUri: "ipfs://seller-metadata"
+};
+
+const optInToSellerUpdateArgs = {
+  id: "1",
+  fieldsToUpdate: { assistant: true }
+};
+
+const createOfferArgsMock = mockCreateOfferArgs();
+
+const conditionStruct = {
+  method: EvaluationMethod.Threshold,
+  tokenType: TokenType.FungibleToken,
+  tokenAddress: TOKEN,
+  gatingType: GatingType.PerAddress,
+  minTokenId: "0",
+  maxTokenId: "0",
+  threshold: "1",
+  maxCommits: "1"
+};
+
+const createGroupArgs = {
+  ...conditionStruct,
+  sellerId: "1",
+  offerIds: ["1"]
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
 describe("meta-tx handler", () => {
+  // ── signMetaTx (base) ──────────────────────────────────────────────────────
+  describe("#signMetaTx()", () => {
+    const extraArgs = { functionName: "testFn()", functionSignature: "0xdeadbeef" };
+
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTx({ ...base(), ...extraArgs });
+      assertSignedMetaTx(result);
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTx({ ...base(), ...extraArgs, returnTypedDataToSign: true });
+      assertStructuredData(result, "MetaTransaction");
+      expect((result as StructuredData).message).toMatchObject({
+        functionName: extraArgs.functionName,
+        from: SIGNER
+      });
+    });
+  });
+
+  // ── signMetaTxCreateSeller ─────────────────────────────────────────────────
+  describe("#signMetaTxCreateSeller()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCreateSeller({ ...base(), createSellerArgs });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("createSeller");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCreateSeller({
+        ...base(),
+        createSellerArgs,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxUpdateSeller ─────────────────────────────────────────────────
+  describe("#signMetaTxUpdateSeller()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxUpdateSeller({ ...base(), updateSellerArgs });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("updateSeller");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxUpdateSeller({
+        ...base(),
+        updateSellerArgs,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxOptInToSellerUpdate ──────────────────────────────────────────
+  describe("#signMetaTxOptInToSellerUpdate()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxOptInToSellerUpdate({
+        ...base(),
+        optInToSellerUpdateArgs
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("optInToSellerUpdate");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxOptInToSellerUpdate({
+        ...base(),
+        optInToSellerUpdateArgs,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxCreateOffer ──────────────────────────────────────────────────
+  describe("#signMetaTxCreateOffer()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCreateOffer({
+        ...base(),
+        createOfferArgs: createOfferArgsMock
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("createOffer");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCreateOffer({
+        ...base(),
+        createOfferArgs: createOfferArgsMock,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxCreateOfferBatch ─────────────────────────────────────────────
+  describe("#signMetaTxCreateOfferBatch()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCreateOfferBatch({
+        ...base(),
+        createOffersArgs: [createOfferArgsMock]
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("createOfferBatch");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCreateOfferBatch({
+        ...base(),
+        createOffersArgs: [createOfferArgsMock],
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxVoidOffer ────────────────────────────────────────────────────
+  describe("#signMetaTxVoidOffer()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxVoidOffer({ ...base(), offerId: "1" });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("voidOffer(uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxVoidOffer({ ...base(), offerId: "1", returnTypedDataToSign: true });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxVoidOfferBatch ───────────────────────────────────────────────
+  describe("#signMetaTxVoidOfferBatch()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxVoidOfferBatch({ ...base(), offerIds: ["1", "2"] });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("voidOfferBatch(uint256[])");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxVoidOfferBatch({
+        ...base(),
+        offerIds: ["1", "2"],
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxExtendOffer ──────────────────────────────────────────────────
+  describe("#signMetaTxExtendOffer()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxExtendOffer({
+        ...base(),
+        offerId: "1",
+        validUntil: Math.floor(Date.now() / 1000) + 3600
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("extendOffer(uint256,uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxExtendOffer({
+        ...base(),
+        offerId: "1",
+        validUntil: Math.floor(Date.now() / 1000) + 3600,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxExtendOfferBatch ─────────────────────────────────────────────
+  describe("#signMetaTxExtendOfferBatch()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxExtendOfferBatch({
+        ...base(),
+        offerIds: ["1", "2"],
+        validUntil: Math.floor(Date.now() / 1000) + 3600
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("extendOfferBatch(uint256[],uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxExtendOfferBatch({
+        ...base(),
+        offerIds: ["1", "2"],
+        validUntil: Math.floor(Date.now() / 1000) + 3600,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxCompleteExchangeBatch ────────────────────────────────────────
+  describe("#signMetaTxCompleteExchangeBatch()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCompleteExchangeBatch({
+        ...base(),
+        exchangeIds: ["1", "2"]
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("completeExchangeBatch(uint256[])");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCompleteExchangeBatch({
+        ...base(),
+        exchangeIds: ["1", "2"],
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxExpireVoucher ────────────────────────────────────────────────
+  describe("#signMetaTxExpireVoucher()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxExpireVoucher({ ...base(), exchangeId: "1" });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("expireVoucher(uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxExpireVoucher({
+        ...base(),
+        exchangeId: "1",
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxRevokeVoucher ────────────────────────────────────────────────
+  describe("#signMetaTxRevokeVoucher()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxRevokeVoucher({ ...base(), exchangeId: "1" });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("revokeVoucher(uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxRevokeVoucher({
+        ...base(),
+        exchangeId: "1",
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxCreateGroup ──────────────────────────────────────────────────
+  describe("#signMetaTxCreateGroup()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCreateGroup({ ...base(), createGroupArgs });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("createGroup");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCreateGroup({
+        ...base(),
+        createGroupArgs,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxReserveRange ─────────────────────────────────────────────────
+  describe("#signMetaTxReserveRange()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxReserveRange({
+        ...base(),
+        offerId: "1",
+        length: "100",
+        to: SIGNER
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("reserveRange(uint256,uint256,address)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxReserveRange({
+        ...base(),
+        offerId: "1",
+        length: "100",
+        to: SIGNER,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxCreateOfferWithCondition ─────────────────────────────────────
+  describe("#signMetaTxCreateOfferWithCondition()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCreateOfferWithCondition({
+        ...base(),
+        offerToCreate: createOfferArgsMock,
+        condition: conditionStruct
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("createOfferWithCondition");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCreateOfferWithCondition({
+        ...base(),
+        offerToCreate: createOfferArgsMock,
+        condition: conditionStruct,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxCommitToOffer ────────────────────────────────────────────────
+  describe("#signMetaTxCommitToOffer()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCommitToOffer({ ...base(), offerId: "1" });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("commitToOffer(address,uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCommitToOffer({
+        ...base(),
+        offerId: "1",
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTxCommitToOffer");
+      expect((result as StructuredData).message).toMatchObject({
+        functionName: "commitToOffer(address,uint256)"
+      });
+    });
+  });
+
+  // ── signMetaTxCommitToConditionalOffer ─────────────────────────────────────
+  describe("#signMetaTxCommitToConditionalOffer()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCommitToConditionalOffer({
+        ...base(),
+        offerId: "1",
+        tokenId: "42"
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe(
+        "commitToConditionalOffer(address,uint256,uint256)"
+      );
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCommitToConditionalOffer({
+        ...base(),
+        offerId: "1",
+        tokenId: "42",
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTxCommitToConditionalOffer");
+      expect((result as StructuredData).message).toMatchObject({
+        functionName: "commitToConditionalOffer(address,uint256,uint256)"
+      });
+    });
+  });
+
+  // ── signMetaTxCommitToBuyerOffer ───────────────────────────────────────────
+  describe("#signMetaTxCommitToBuyerOffer()", () => {
+    const sellerParams = {
+      collectionIndex: "0",
+      royaltyInfo: { recipients: [AddressZero], bps: ["0"] },
+      mutualizerAddress: AddressZero
+    };
+
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCommitToBuyerOffer({
+        ...base(),
+        offerId: "1",
+        sellerParams
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("commitToBuyerOffer");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCommitToBuyerOffer({
+        ...base(),
+        offerId: "1",
+        sellerParams,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxCreateOfferAndCommit ─────────────────────────────────────────
+  describe("#signMetaTxCreateOfferAndCommit()", () => {
+    const createOfferAndCommitArgs = {
+      ...createOfferArgsMock,
+      offerCreator: SIGNER,
+      committer: SIGNER,
+      condition: conditionStruct,
+      useDepositedFunds: false,
+      signature: MOCK_SIG,
+      sellerId: "1",
+      buyerId: "1",
+      sellerOfferParams: {
+        collectionIndex: "0",
+        royaltyInfo: { recipients: [AddressZero], bps: ["0"] },
+        mutualizerAddress: AddressZero
+      }
+    };
+
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxCreateOfferAndCommit({
+        ...base(),
+        createOfferAndCommitArgs
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toContain("createOfferAndCommit");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxCreateOfferAndCommit({
+        ...base(),
+        createOfferAndCommitArgs,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── Exchange meta-tx functions (via makeExchangeMetaTxSigner) ──────────────
+  describe.each([
+    ["#signMetaTxCancelVoucher()", signMetaTxCancelVoucher, "cancelVoucher(uint256)"],
+    ["#signMetaTxRedeemVoucher()", signMetaTxRedeemVoucher, "redeemVoucher(uint256)"],
+    ["#signMetaTxCompleteExchange()", signMetaTxCompleteExchange, "completeExchange(uint256)"],
+    ["#signMetaTxRetractDispute()", signMetaTxRetractDispute, "retractDispute(uint256)"],
+    ["#signMetaTxEscalateDispute()", signMetaTxEscalateDispute, "escalateDispute(uint256)"],
+    ["#signMetaTxRaiseDispute()", signMetaTxRaiseDispute, "raiseDispute(uint256)"]
+  ] as const)(
+    "%s",
+    (_name, fn, expectedFunctionName) => {
+      test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+        const result = await fn({ ...base(), exchangeId: "1" });
+        assertSignedMetaTx(result);
+        expect(result.functionName).toBe(expectedFunctionName);
+      });
+
+      test("returns StructuredData with returnTypedDataToSign: true", async () => {
+        const result = await fn({ ...base(), exchangeId: "1", returnTypedDataToSign: true });
+        assertStructuredData(result, "MetaTxExchange");
+        expect((result as StructuredData).message).toMatchObject({
+          functionName: expectedFunctionName
+        });
+      });
+    }
+  );
+
+  // ── signMetaTxResolveDispute ───────────────────────────────────────────────
   describe("#signMetaTxResolveDispute()", () => {
-    const counterpartySignature = {
+    const counterpartySig = {
       signature:
         "0xd093bf19f8e5d7526953f63b7721628b95820e94cf42298f97cd4502b61ff392024b4030ee7db3f74690e721289b287583d72ccd8ad297e69c822eb4f1f87c2a1b",
       r: "0xd093bf19f8e5d7526953f63b7721628b95820e94cf42298f97cd4502b61ff392",
       s: "0x024b4030ee7db3f74690e721289b287583d72ccd8ad297e69c822eb4f1f87c2a1b",
       v: 27
     };
-    const expectedSignedMetaTx = {
-      signature:
-        "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b",
-      r: "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd",
-      s: "0x72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a",
-      v: 27
-    };
+
     test("call with string format signature", async () => {
       const signedMetaTx = await signMetaTxResolveDispute({
-        chainId: 31337,
-        metaTxHandlerAddress: "0x0000000000000000000000000000000000000000",
-        nonce: 1,
-        web3Lib: new MockWeb3LibAdapter({
-          getSignerAddress: "0x0000000000000000000000000000000000000001",
-          send: expectedSignedMetaTx.signature
-        }),
+        ...base(),
         exchangeId: 1,
         buyerPercent: 10,
-        counterpartySig: counterpartySignature.signature
+        counterpartySig: counterpartySig.signature
       });
-      expect(signedMetaTx.r).toEqual(expectedSignedMetaTx.r);
-      expect(signedMetaTx.s).toEqual(expectedSignedMetaTx.s);
-      expect(signedMetaTx.v).toEqual(expectedSignedMetaTx.v);
+      expect(signedMetaTx.r).toEqual(EXPECTED_R);
+      expect(signedMetaTx.s).toEqual(EXPECTED_S);
+      expect(signedMetaTx.v).toEqual(EXPECTED_V);
     });
+
     test("call with {r,s,v} format signature", async () => {
       const signedMetaTx = await signMetaTxResolveDispute({
-        chainId: 31337,
-        metaTxHandlerAddress: "0x0000000000000000000000000000000000000000",
-        nonce: 1,
-        web3Lib: new MockWeb3LibAdapter({
-          getSignerAddress: "0x0000000000000000000000000000000000000001",
-          send: expectedSignedMetaTx.signature
-        }),
+        ...base(),
         exchangeId: 1,
         buyerPercent: 10,
-        counterpartySig: {
-          r: counterpartySignature.r,
-          s: counterpartySignature.s,
-          v: counterpartySignature.v
-        }
+        counterpartySig: { r: counterpartySig.r, s: counterpartySig.s, v: counterpartySig.v }
       });
-      expect(signedMetaTx.r).toEqual(expectedSignedMetaTx.r);
-      expect(signedMetaTx.s).toEqual(expectedSignedMetaTx.s);
-      expect(signedMetaTx.v).toEqual(expectedSignedMetaTx.v);
+      expect(signedMetaTx.r).toEqual(EXPECTED_R);
+      expect(signedMetaTx.s).toEqual(EXPECTED_S);
+      expect(signedMetaTx.v).toEqual(EXPECTED_V);
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxResolveDispute({
+        ...base(),
+        exchangeId: 1,
+        buyerPercent: 10,
+        counterpartySig: counterpartySig.signature,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTxDisputeResolution");
+      expect((result as StructuredData).message).toMatchObject({
+        functionName: "resolveDispute(uint256,uint256,bytes)"
+      });
     });
   });
+
+  // ── signMetaTxExtendDisputeTimeout ─────────────────────────────────────────
+  describe("#signMetaTxExtendDisputeTimeout()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxExtendDisputeTimeout({
+        ...base(),
+        exchangeId: "1",
+        newTimeout: Math.floor(Date.now() / 1000) + 86400
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("extendDisputeTimeout(uint256,uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxExtendDisputeTimeout({
+        ...base(),
+        exchangeId: "1",
+        newTimeout: Math.floor(Date.now() / 1000) + 86400,
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── signMetaTxWithdrawFunds ────────────────────────────────────────────────
+  describe("#signMetaTxWithdrawFunds()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxWithdrawFunds({
+        ...base(),
+        entityId: "1",
+        tokenList: [TOKEN],
+        tokenAmounts: ["1000000000000000000"]
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("withdrawFunds(uint256,address[],uint256[])");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxWithdrawFunds({
+        ...base(),
+        entityId: "1",
+        tokenList: [TOKEN],
+        tokenAmounts: ["1000000000000000000"],
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTxFund");
+      expect((result as StructuredData).message).toMatchObject({
+        functionName: "withdrawFunds(uint256,address[],uint256[])"
+      });
+    });
+  });
+
+  // ── signMetaTxDepositFunds ─────────────────────────────────────────────────
+  describe("#signMetaTxDepositFunds()", () => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      const result = await signMetaTxDepositFunds({
+        ...base(),
+        entityId: "1",
+        fundsTokenAddress: TOKEN,
+        fundsAmount: "1000000000000000000"
+      });
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe("depositFunds(uint256,address,uint256)");
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await signMetaTxDepositFunds({
+        ...base(),
+        entityId: "1",
+        fundsTokenAddress: TOKEN,
+        fundsAmount: "1000000000000000000",
+        returnTypedDataToSign: true
+      });
+      assertStructuredData(result, "MetaTransaction");
+    });
+  });
+
+  // ── Voucher meta-tx (no returnTypedDataToSign – unchanged) ─────────────────
   describe("#signMetaTxPreMint()", () => {
     const biconomyUrl = "https://api.biconomy.io";
-    const expectedSignedMetaTx = {
-      signature:
-        "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b",
-      r: "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd",
-      s: "0x72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a",
-      v: 27
-    };
+    const expectedSig =
+      "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b";
 
-    test("call signMetaTxPreMint", async () => {
+    test("call signMetaTxPreMint (Biconomy path)", async () => {
       nock(biconomyUrl)
         .get("/api/v2/meta-tx/systemInfo?networkId=1")
         .reply(200, {
@@ -92,35 +771,31 @@ describe("meta-tx handler", () => {
         });
 
       const signedMetaTx = await signMetaTxPreMint({
-        chainId: 1, // do not use local chain to force use of Biconomy methods
+        chainId: 1, // non-local → Biconomy path
         bosonVoucherAddress: "0x0000000000000000000000000000000000000000",
         web3Lib: new MockWeb3LibAdapter({
-          getSignerAddress: "0x0000000000000000000000000000000000000001",
-          send: expectedSignedMetaTx.signature,
+          getSignerAddress: SIGNER,
+          send: expectedSig,
           getChainId: 1,
-          call: "0x0000000000000000000000000000000000000000000000000000000000000042" // mock isTrustedForwarder call
+          call: "0x0000000000000000000000000000000000000000000000000000000000000042"
         }),
         offerId: 1,
         amount: 1,
         relayerUrl: biconomyUrl,
         forwarderAbi: mockInterface.abi
       });
-      expect(signedMetaTx.r).toEqual(expectedSignedMetaTx.r);
-      expect(signedMetaTx.s).toEqual(expectedSignedMetaTx.s);
-      expect(signedMetaTx.v).toEqual(expectedSignedMetaTx.v);
+      expect(signedMetaTx.r).toEqual(EXPECTED_R);
+      expect(signedMetaTx.s).toEqual(EXPECTED_S);
+      expect(signedMetaTx.v).toEqual(EXPECTED_V);
     });
   });
+
   describe("#signMetaTxSetApprovalForAll()", () => {
     const biconomyUrl = "https://api.biconomy.io";
-    const expectedSignedMetaTx = {
-      signature:
-        "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b",
-      r: "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd",
-      s: "0x72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a",
-      v: 27
-    };
+    const expectedSig =
+      "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b";
 
-    test("call signMetaTxSetApprovalForAll()", async () => {
+    test("call signMetaTxSetApprovalForAll() (Biconomy path)", async () => {
       nock(biconomyUrl)
         .get("/api/v2/meta-tx/systemInfo?networkId=1")
         .reply(200, {
@@ -137,25 +812,26 @@ describe("meta-tx handler", () => {
         });
 
       const signedMetaTx = await signMetaTxSetApprovalForAll({
-        chainId: 1, // do not use local chain to force use of Biconomy methods
+        chainId: 1, // non-local → Biconomy path
         bosonVoucherAddress: "0x0000000000000000000000000000000000000000",
         web3Lib: new MockWeb3LibAdapter({
-          getSignerAddress: "0x0000000000000000000000000000000000000001",
-          send: expectedSignedMetaTx.signature,
+          getSignerAddress: SIGNER,
+          send: expectedSig,
           getChainId: 1,
-          call: "0x0000000000000000000000000000000000000000000000000000000000000042" // mock isTrustedForwarder call
+          call: "0x0000000000000000000000000000000000000000000000000000000000000042"
         }),
-        operator: "0x0000000000000000000000000000000000000001",
+        operator: SIGNER,
         approved: true,
         relayerUrl: biconomyUrl,
         forwarderAbi: mockInterface.abi
       });
-      expect(signedMetaTx.r).toEqual(expectedSignedMetaTx.r);
-      expect(signedMetaTx.s).toEqual(expectedSignedMetaTx.s);
-      expect(signedMetaTx.v).toEqual(expectedSignedMetaTx.v);
+      expect(signedMetaTx.r).toEqual(EXPECTED_R);
+      expect(signedMetaTx.s).toEqual(EXPECTED_S);
+      expect(signedMetaTx.v).toEqual(EXPECTED_V);
     });
   });
 
+  // ── getResubmitted ─────────────────────────────────────────────────────────
   test("getResubmitted", async () => {
     const biconomyUrl = "https://api.biconomy.io";
     nock(biconomyUrl)
@@ -163,9 +839,7 @@ describe("meta-tx handler", () => {
       .reply(200, {
         code: 200,
         message: "OK",
-        data: {
-          key1: "value1"
-        }
+        data: { key1: "value1" }
       });
     const data = await getResubmitted({
       chainId: 1,

--- a/packages/core-sdk/tests/meta-tx/handler.test.ts
+++ b/packages/core-sdk/tests/meta-tx/handler.test.ts
@@ -38,7 +38,7 @@ import {
   getResubmitted
 } from "../../src/meta-tx/handler";
 import * as mockInterface from "../../src/forwarder/mock-interface";
-import { StructuredData } from "../../src/utils/signature";
+import { UnsignedMetaTx } from "../../src/meta-tx/handler";
 import nock from "nock";
 import { AddressZero } from "@ethersproject/constants";
 import {
@@ -104,7 +104,7 @@ function assertSignedMetaTx(result: unknown) {
 }
 
 function assertStructuredData(result: unknown, expectedPrimaryType: string) {
-  const d = result as StructuredData;
+  const d = result as UnsignedMetaTx;
   expect(d.primaryType).toBe(expectedPrimaryType);
   expect(d.domain.name).toBe("Boson Protocol");
   expect(d.domain.verifyingContract).toBe(META_TX_HANDLER);
@@ -112,6 +112,9 @@ function assertStructuredData(result: unknown, expectedPrimaryType: string) {
   expect(typeof d.message).toBe("object");
   // Confirm it is NOT a SignedMetaTx
   expect((d as unknown as { r?: unknown }).r).toBeUndefined();
+  // Confirm UnsignedMetaTx fields are present
+  expect(typeof d.functionName).toBe("string");
+  expect(typeof d.functionSignature).toBe("string");
 }
 
 // ─── Shared arg fixtures ─────────────────────────────────────────────────────
@@ -183,7 +186,7 @@ describe("meta-tx handler", () => {
         returnTypedDataToSign: true
       });
       assertStructuredData(result, "MetaTransaction");
-      expect((result as StructuredData).message).toMatchObject({
+      expect((result as UnsignedMetaTx).message).toMatchObject({
         functionName: extraArgs.functionName,
         from: SIGNER
       });
@@ -527,7 +530,7 @@ describe("meta-tx handler", () => {
         returnTypedDataToSign: true
       });
       assertStructuredData(result, "MetaTxCommitToOffer");
-      expect((result as StructuredData).message).toMatchObject({
+      expect((result as UnsignedMetaTx).message).toMatchObject({
         functionName: "commitToOffer(address,uint256)"
       });
     });
@@ -555,7 +558,7 @@ describe("meta-tx handler", () => {
         returnTypedDataToSign: true
       });
       assertStructuredData(result, "MetaTxCommitToConditionalOffer");
-      expect((result as StructuredData).message).toMatchObject({
+      expect((result as UnsignedMetaTx).message).toMatchObject({
         functionName: "commitToConditionalOffer(address,uint256,uint256)"
       });
     });
@@ -673,7 +676,7 @@ describe("meta-tx handler", () => {
         returnTypedDataToSign: true
       });
       assertStructuredData(result, "MetaTxExchange");
-      expect((result as StructuredData).message).toMatchObject({
+      expect((result as UnsignedMetaTx).message).toMatchObject({
         functionName: expectedFunctionName
       });
     });
@@ -726,7 +729,7 @@ describe("meta-tx handler", () => {
         returnTypedDataToSign: true
       });
       assertStructuredData(result, "MetaTxDisputeResolution");
-      expect((result as StructuredData).message).toMatchObject({
+      expect((result as UnsignedMetaTx).message).toMatchObject({
         functionName: "resolveDispute(uint256,uint256,bytes)"
       });
     });
@@ -779,7 +782,7 @@ describe("meta-tx handler", () => {
         returnTypedDataToSign: true
       });
       assertStructuredData(result, "MetaTxFund");
-      expect((result as StructuredData).message).toMatchObject({
+      expect((result as UnsignedMetaTx).message).toMatchObject({
         functionName: "withdrawFunds(uint256,address[],uint256[])"
       });
     });

--- a/packages/core-sdk/tests/meta-tx/mixin.test.ts
+++ b/packages/core-sdk/tests/meta-tx/mixin.test.ts
@@ -688,7 +688,8 @@ const createOfferAndCommitArgsMock = {
   committer: SIGNER,
   condition: conditionStruct,
   useDepositedFunds: false,
-  signature: "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b",
+  signature:
+    "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b",
   sellerId: "1",
   buyerId: "1",
   sellerOfferParams: sellerParamsMock
@@ -747,10 +748,16 @@ describe("MetaTxMixin#signMetaTxCallExternalContract()", () => {
 // ─── Tier 2-A: signMetaTx (base) ─────────────────────────────────────────────
 
 describe("MetaTxMixin#signMetaTx() overload dispatch", () => {
-  const extraArgs = { functionName: "testFn()", functionSignature: "0xdeadbeef" };
+  const extraArgs = {
+    functionName: "testFn()",
+    functionSignature: "0xdeadbeef"
+  };
 
   test("returns SignedMetaTx without returnTypedDataToSign", async () => {
-    const result = await makeCoreSDK().signMetaTx({ ...extraArgs, nonce: NONCE });
+    const result = await makeCoreSDK().signMetaTx({
+      ...extraArgs,
+      nonce: NONCE
+    });
     assertSignedMetaTx(result);
     expect(result.functionName).toBe("testFn()");
   });
@@ -909,7 +916,9 @@ describe("MetaTxMixin#signMetaTxCreateOfferWithCondition() overload dispatch", (
 
   test("returns StructuredData with returnTypedDataToSign: true", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await (makeCoreSDK().signMetaTxCreateOfferWithCondition as any)({
+    const result = await (
+      makeCoreSDK().signMetaTxCreateOfferWithCondition as any
+    )({
       offerToCreate: createOfferArgsMock,
       condition: conditionStruct,
       nonce: NONCE,
@@ -978,7 +987,9 @@ describe("MetaTxMixin#signMetaTxCommitToConditionalOffer() overload dispatch", (
 
   test("returns StructuredData with returnTypedDataToSign: true", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await (makeCoreSDK().signMetaTxCommitToConditionalOffer as any)({
+    const result = await (
+      makeCoreSDK().signMetaTxCommitToConditionalOffer as any
+    )({
       offerId: "1",
       tokenId: "42",
       nonce: NONCE,

--- a/packages/core-sdk/tests/meta-tx/mixin.test.ts
+++ b/packages/core-sdk/tests/meta-tx/mixin.test.ts
@@ -12,7 +12,7 @@ import {
 import { AddressZero } from "@ethersproject/constants";
 import { CoreSDK } from "../../src/core-sdk";
 import * as metaTxHandler from "../../src/meta-tx/handler";
-import { StructuredData } from "../../src/utils/signature";
+import { UnsignedMetaTx } from "../../src/meta-tx/handler";
 import {
   BICONOMY_URL,
   SUBGRAPH_URL,
@@ -78,13 +78,16 @@ function assertStructuredDataShape(
   result: unknown,
   expectedPrimaryType?: string
 ) {
-  const d = result as StructuredData;
+  const d = result as UnsignedMetaTx;
   expect(d.domain.verifyingContract).toBe(PROTOCOL_DIAMOND);
   expect(typeof d.primaryType).toBe("string");
   if (expectedPrimaryType) expect(d.primaryType).toBe(expectedPrimaryType);
   expect(typeof d.message).toBe("object");
   // Must NOT look like a SignedMetaTx
   expect((d as unknown as { r?: unknown }).r).toBeUndefined();
+  // Confirm UnsignedMetaTx fields are present
+  expect(typeof d.functionName).toBe("string");
+  expect(typeof d.functionSignature).toBe("string");
 }
 
 function assertSignedMetaTx(result: unknown) {
@@ -163,7 +166,7 @@ describe("MetaTxMixin#signMetaTxCommitToOffer()", () => {
       nonce: NONCE,
       returnTypedDataToSign: true
     });
-    const data = result as StructuredData;
+    const data = result as UnsignedMetaTx;
     expect(data.primaryType).toBe("MetaTxCommitToOffer");
     expect(data.domain.verifyingContract).toBe(PROTOCOL_DIAMOND);
   });
@@ -194,7 +197,7 @@ describe("MetaTxMixin#signMetaTxCommitToOffer()", () => {
       nonce: NONCE,
       returnTypedDataToSign: true
     });
-    const data = result as StructuredData;
+    const data = result as UnsignedMetaTx;
     expect(data.primaryType).toBe("MetaTxCommitToConditionalOffer");
   });
 });

--- a/packages/core-sdk/tests/meta-tx/mixin.test.ts
+++ b/packages/core-sdk/tests/meta-tx/mixin.test.ts
@@ -305,10 +305,13 @@ describe("MetaTxMixin#signMetaTxUpdateSellerAndOptIn()", () => {
     let relayCount = 0;
     jest
       .spyOn(sdk, "relayMetaTransaction")
-      .mockImplementation(async () => (relayCount++ === 0 ? mockUpdateTx : mockOptInTx));
+      .mockImplementation(async () =>
+        relayCount++ === 0 ? mockUpdateTx : mockOptInTx
+      );
 
     jest.spyOn(sdk, "signMetaTxUpdateSeller").mockResolvedValue({
-      functionName: "updateSeller((uint256,address,address,address,address,uint256,uint8))",
+      functionName:
+        "updateSeller((uint256,address,address,address,address,uint256,uint8))",
       functionSignature: "0xabcd",
       r: "0x",
       s: "0x",
@@ -367,19 +370,17 @@ describe("MetaTxMixin#signMetaTxUpdateSellerAndOptIn()", () => {
     const sdkAny = sdk as any;
     spyOnRelayAndSign(sdkAny);
     // First poll: seller found with pendingSeller.assistant === SIGNER → exits while loop
-    jest
-      .spyOn(sdkAny, "getSellerById")
-      .mockResolvedValue(
-        mockRawSellerFromSubgraph({
-          pendingSeller: {
-            assistant: SIGNER,
-            admin: "0x000000000000000000000000000000000000dead",
-            clerk: null,
-            authTokenId: "0",
-            authTokenType: AuthTokenType.NONE
-          }
-        })
-      );
+    jest.spyOn(sdkAny, "getSellerById").mockResolvedValue(
+      mockRawSellerFromSubgraph({
+        pendingSeller: {
+          assistant: SIGNER,
+          admin: "0x000000000000000000000000000000000000dead",
+          clerk: null,
+          authTokenId: "0",
+          authTokenType: AuthTokenType.NONE
+        }
+      })
+    );
 
     const tx = await sdk.signMetaTxUpdateSellerAndOptIn(sellerUpdates);
 
@@ -395,19 +396,17 @@ describe("MetaTxMixin#signMetaTxUpdateSellerAndOptIn()", () => {
     const sdkAny = sdk as any;
     spyOnRelayAndSign(sdkAny);
     // pendingSeller has neither assistant/admin matching SIGNER, authTokenType is NONE
-    jest
-      .spyOn(sdkAny, "getSellerById")
-      .mockResolvedValue(
-        mockRawSellerFromSubgraph({
-          pendingSeller: {
-            assistant: "0x000000000000000000000000000000000000dead",
-            admin: "0x000000000000000000000000000000000000dead",
-            clerk: null,
-            authTokenId: "0",
-            authTokenType: AuthTokenType.NONE
-          }
-        })
-      );
+    jest.spyOn(sdkAny, "getSellerById").mockResolvedValue(
+      mockRawSellerFromSubgraph({
+        pendingSeller: {
+          assistant: "0x000000000000000000000000000000000000dead",
+          admin: "0x000000000000000000000000000000000000dead",
+          clerk: null,
+          authTokenId: "0",
+          authTokenType: AuthTokenType.NONE
+        }
+      })
+    );
 
     const tx = await sdk.signMetaTxUpdateSellerAndOptIn(sellerUpdates);
 
@@ -482,9 +481,7 @@ describe("MetaTxMixin#signMetaTxPreMint()", () => {
 
     await sdk.signMetaTxPreMint({ offerId: "1", amount: "5" }, { batchId: 7 });
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ batchId: 7 })
-    );
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ batchId: 7 }));
     spy.mockRestore();
   });
 });
@@ -581,7 +578,10 @@ describe("MetaTxMixin#signMetaTxSetApprovalForAllToContract()", () => {
     interceptSellersQuery();
     const spy = jest
       .spyOn(metaTxHandler, "signMetaTxSetApprovalForAllToContract")
-      .mockResolvedValueOnce({ ...mockVoucherMetaTxResult, to: EXPLICIT_VOUCHER });
+      .mockResolvedValueOnce({
+        ...mockVoucherMetaTxResult,
+        to: EXPLICIT_VOUCHER
+      });
     const sdk = makeCoreSDK();
 
     await sdk.signMetaTxSetApprovalForAllToContract({

--- a/packages/core-sdk/tests/meta-tx/mixin.test.ts
+++ b/packages/core-sdk/tests/meta-tx/mixin.test.ts
@@ -1,5 +1,15 @@
-import { AuthTokenType, abis } from "@bosonprotocol/common";
-import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
+import {
+  AuthTokenType,
+  EvaluationMethod,
+  GatingType,
+  TokenType,
+  abis
+} from "@bosonprotocol/common";
+import {
+  MockWeb3LibAdapter,
+  mockCreateOfferArgs
+} from "@bosonprotocol/common/tests/mocks";
+import { AddressZero } from "@ethersproject/constants";
 import { CoreSDK } from "../../src/core-sdk";
 import * as metaTxHandler from "../../src/meta-tx/handler";
 import { StructuredData } from "../../src/utils/signature";
@@ -58,6 +68,23 @@ function makeCoreSDK() {
       forwarder: FORWARDER
     }
   });
+}
+
+/**
+ * Generic StructuredData shape assertion for mixin-level tests.
+ * Verifies the mixin correctly injected PROTOCOL_DIAMOND as verifyingContract.
+ */
+function assertStructuredDataShape(
+  result: unknown,
+  expectedPrimaryType?: string
+) {
+  const d = result as StructuredData;
+  expect(d.domain.verifyingContract).toBe(PROTOCOL_DIAMOND);
+  expect(typeof d.primaryType).toBe("string");
+  if (expectedPrimaryType) expect(d.primaryType).toBe(expectedPrimaryType);
+  expect(typeof d.message).toBe("object");
+  // Must NOT look like a SignedMetaTx
+  expect((d as unknown as { r?: unknown }).r).toBeUndefined();
 }
 
 function assertSignedMetaTx(result: unknown) {
@@ -598,6 +625,75 @@ describe("MetaTxMixin#signMetaTxSetApprovalForAllToContract()", () => {
   });
 });
 
+// ─── Tier 2 shared fixtures ──────────────────────────────────────────────────
+
+const TOKEN = "0x0000000000000000000000000000000000000002";
+const NONCE = 1;
+const VALID_UNTIL = Math.floor(Date.now() / 1000) + 3600;
+
+const createSellerArgsMock = {
+  assistant: SIGNER,
+  admin: SIGNER,
+  treasury: SIGNER,
+  contractUri: "ipfs://contract-uri",
+  royaltyPercentage: "0",
+  authTokenId: "0",
+  authTokenType: AuthTokenType.NONE,
+  metadataUri: "ipfs://seller-metadata"
+};
+
+const updateSellerArgsMock = {
+  id: "1",
+  assistant: SIGNER,
+  admin: SIGNER,
+  treasury: SIGNER,
+  authTokenId: "0",
+  authTokenType: AuthTokenType.NONE,
+  metadataUri: "ipfs://seller-metadata"
+};
+
+const optInToSellerUpdateArgsMock = {
+  id: "1",
+  fieldsToUpdate: { assistant: true }
+};
+
+const conditionStruct = {
+  method: EvaluationMethod.Threshold,
+  tokenType: TokenType.FungibleToken,
+  tokenAddress: TOKEN,
+  gatingType: GatingType.PerAddress,
+  minTokenId: "0",
+  maxTokenId: "0",
+  threshold: "1",
+  maxCommits: "1"
+};
+
+const createGroupArgsMock = {
+  ...conditionStruct,
+  sellerId: "1",
+  offerIds: ["1"]
+};
+
+const createOfferArgsMock = mockCreateOfferArgs();
+
+const sellerParamsMock = {
+  collectionIndex: "0",
+  royaltyInfo: { recipients: [AddressZero], bps: ["0"] },
+  mutualizerAddress: AddressZero
+};
+
+const createOfferAndCommitArgsMock = {
+  ...createOfferArgsMock,
+  offerCreator: SIGNER,
+  committer: SIGNER,
+  condition: conditionStruct,
+  useDepositedFunds: false,
+  signature: "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b",
+  sellerId: "1",
+  buyerId: "1",
+  sellerOfferParams: sellerParamsMock
+};
+
 // ─── 7. signMetaTxCallExternalContract ───────────────────────────────────────
 
 describe("MetaTxMixin#signMetaTxCallExternalContract()", () => {
@@ -638,5 +734,440 @@ describe("MetaTxMixin#signMetaTxCallExternalContract()", () => {
       expect.anything()
     );
     spy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tier 2: pure handler-delegating overloads
+// These methods have no mixin-specific logic beyond injecting web3Lib /
+// metaTxHandlerAddress / chainId.  Tests verify the returnTypedDataToSign
+// dispatch is wired correctly and that PROTOCOL_DIAMOND is injected.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── Tier 2-A: signMetaTx (base) ─────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTx() overload dispatch", () => {
+  const extraArgs = { functionName: "testFn()", functionSignature: "0xdeadbeef" };
+
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTx({ ...extraArgs, nonce: NONCE });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe("testFn()");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTx as any)({
+      ...extraArgs,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+// ─── Tier 2-B: seller account methods ────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxCreateSeller() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCreateSeller({
+      createSellerArgs: createSellerArgsMock,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("createSeller");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCreateSeller as any)({
+      createSellerArgs: createSellerArgsMock,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxUpdateSeller() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxUpdateSeller({
+      updateSellerArgs: updateSellerArgsMock,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("updateSeller");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxUpdateSeller as any)({
+      updateSellerArgs: updateSellerArgsMock,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxOptInToSellerUpdate() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxOptInToSellerUpdate({
+      optInToSellerUpdateArgs: optInToSellerUpdateArgsMock,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("optInToSellerUpdate");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxOptInToSellerUpdate as any)({
+      optInToSellerUpdateArgs: optInToSellerUpdateArgsMock,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+// ─── Tier 2-C: offer management ──────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxCreateOffer() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCreateOffer({
+      createOfferArgs: createOfferArgsMock,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("createOffer");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCreateOffer as any)({
+      createOfferArgs: createOfferArgsMock,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxCreateOfferBatch() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCreateOfferBatch({
+      createOffersArgs: [createOfferArgsMock],
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("createOfferBatch");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCreateOfferBatch as any)({
+      createOffersArgs: [createOfferArgsMock],
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxCreateGroup() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCreateGroup({
+      createGroupArgs: createGroupArgsMock,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("createGroup");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCreateGroup as any)({
+      createGroupArgs: createGroupArgsMock,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxCreateOfferWithCondition() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCreateOfferWithCondition({
+      offerToCreate: createOfferArgsMock,
+      condition: conditionStruct,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("createOfferWithCondition");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCreateOfferWithCondition as any)({
+      offerToCreate: createOfferArgsMock,
+      condition: conditionStruct,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+describe.each([
+  ["signMetaTxVoidOffer", "voidOffer(uint256)", { offerId: "1", nonce: NONCE }],
+  [
+    "signMetaTxVoidOfferBatch",
+    "voidOfferBatch(uint256[])",
+    { offerIds: ["1", "2"], nonce: NONCE }
+  ],
+  [
+    "signMetaTxExtendOffer",
+    "extendOffer(uint256,uint256)",
+    { offerId: "1", validUntil: VALID_UNTIL, nonce: NONCE }
+  ],
+  [
+    "signMetaTxExtendOfferBatch",
+    "extendOfferBatch(uint256[],uint256)",
+    { offerIds: ["1", "2"], validUntil: VALID_UNTIL, nonce: NONCE }
+  ],
+  [
+    "signMetaTxCompleteExchangeBatch",
+    "completeExchangeBatch(uint256[])",
+    { exchangeIds: ["1", "2"], nonce: NONCE }
+  ]
+] as const)(
+  "MetaTxMixin#%s() overload dispatch",
+  (methodName, expectedFunctionName, args) => {
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (makeCoreSDK() as any)[methodName](args);
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe(expectedFunctionName);
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await (makeCoreSDK() as any)[methodName]({
+        ...args,
+        returnTypedDataToSign: true
+      });
+      assertStructuredDataShape(result, "MetaTransaction");
+    });
+  }
+);
+
+// ─── Tier 2-D: commit methods ─────────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxCommitToConditionalOffer() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCommitToConditionalOffer({
+      offerId: "1",
+      tokenId: "42",
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe(
+      "commitToConditionalOffer(address,uint256,uint256)"
+    );
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCommitToConditionalOffer as any)({
+      offerId: "1",
+      tokenId: "42",
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTxCommitToConditionalOffer");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxCommitToBuyerOffer() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCommitToBuyerOffer({
+      offerId: "1",
+      sellerParams: sellerParamsMock,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("commitToBuyerOffer");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCommitToBuyerOffer as any)({
+      offerId: "1",
+      sellerParams: sellerParamsMock,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxCreateOfferAndCommit() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxCreateOfferAndCommit({
+      createOfferAndCommitArgs: createOfferAndCommitArgsMock,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toContain("createOfferAndCommit");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxCreateOfferAndCommit as any)({
+      createOfferAndCommitArgs: createOfferAndCommitArgsMock,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+// ─── Tier 2-E: exchange / dispute methods (exchangeId-only) ──────────────────
+
+describe.each([
+  ["signMetaTxCancelVoucher", "cancelVoucher(uint256)", "MetaTxExchange"],
+  ["signMetaTxRedeemVoucher", "redeemVoucher(uint256)", "MetaTxExchange"],
+  ["signMetaTxCompleteExchange", "completeExchange(uint256)", "MetaTxExchange"],
+  ["signMetaTxExpireVoucher", "expireVoucher(uint256)", "MetaTransaction"],
+  ["signMetaTxRevokeVoucher", "revokeVoucher(uint256)", "MetaTransaction"],
+  ["signMetaTxRetractDispute", "retractDispute(uint256)", "MetaTxExchange"],
+  ["signMetaTxEscalateDispute", "escalateDispute(uint256)", "MetaTxExchange"],
+  ["signMetaTxRaiseDispute", "raiseDispute(uint256)", "MetaTxExchange"]
+] as const)(
+  "MetaTxMixin#%s() overload dispatch",
+  (methodName, expectedFunctionName, expectedPrimaryType) => {
+    const args = { exchangeId: "1", nonce: NONCE };
+
+    test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (makeCoreSDK() as any)[methodName](args);
+      assertSignedMetaTx(result);
+      expect(result.functionName).toBe(expectedFunctionName);
+    });
+
+    test("returns StructuredData with returnTypedDataToSign: true", async () => {
+      const result = await (makeCoreSDK() as any)[methodName]({
+        ...args,
+        returnTypedDataToSign: true
+      });
+      assertStructuredDataShape(result, expectedPrimaryType);
+    });
+  }
+);
+
+// ─── Tier 2-F: dispute resolution ────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxResolveDispute() overload dispatch", () => {
+  const COUNTERPARTY_SIG =
+    "0xd093bf19f8e5d7526953f63b7721628b95820e94cf42298f97cd4502b61ff392024b4030ee7db3f74690e721289b287583d72ccd8ad297e69c822eb4f1f87c2a1b";
+
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxResolveDispute({
+      exchangeId: "1",
+      buyerPercent: 10,
+      counterpartySig: COUNTERPARTY_SIG,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe("resolveDispute(uint256,uint256,bytes)");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxResolveDispute as any)({
+      exchangeId: "1",
+      buyerPercent: 10,
+      counterpartySig: COUNTERPARTY_SIG,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTxDisputeResolution");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxExtendDisputeTimeout() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxExtendDisputeTimeout({
+      exchangeId: "1",
+      newTimeout: VALID_UNTIL,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe("extendDisputeTimeout(uint256,uint256)");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxExtendDisputeTimeout as any)({
+      exchangeId: "1",
+      newTimeout: VALID_UNTIL,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
+  });
+});
+
+// ─── Tier 2-G: funds ─────────────────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxWithdrawFunds() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxWithdrawFunds({
+      entityId: "1",
+      tokenList: [TOKEN],
+      tokenAmounts: ["1000000000000000000"],
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe(
+      "withdrawFunds(uint256,address[],uint256[])"
+    );
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxWithdrawFunds as any)({
+      entityId: "1",
+      tokenList: [TOKEN],
+      tokenAmounts: ["1000000000000000000"],
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTxFund");
+  });
+});
+
+describe("MetaTxMixin#signMetaTxDepositFunds() overload dispatch", () => {
+  test("returns SignedMetaTx without returnTypedDataToSign", async () => {
+    const result = await makeCoreSDK().signMetaTxDepositFunds({
+      entityId: "1",
+      fundsTokenAddress: TOKEN,
+      fundsAmount: "1000000000000000000",
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe("depositFunds(uint256,address,uint256)");
+  });
+
+  test("returns StructuredData with returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (makeCoreSDK().signMetaTxDepositFunds as any)({
+      entityId: "1",
+      fundsTokenAddress: TOKEN,
+      fundsAmount: "1000000000000000000",
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    assertStructuredDataShape(result, "MetaTransaction");
   });
 });

--- a/packages/core-sdk/tests/meta-tx/mixin.test.ts
+++ b/packages/core-sdk/tests/meta-tx/mixin.test.ts
@@ -1,0 +1,642 @@
+import { AuthTokenType, abis } from "@bosonprotocol/common";
+import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
+import { CoreSDK } from "../../src/core-sdk";
+import * as metaTxHandler from "../../src/meta-tx/handler";
+import { StructuredData } from "../../src/utils/signature";
+import {
+  BICONOMY_URL,
+  SUBGRAPH_URL,
+  ZERO_ADDRESS,
+  interceptSubgraph,
+  mockRawOfferFromSubgraph,
+  mockRawSellerFromSubgraph
+} from "../mocks";
+
+jest.setTimeout(30_000);
+
+// ─── Shared constants ─────────────────────────────────────────────────────────
+
+const CHAIN_ID = 31337; // local chain → takes the isLocal(chainId) path in handler
+const PROTOCOL_DIAMOND = "0x0000000000000000000000000000000000000001";
+const PRICE_DISCOVERY = "0x0000000000000000000000000000000000000002";
+const FORWARDER = "0x0000000000000000000000000000000000000003";
+const SIGNER = "0x0000000000000000000000000000000000000004";
+const VOUCHER_CLONE = "0x0000000000000000000000000000000000000005";
+const ASSISTANT = "0x0000000000000000000000000000000000000006";
+// A real-looking ECDSA signature returned by MockWeb3LibAdapter.send()
+const MOCK_SIG =
+  "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b";
+// ABI-encoded uint256(1) – used as the forwarder getNonce() response
+const ABI_UINT256_ONE =
+  "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+// ─── Factory helpers ──────────────────────────────────────────────────────────
+
+function makeCoreSDK() {
+  return new CoreSDK({
+    web3Lib: new MockWeb3LibAdapter({
+      getSignerAddress: SIGNER,
+      send: MOCK_SIG,
+      call: ABI_UINT256_ONE
+    }),
+    subgraphUrl: SUBGRAPH_URL,
+    protocolDiamond: PROTOCOL_DIAMOND,
+    chainId: CHAIN_ID,
+    metaTx: {
+      relayerUrl: BICONOMY_URL,
+      apiKey: "test-api-key",
+      apiIds: {
+        [PROTOCOL_DIAMOND.toLowerCase()]: {
+          executeMetaTransaction: "test-api-id"
+        }
+      },
+      forwarderAbi: abis.MockForwarderABI
+    },
+    contracts: {
+      protocolDiamond: PROTOCOL_DIAMOND,
+      priceDiscoveryClient: PRICE_DISCOVERY,
+      forwarder: FORWARDER
+    }
+  });
+}
+
+function assertSignedMetaTx(result: unknown) {
+  const r = result as {
+    r: string;
+    s: string;
+    v: number;
+    functionName: string;
+    functionSignature: string;
+  };
+  expect(typeof r.r).toBe("string");
+  expect(typeof r.s).toBe("string");
+  expect(typeof r.v).toBe("number");
+  expect(typeof r.functionName).toBe("string");
+  expect(typeof r.functionSignature).toBe("string");
+}
+
+// ─── 1. signMetaTxCommitToOffer ───────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxCommitToOffer()", () => {
+  const OFFER_ID = "1";
+  const NONCE = 1;
+
+  test("offer without condition → calls direct commitToOffer path", async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: mockRawOfferFromSubgraph() } // condition defaults to undefined
+    });
+    const sdk = makeCoreSDK();
+    const result = await sdk.signMetaTxCommitToOffer({
+      offerId: OFFER_ID,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe("commitToOffer(address,uint256)");
+  });
+
+  test("offer with condition → redirects to commitToConditionalOffer using condition.minTokenId as tokenId", async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: {
+        offer: mockRawOfferFromSubgraph({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          condition: {
+            id: "1-condition",
+            method: 1,
+            tokenType: 1,
+            tokenAddress: ZERO_ADDRESS,
+            gatingType: 0,
+            minTokenId: "42",
+            maxTokenId: "42",
+            threshold: "1",
+            maxCommits: "1"
+          } as any
+        })
+      }
+    });
+    const sdk = makeCoreSDK();
+    const result = await sdk.signMetaTxCommitToOffer({
+      offerId: OFFER_ID,
+      nonce: NONCE
+    });
+    assertSignedMetaTx(result);
+    expect(result.functionName).toBe(
+      "commitToConditionalOffer(address,uint256,uint256)"
+    );
+  });
+
+  test("offer without condition, returnTypedDataToSign: true → returns StructuredData for commitToOffer", async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: mockRawOfferFromSubgraph() }
+    });
+    const sdk = makeCoreSDK();
+    // Cast needed: TypeScript overload resolution struggles with the complex Omit<Parameters<...>> pattern
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (sdk.signMetaTxCommitToOffer as any)({
+      offerId: OFFER_ID,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    const data = result as StructuredData;
+    expect(data.primaryType).toBe("MetaTxCommitToOffer");
+    expect(data.domain.verifyingContract).toBe(PROTOCOL_DIAMOND);
+  });
+
+  test("offer with condition, returnTypedDataToSign: true → returns StructuredData for commitToConditionalOffer", async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: {
+        offer: mockRawOfferFromSubgraph({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          condition: {
+            id: "1-condition",
+            method: 1,
+            tokenType: 1,
+            tokenAddress: ZERO_ADDRESS,
+            gatingType: 0,
+            minTokenId: "7",
+            maxTokenId: "7",
+            threshold: "1",
+            maxCommits: "1"
+          } as any
+        })
+      }
+    });
+    const sdk = makeCoreSDK();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (sdk.signMetaTxCommitToOffer as any)({
+      offerId: OFFER_ID,
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+    const data = result as StructuredData;
+    expect(data.primaryType).toBe("MetaTxCommitToConditionalOffer");
+  });
+});
+
+// ─── 2. signMetaTxReserveRange ────────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxReserveRange()", () => {
+  const OFFER_ID = "1";
+  const NONCE = 1;
+  const LENGTH = "100";
+
+  // Partial seller via `as any` because mockRawOfferFromSubgraph expects the full seller shape
+  // but the spread inside the mock helper merges these overrides correctly at runtime.
+  const offerWithAddresses = mockRawOfferFromSubgraph({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    seller: { assistant: ASSISTANT, voucherCloneAddress: VOUCHER_CLONE } as any
+  });
+
+  test('to: "seller" → passes offer.seller.assistant as the `to` address to the handler', async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: offerWithAddresses }
+    });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxReserveRange")
+      .mockResolvedValueOnce({
+        r: "0x",
+        s: "0x",
+        v: 0,
+        functionName: "reserveRange(uint256,uint256,address)",
+        functionSignature: "0x"
+      });
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxReserveRange({
+      offerId: OFFER_ID,
+      length: LENGTH,
+      to: "seller",
+      nonce: NONCE
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ASSISTANT })
+    );
+    spy.mockRestore();
+  });
+
+  test('to: "contract" → passes offer.seller.voucherCloneAddress as the `to` address to the handler', async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: offerWithAddresses }
+    });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxReserveRange")
+      .mockResolvedValueOnce({
+        r: "0x",
+        s: "0x",
+        v: 0,
+        functionName: "reserveRange(uint256,uint256,address)",
+        functionSignature: "0x"
+      });
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxReserveRange({
+      offerId: OFFER_ID,
+      length: LENGTH,
+      to: "contract",
+      nonce: NONCE
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ to: VOUCHER_CLONE })
+    );
+    spy.mockRestore();
+  });
+
+  test('to: "seller", returnTypedDataToSign: true → passes returnTypedDataToSign: true to the handler', async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: offerWithAddresses }
+    });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxReserveRange")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValueOnce({} as any);
+    const sdk = makeCoreSDK();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sdk.signMetaTxReserveRange as any)({
+      offerId: OFFER_ID,
+      length: LENGTH,
+      to: "seller",
+      nonce: NONCE,
+      returnTypedDataToSign: true
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ASSISTANT, returnTypedDataToSign: true })
+    );
+    spy.mockRestore();
+  });
+});
+
+// ─── 3. signMetaTxUpdateSellerAndOptIn ───────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxUpdateSellerAndOptIn()", () => {
+  const sellerUpdates = {
+    id: "1",
+    assistant: SIGNER,
+    admin: SIGNER,
+    treasury: SIGNER,
+    authTokenId: "0",
+    authTokenType: AuthTokenType.NONE,
+    metadataUri: "ipfs://seller-metadata"
+  };
+
+  // Mock TransactionResponse objects returned by relayMetaTransaction
+  const mockUpdateTx = {
+    hash: "0xupdate",
+    wait: jest.fn().mockResolvedValue({ transactionHash: "0xupdate" })
+  };
+  const mockOptInTx = {
+    hash: "0xopt-in",
+    wait: jest.fn().mockResolvedValue({ transactionHash: "0xopt-in" })
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * Spy on the SDK instance methods that hit Biconomy / the handler,
+   * so tests focus on the orchestration logic rather than HTTP plumbing.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function spyOnRelayAndSign(sdk: any) {
+    let relayCount = 0;
+    jest
+      .spyOn(sdk, "relayMetaTransaction")
+      .mockImplementation(async () => (relayCount++ === 0 ? mockUpdateTx : mockOptInTx));
+
+    jest.spyOn(sdk, "signMetaTxUpdateSeller").mockResolvedValue({
+      functionName: "updateSeller((uint256,address,address,address,address,uint256,uint8))",
+      functionSignature: "0xabcd",
+      r: "0x",
+      s: "0x",
+      v: 27
+    });
+
+    jest.spyOn(sdk, "signMetaTxOptInToSellerUpdate").mockResolvedValue({
+      functionName: "optInToSellerUpdate(uint256,(bool,bool,bool))",
+      functionSignature: "0xdead",
+      r: "0x",
+      s: "0x",
+      v: 27
+    });
+  }
+
+  test("throws when seller cannot be retrieved after polling exhausts", async () => {
+    const sdk = makeCoreSDK();
+    spyOnRelayAndSign(sdk);
+    // getSellerById always returns null → while loop exhausts count
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(sdk as any, "getSellerById").mockResolvedValue(null);
+
+    jest.useFakeTimers();
+    const promise = sdk.signMetaTxUpdateSellerAndOptIn(sellerUpdates);
+    // Attach the rejection handler BEFORE advancing timers to prevent unhandledRejection
+    const check = expect(promise).rejects.toThrow(
+      "[signMetaTxUpdateSellerAndOptIn] seller could not be retrieved in time"
+    );
+    // Fire all 200 setTimeout(resolve, 300) calls in the polling loop
+    await jest.runAllTimersAsync();
+    await check;
+  });
+
+  test("throws when seller.pendingSeller is null after polling exhausts", async () => {
+    const sdk = makeCoreSDK();
+    spyOnRelayAndSign(sdk);
+    // Seller exists but pendingSeller is always null → loop exhausts count
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest
+      .spyOn(sdk as any, "getSellerById")
+      .mockResolvedValue(mockRawSellerFromSubgraph({ pendingSeller: null }));
+
+    jest.useFakeTimers();
+    const promise = sdk.signMetaTxUpdateSellerAndOptIn(sellerUpdates);
+    // Attach rejection handler before advancing timers
+    const check = expect(promise).rejects.toThrow(
+      "[signMetaTxUpdateSellerAndOptIn] seller.pendingSeller could not be retrieved in time"
+    );
+    await jest.runAllTimersAsync();
+    await check;
+  });
+
+  test("when currentAccount matches pendingSeller.assistant → relays opt-in tx and returns it", async () => {
+    const sdk = makeCoreSDK();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sdkAny = sdk as any;
+    spyOnRelayAndSign(sdkAny);
+    // First poll: seller found with pendingSeller.assistant === SIGNER → exits while loop
+    jest
+      .spyOn(sdkAny, "getSellerById")
+      .mockResolvedValue(
+        mockRawSellerFromSubgraph({
+          pendingSeller: {
+            assistant: SIGNER,
+            admin: "0x000000000000000000000000000000000000dead",
+            clerk: null,
+            authTokenId: "0",
+            authTokenType: AuthTokenType.NONE
+          }
+        })
+      );
+
+    const tx = await sdk.signMetaTxUpdateSellerAndOptIn(sellerUpdates);
+
+    expect(tx).toBeDefined();
+    expect(typeof tx.wait).toBe("function");
+    // opt-in relay was called: relayMetaTransaction invoked twice (updateSeller + optIn)
+    expect(sdkAny.relayMetaTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  test("when no pendingSeller fields match current account → returns updateSeller tx directly", async () => {
+    const sdk = makeCoreSDK();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sdkAny = sdk as any;
+    spyOnRelayAndSign(sdkAny);
+    // pendingSeller has neither assistant/admin matching SIGNER, authTokenType is NONE
+    jest
+      .spyOn(sdkAny, "getSellerById")
+      .mockResolvedValue(
+        mockRawSellerFromSubgraph({
+          pendingSeller: {
+            assistant: "0x000000000000000000000000000000000000dead",
+            admin: "0x000000000000000000000000000000000000dead",
+            clerk: null,
+            authTokenId: "0",
+            authTokenType: AuthTokenType.NONE
+          }
+        })
+      );
+
+    const tx = await sdk.signMetaTxUpdateSellerAndOptIn(sellerUpdates);
+
+    expect(tx).toBeDefined();
+    expect(typeof tx.wait).toBe("function");
+    // No opt-in: relayMetaTransaction was called only once (update only)
+    expect(sdkAny.relayMetaTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── 4. signMetaTxPreMint ─────────────────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxPreMint()", () => {
+  const offerWithVoucher = mockRawOfferFromSubgraph({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    seller: { voucherCloneAddress: VOUCHER_CLONE } as any
+  });
+
+  const mockVoucherMetaTxResult = {
+    to: VOUCHER_CLONE,
+    functionSignature: "0x",
+    signature: "0x",
+    request: { from: SIGNER, to: VOUCHER_CLONE, nonce: "0", data: "0x" },
+    r: "0x",
+    s: "0x",
+    v: 0
+  };
+
+  test("resolves bosonVoucherAddress from offer.seller.voucherCloneAddress", async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: offerWithVoucher }
+    });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxPreMint")
+      .mockResolvedValueOnce(mockVoucherMetaTxResult);
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxPreMint({ offerId: "1", amount: "5" });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bosonVoucherAddress: VOUCHER_CLONE,
+        forwarderAddress: FORWARDER
+      })
+    );
+    spy.mockRestore();
+  });
+
+  test("defaults batchId to 0 when no override is provided", async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: offerWithVoucher }
+    });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxPreMint")
+      .mockResolvedValueOnce(mockVoucherMetaTxResult);
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxPreMint({ offerId: "1", amount: "5" });
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ batchId: 0 }));
+    spy.mockRestore();
+  });
+
+  test("uses batchId override when provided", async () => {
+    interceptSubgraph("getOfferByIdQuery").reply(200, {
+      data: { offer: offerWithVoucher }
+    });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxPreMint")
+      .mockResolvedValueOnce(mockVoucherMetaTxResult);
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxPreMint({ offerId: "1", amount: "5" }, { batchId: 7 });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ batchId: 7 })
+    );
+    spy.mockRestore();
+  });
+});
+
+// ─── 5. signMetaTxSetApprovalForAll ──────────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxSetApprovalForAll()", () => {
+  const sellerFromSubgraph = mockRawSellerFromSubgraph({
+    assistant: SIGNER,
+    voucherCloneAddress: VOUCHER_CLONE
+  });
+
+  const mockVoucherMetaTxResult = {
+    to: VOUCHER_CLONE,
+    functionSignature: "0x",
+    signature: "0x",
+    request: { from: SIGNER, to: VOUCHER_CLONE, nonce: "0", data: "0x" },
+    r: "0x",
+    s: "0x",
+    v: 0
+  };
+
+  test("resolves bosonVoucherAddress via subgraph getSellerByAddress", async () => {
+    // getSellerByAddress makes two parallel getSellersQuery calls (assistant + admin lookup)
+    interceptSubgraph("getSellersQuery")
+      .times(2)
+      .reply(200, { data: { sellers: [sellerFromSubgraph] } });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxSetApprovalForAll")
+      .mockResolvedValueOnce(mockVoucherMetaTxResult);
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxSetApprovalForAll({
+      operator: ZERO_ADDRESS,
+      approved: true
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bosonVoucherAddress: VOUCHER_CLONE,
+        forwarderAddress: FORWARDER
+      })
+    );
+    spy.mockRestore();
+  });
+});
+
+// ─── 6. signMetaTxSetApprovalForAllToContract ─────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxSetApprovalForAllToContract()", () => {
+  const sellerFromSubgraph = mockRawSellerFromSubgraph({
+    assistant: SIGNER,
+    voucherCloneAddress: VOUCHER_CLONE
+  });
+
+  const mockVoucherMetaTxResult = {
+    to: VOUCHER_CLONE,
+    functionSignature: "0x",
+    signature: "0x",
+    request: { from: SIGNER, to: VOUCHER_CLONE, nonce: "0", data: "0x" },
+    r: "0x",
+    s: "0x",
+    v: 0
+  };
+
+  // The mixin always fetches seller from subgraph, even when args.bosonVoucherAddress is provided
+  function interceptSellersQuery() {
+    interceptSubgraph("getSellersQuery")
+      .times(2)
+      .reply(200, { data: { sellers: [sellerFromSubgraph] } });
+  }
+
+  test("without explicit bosonVoucherAddress → uses seller.voucherCloneAddress from subgraph", async () => {
+    interceptSellersQuery();
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxSetApprovalForAllToContract")
+      .mockResolvedValueOnce(mockVoucherMetaTxResult);
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxSetApprovalForAllToContract({
+      operator: ZERO_ADDRESS,
+      approved: true
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ bosonVoucherAddress: VOUCHER_CLONE }),
+      expect.anything()
+    );
+    spy.mockRestore();
+  });
+
+  test("with explicit bosonVoucherAddress → uses the provided address, not the subgraph value", async () => {
+    const EXPLICIT_VOUCHER = "0x0000000000000000000000000000000000000099";
+    interceptSellersQuery();
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxSetApprovalForAllToContract")
+      .mockResolvedValueOnce({ ...mockVoucherMetaTxResult, to: EXPLICIT_VOUCHER });
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxSetApprovalForAllToContract({
+      operator: ZERO_ADDRESS,
+      approved: true,
+      bosonVoucherAddress: EXPLICIT_VOUCHER
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ bosonVoucherAddress: EXPLICIT_VOUCHER }),
+      expect.anything()
+    );
+    spy.mockRestore();
+  });
+});
+
+// ─── 7. signMetaTxCallExternalContract ───────────────────────────────────────
+
+describe("MetaTxMixin#signMetaTxCallExternalContract()", () => {
+  const sellerFromSubgraph = mockRawSellerFromSubgraph({
+    assistant: SIGNER,
+    voucherCloneAddress: VOUCHER_CLONE
+  });
+
+  const mockVoucherMetaTxResult = {
+    to: VOUCHER_CLONE,
+    functionSignature: "0x",
+    signature: "0x",
+    request: { from: SIGNER, to: VOUCHER_CLONE, nonce: "0", data: "0x" },
+    r: "0x",
+    s: "0x",
+    v: 0
+  };
+
+  test("resolves bosonVoucherAddress via subgraph getSellerByAddress", async () => {
+    interceptSubgraph("getSellersQuery")
+      .times(2)
+      .reply(200, { data: { sellers: [sellerFromSubgraph] } });
+    const spy = jest
+      .spyOn(metaTxHandler, "signMetaTxCallExternalContract")
+      .mockResolvedValueOnce(mockVoucherMetaTxResult);
+    const sdk = makeCoreSDK();
+
+    await sdk.signMetaTxCallExternalContract({
+      to: ZERO_ADDRESS,
+      data: "0x1234"
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bosonVoucherAddress: VOUCHER_CLONE,
+        forwarderAddress: FORWARDER
+      }),
+      expect.anything()
+    );
+    spy.mockRestore();
+  });
+});

--- a/packages/core-sdk/tests/native-meta-tx/handler.test.ts
+++ b/packages/core-sdk/tests/native-meta-tx/handler.test.ts
@@ -1,0 +1,109 @@
+import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
+import * as erc20Handler from "../../src/erc20/handler";
+import { signNativeMetaTxApproveExchangeToken } from "../../src/native-meta-tx/handler";
+import { StructuredData } from "../../src/utils/signature";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHAIN_ID = 137; // Polygon mainnet – representative for native meta-tx
+const EXCHANGE_TOKEN = "0x0000000000000000000000000000000000000010";
+const SPENDER = "0x0000000000000000000000000000000000000011";
+const USER = "0x0000000000000000000000000000000000000012";
+const VALUE = "1000000000000000000";
+// Real-looking ECDSA signature from MockWeb3LibAdapter.send()
+const MOCK_SIG =
+  "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b";
+const EXPECTED_R =
+  "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd";
+const EXPECTED_S =
+  "0x72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a";
+const EXPECTED_V = 27;
+// ABI-encoded uint256(1) – returned as nonce by MockWeb3LibAdapter.call()
+const ABI_UINT256_ONE =
+  "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeWeb3Lib() {
+  return new MockWeb3LibAdapter({
+    getSignerAddress: USER,
+    send: MOCK_SIG,
+    call: ABI_UINT256_ONE
+  });
+}
+
+function baseArgs() {
+  return {
+    web3Lib: makeWeb3Lib(),
+    chainId: CHAIN_ID,
+    user: USER,
+    exchangeToken: EXCHANGE_TOKEN,
+    spender: SPENDER,
+    value: VALUE
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("signNativeMetaTxApproveExchangeToken()", () => {
+  beforeEach(() => {
+    // Avoid real ERC20 contract call for token name
+    jest.spyOn(erc20Handler, "getName").mockResolvedValue("TestToken");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("returns SignedMetaTx when returnTypedDataToSign is omitted", async () => {
+    const result = await signNativeMetaTxApproveExchangeToken(baseArgs());
+    expect(result.functionName).toBe("approve(address,uint256)");
+    expect(result.r).toBe(EXPECTED_R);
+    expect(result.s).toBe(EXPECTED_S);
+    expect(result.v).toBe(EXPECTED_V);
+    expect(typeof result.functionSignature).toBe("string");
+    expect(result.functionSignature.startsWith("0x")).toBe(true);
+  });
+
+  test("returns SignedMetaTx when returnTypedDataToSign: false", async () => {
+    const result = await signNativeMetaTxApproveExchangeToken({
+      ...baseArgs(),
+      returnTypedDataToSign: false
+    });
+    expect(result.functionName).toBe("approve(address,uint256)");
+    expect(result.r).toBe(EXPECTED_R);
+  });
+
+  test("returns StructuredData when returnTypedDataToSign: true", async () => {
+    const result = await signNativeMetaTxApproveExchangeToken({
+      ...baseArgs(),
+      returnTypedDataToSign: true
+    });
+    const data = result as StructuredData;
+    expect(data.primaryType).toBe("MetaTransaction");
+    // verifyingContract is the exchange token (the native meta-tx contract)
+    expect(data.domain.verifyingContract).toBe(EXCHANGE_TOKEN);
+    expect(data.domain.name).toBe("TestToken");
+    expect(Array.isArray(data.types.EIP712Domain)).toBe(true);
+    expect(typeof data.message).toBe("object");
+    expect(data.message.from).toBe(USER);
+    // Must NOT look like a SignedMetaTx
+    expect((data as unknown as { r?: unknown }).r).toBeUndefined();
+  });
+
+  test("uses the token name returned by getERC20Name as domain.name", async () => {
+    (erc20Handler.getName as jest.Mock).mockResolvedValue("USD Coin");
+    const result = await signNativeMetaTxApproveExchangeToken({
+      ...baseArgs(),
+      returnTypedDataToSign: true
+    });
+    expect((result as StructuredData).domain.name).toBe("USD Coin");
+  });
+
+  test("encodes the correct spender and value in functionSignature", async () => {
+    const result = await signNativeMetaTxApproveExchangeToken(baseArgs());
+    // functionSignature should be the ABI encoding of approve(spender, value)
+    // Selector for approve(address,uint256) is 0x095ea7b3
+    expect(result.functionSignature.startsWith("0x095ea7b3")).toBe(true);
+  });
+});

--- a/packages/core-sdk/tests/native-meta-tx/handler.test.ts
+++ b/packages/core-sdk/tests/native-meta-tx/handler.test.ts
@@ -1,7 +1,7 @@
 import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
 import * as erc20Handler from "../../src/erc20/handler";
 import { signNativeMetaTxApproveExchangeToken } from "../../src/native-meta-tx/handler";
-import { StructuredData } from "../../src/utils/signature";
+import { UnsignedMetaTx } from "../../src/meta-tx/handler";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -79,7 +79,7 @@ describe("signNativeMetaTxApproveExchangeToken()", () => {
       ...baseArgs(),
       returnTypedDataToSign: true
     });
-    const data = result as StructuredData;
+    const data = result as UnsignedMetaTx;
     expect(data.primaryType).toBe("MetaTransaction");
     // verifyingContract is the exchange token (the native meta-tx contract)
     expect(data.domain.verifyingContract).toBe(EXCHANGE_TOKEN);
@@ -89,6 +89,9 @@ describe("signNativeMetaTxApproveExchangeToken()", () => {
     expect(data.message.from).toBe(USER);
     // Must NOT look like a SignedMetaTx
     expect((data as unknown as { r?: unknown }).r).toBeUndefined();
+    // Confirm UnsignedMetaTx fields are present
+    expect(data.functionName).toBe("approve(address,uint256)");
+    expect(typeof data.functionSignature).toBe("string");
   });
 
   test("uses the token name returned by getERC20Name as domain.name", async () => {
@@ -97,7 +100,7 @@ describe("signNativeMetaTxApproveExchangeToken()", () => {
       ...baseArgs(),
       returnTypedDataToSign: true
     });
-    expect((result as StructuredData).domain.name).toBe("USD Coin");
+    expect((result as UnsignedMetaTx).domain.name).toBe("USD Coin");
   });
 
   test("encodes the correct spender and value in functionSignature", async () => {

--- a/packages/core-sdk/tests/native-meta-tx/mixin.test.ts
+++ b/packages/core-sdk/tests/native-meta-tx/mixin.test.ts
@@ -3,7 +3,7 @@ import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
 import * as erc20Handler from "../../src/erc20/handler";
 import * as nativeMetaTxHandler from "../../src/native-meta-tx/handler";
 import { CoreSDK } from "../../src/core-sdk";
-import { StructuredData } from "../../src/utils/signature";
+import { UnsignedMetaTx } from "../../src/meta-tx/handler";
 import { BICONOMY_URL, SUBGRAPH_URL } from "../mocks";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -89,12 +89,15 @@ describe("NativeMetaTxMixin#signNativeMetaTxApproveExchangeToken()", () => {
     const result = await (
       makeCoreSDK().signNativeMetaTxApproveExchangeToken as any
     )(EXCHANGE_TOKEN, VALUE, { returnTypedDataToSign: true });
-    const data = result as StructuredData;
+    const data = result as UnsignedMetaTx;
     expect(data.primaryType).toBe("MetaTransaction");
     expect(data.domain.verifyingContract).toBe(EXCHANGE_TOKEN);
     expect(data.domain.name).toBe("TestToken");
     expect(typeof data.message).toBe("object");
     expect((data as unknown as { r?: unknown }).r).toBeUndefined();
+    // Confirm UnsignedMetaTx fields are present
+    expect(data.functionName).toBe("approve(address,uint256)");
+    expect(typeof data.functionSignature).toBe("string");
   });
 
   // ── argument injection ─────────────────────────────────────────────────────

--- a/packages/core-sdk/tests/native-meta-tx/mixin.test.ts
+++ b/packages/core-sdk/tests/native-meta-tx/mixin.test.ts
@@ -1,0 +1,166 @@
+import { abis } from "@bosonprotocol/common";
+import { MockWeb3LibAdapter } from "@bosonprotocol/common/tests/mocks";
+import * as erc20Handler from "../../src/erc20/handler";
+import * as nativeMetaTxHandler from "../../src/native-meta-tx/handler";
+import { CoreSDK } from "../../src/core-sdk";
+import { StructuredData } from "../../src/utils/signature";
+import { BICONOMY_URL, SUBGRAPH_URL } from "../mocks";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHAIN_ID = 31337;
+const PROTOCOL_DIAMOND = "0x0000000000000000000000000000000000000001";
+const PRICE_DISCOVERY = "0x0000000000000000000000000000000000000002";
+const FORWARDER = "0x0000000000000000000000000000000000000003";
+const SIGNER = "0x0000000000000000000000000000000000000004";
+const EXCHANGE_TOKEN = "0x0000000000000000000000000000000000000010";
+const CUSTOM_SPENDER = "0x0000000000000000000000000000000000000011";
+const VALUE = "1000000000000000000";
+const MOCK_SIG =
+  "0x020d671b80fbd20466d8cb65cef79a24e3bca3fdf82e9dd89d78e7a4c4c045bd72944c20bb1d839e76ee6bb69fed61f64376c37799598b40b8c49148f3cdd88a1b";
+const ABI_UINT256_ONE =
+  "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+function makeCoreSDK() {
+  return new CoreSDK({
+    web3Lib: new MockWeb3LibAdapter({
+      getSignerAddress: SIGNER,
+      send: MOCK_SIG,
+      call: ABI_UINT256_ONE
+    }),
+    subgraphUrl: SUBGRAPH_URL,
+    protocolDiamond: PROTOCOL_DIAMOND,
+    chainId: CHAIN_ID,
+    metaTx: {
+      relayerUrl: BICONOMY_URL,
+      apiKey: "test-api-key",
+      apiIds: {
+        [PROTOCOL_DIAMOND.toLowerCase()]: {
+          executeMetaTransaction: "test-api-id"
+        }
+      },
+      forwarderAbi: abis.MockForwarderABI
+    },
+    contracts: {
+      protocolDiamond: PROTOCOL_DIAMOND,
+      priceDiscoveryClient: PRICE_DISCOVERY,
+      forwarder: FORWARDER
+    }
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("NativeMetaTxMixin#signNativeMetaTxApproveExchangeToken()", () => {
+  beforeEach(() => {
+    jest.spyOn(erc20Handler, "getName").mockResolvedValue("TestToken");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ── overload dispatch ──────────────────────────────────────────────────────
+
+  test("returns SignedMetaTx when overrides is omitted", async () => {
+    const result = await makeCoreSDK().signNativeMetaTxApproveExchangeToken(
+      EXCHANGE_TOKEN,
+      VALUE
+    );
+    expect(result.functionName).toBe("approve(address,uint256)");
+    expect(typeof result.r).toBe("string");
+    expect(typeof result.s).toBe("string");
+    expect(typeof result.v).toBe("number");
+  });
+
+  test("returns SignedMetaTx when returnTypedDataToSign: false", async () => {
+    const result = await makeCoreSDK().signNativeMetaTxApproveExchangeToken(
+      EXCHANGE_TOKEN,
+      VALUE,
+      { returnTypedDataToSign: false }
+    );
+    expect(result.functionName).toBe("approve(address,uint256)");
+  });
+
+  test("returns StructuredData when returnTypedDataToSign: true", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (
+      makeCoreSDK().signNativeMetaTxApproveExchangeToken as any
+    )(EXCHANGE_TOKEN, VALUE, { returnTypedDataToSign: true });
+    const data = result as StructuredData;
+    expect(data.primaryType).toBe("MetaTransaction");
+    expect(data.domain.verifyingContract).toBe(EXCHANGE_TOKEN);
+    expect(data.domain.name).toBe("TestToken");
+    expect(typeof data.message).toBe("object");
+    expect((data as unknown as { r?: unknown }).r).toBeUndefined();
+  });
+
+  // ── argument injection ─────────────────────────────────────────────────────
+
+  test("defaults spender to protocolDiamond when not provided", async () => {
+    const spy = jest
+      .spyOn(nativeMetaTxHandler, "signNativeMetaTxApproveExchangeToken")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValueOnce({} as any);
+
+    await makeCoreSDK().signNativeMetaTxApproveExchangeToken(
+      EXCHANGE_TOKEN,
+      VALUE
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ spender: PROTOCOL_DIAMOND })
+    );
+  });
+
+  test("uses the provided spender override", async () => {
+    const spy = jest
+      .spyOn(nativeMetaTxHandler, "signNativeMetaTxApproveExchangeToken")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValueOnce({} as any);
+
+    await makeCoreSDK().signNativeMetaTxApproveExchangeToken(
+      EXCHANGE_TOKEN,
+      VALUE,
+      { spender: CUSTOM_SPENDER }
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ spender: CUSTOM_SPENDER })
+    );
+  });
+
+  test("injects the signer address as user", async () => {
+    const spy = jest
+      .spyOn(nativeMetaTxHandler, "signNativeMetaTxApproveExchangeToken")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValueOnce({} as any);
+
+    await makeCoreSDK().signNativeMetaTxApproveExchangeToken(
+      EXCHANGE_TOKEN,
+      VALUE
+    );
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ user: SIGNER }));
+  });
+
+  test("passes returnTypedDataToSign: true through to the handler", async () => {
+    const spy = jest
+      .spyOn(nativeMetaTxHandler, "signNativeMetaTxApproveExchangeToken")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValueOnce({} as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (makeCoreSDK().signNativeMetaTxApproveExchangeToken as any)(
+      EXCHANGE_TOKEN,
+      VALUE,
+      { returnTypedDataToSign: true }
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ returnTypedDataToSign: true })
+    );
+  });
+});


### PR DESCRIPTION
Adds support and test coverage for returning EIP-712 typed data (StructuredData) from core meta-tx signing helpers, alongside existing SignedMetaTx outputs, improving SDK ergonomics for clients that want to sign externally.

**Changes:**
- Expanded `packages/core-sdk/tests/meta-tx/handler.test.ts` with broad coverage across many `signMetaTx*` helpers, including assertions for both SignedMetaTx and StructuredData modes.
- Added `returnTypedDataToSign` overloads throughout `packages/core-sdk/src/meta-tx/handler.ts` to return `StructuredData` when requested.
- Added corresponding overloads and branching logic in `packages/core-sdk/src/meta-tx/mixin.ts` to expose the same behavior via the SDK mixin API.