### PR TITLE
feat: upgrade protocol 2.5.1 rc.1 no new features

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -134,7 +134,7 @@ module.exports = {
               yul: true
             }
           },
-          evmVersion: "shanghai" // for ethereum mainnet, use shanghai, for polygon, use london
+          evmVersion: "cancun"
         },
       },
       {
@@ -178,7 +178,8 @@ module.exports = {
     hardhat: {
       allowUnlimitedContractSize: true,
       chainId: 31337,
-      blockGasLimit: 16000000,
+      blockGasLimit: 16_000_000,
+      hardfork: "cancun",
       accounts: ACCOUNTS.map(({ privateKey }) => ({
         privateKey,
         balance: "1000000000000000000000000000"

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -178,6 +178,7 @@ module.exports = {
     hardhat: {
       allowUnlimitedContractSize: true,
       chainId: 31337,
+      blockGasLimit: 16000000,
       accounts: ACCOUNTS.map(({ privateKey }) => ({
         privateKey,
         balance: "1000000000000000000000000000"

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -138,17 +138,17 @@ module.exports = {
         },
       },
       {
-        version: "0.8.22",
+        version: "0.8.35",
         settings: {
           viaIR: false,
           optimizer: {
             enabled: true,
-            runs: 100,
+            runs: 50,
             details: {
               yul: true
             }
           },
-          evmVersion: "shanghai" // for ethereum mainnet, use shanghai, for polygon, use london
+          evmVersion: "cancun"
         }
       },
       {

--- a/contracts/other-contracts/mock/MockBosonSellerHandler.sol
+++ b/contracts/other-contracts/mock/MockBosonSellerHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.22;
+pragma solidity 0.8.35;
 
 import { BosonTypes } from "../../protocol-contracts/contracts/domain/BosonTypes.sol";
 

--- a/contracts/other-contracts/mock/MockBosonVoucher.sol
+++ b/contracts/other-contracts/mock/MockBosonVoucher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.22;
+pragma solidity 0.8.35;
 
 contract MockBosonVoucher {
   uint256 private sellerId;

--- a/contracts/other-contracts/opensea-wrapper/OpenSeaWrapper.sol
+++ b/contracts/other-contracts/opensea-wrapper/OpenSeaWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.22;
+pragma solidity 0.8.35;
 import { IBosonExchangeHandler } from "../../protocol-contracts/contracts/interfaces/handlers/IBosonExchangeHandler.sol";
 import { IBosonOfferHandler } from "../../protocol-contracts/contracts/interfaces/handlers/IBosonOfferHandler.sol";
 import { DAIAliases as DAI } from "../../protocol-contracts/contracts/interfaces/DAIAliases.sol";

--- a/contracts/other-contracts/opensea-wrapper/OpenSeaWrapperFactory.sol
+++ b/contracts/other-contracts/opensea-wrapper/OpenSeaWrapperFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.22;
+pragma solidity 0.8.35;
 
 import { OpenSeaWrapper } from './OpenSeaWrapper.sol';
 import { BosonTypes } from "../../protocol-contracts/contracts/domain/BosonTypes.sol";

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -11,7 +11,7 @@
         "@openzeppelin/contracts-upgradeable": "4.9.6"
       },
       "devDependencies": {
-        "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#6a14c31bead936ed03b2d51ab82010ecd1047f40",
+        "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#858661679cc8ba2be97eedf3cbc3acd0f5c1903e",
         "@manifoldxyz/royalty-registry-solidity": "github:manifoldxyz/royalty-registry-solidity#e5369fc79279ce2e4c6ea2eb5914df51e89e8bd8",
         "@nomicfoundation/hardhat-ethers": "^3.0.9",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.13",
@@ -19,10 +19,10 @@
         "chai": "^4.3.6",
         "dotenv": "^16.0.1",
         "ethereum-waffle": "^3.4.4",
-        "ethers": "^6.15.0",
+        "ethers": "^6.16.0",
         "ethersv5": "npm:ethers@^5.7.2",
         "glob": "^9.1.0",
-        "hardhat": "^2.25.0",
+        "hardhat": "^2.28.6",
         "hardhat-abi-exporter": "^2.9.0",
         "patch-package": "^8.0.0",
         "seaport": "github:ProjectOpenSea/seaport#e9c5a9f17cb5ee658ccc9cb1a8eeab02c1f5a4cd"
@@ -36,9 +36,9 @@
       "license": "MIT"
     },
     "node_modules/@bosonprotocol/boson-protocol-contracts": {
-      "version": "2.4.2",
-      "resolved": "git+ssh://git@github.com/bosonprotocol/boson-protocol-contracts.git#6a14c31bead936ed03b2d51ab82010ecd1047f40",
-      "integrity": "sha512-iFITQfvZWTa5SfqXciRAk/cqZXxwafXyEJ94IzCneujQl7R/8O5aKAVOtoO9Sdfpz8zEO7J6GGuClbJmBTVm8w==",
+      "version": "2.5.0",
+      "resolved": "git+ssh://git@github.com/bosonprotocol/boson-protocol-contracts.git#858661679cc8ba2be97eedf3cbc3acd0f5c1903e",
+      "integrity": "sha512-CyPEIyh7a7J48mX07wMOALFamvyqySOkPrBbcIyJ/Ipz4G6fV2ZLYFt/9noMjApPTgurKkMZVtVkJtAWVEwRmg==",
       "dev": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -874,6 +874,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@ethereum-waffle/provider/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/@ethereum-waffle/provider/node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -888,9 +901,9 @@
       }
     },
     "node_modules/@ethereum-waffle/provider/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1847,14 +1860,14 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -2045,98 +2058,98 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.11.3.tgz",
-      "integrity": "sha512-kqILRkAd455Sd6v8mfP3C1/0tCOynJWY+Ir+k/9Boocu2kObCrsFgG+ZWB7fSBVdd9cPVSNrnhWS+V+PEo637g==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.23.tgz",
+      "integrity": "sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.11.3",
-        "@nomicfoundation/edr-darwin-x64": "0.11.3",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.11.3",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.11.3",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.11.3",
-        "@nomicfoundation/edr-linux-x64-musl": "0.11.3",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.11.3"
+        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.23",
+        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.23",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.23"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.11.3.tgz",
-      "integrity": "sha512-w0tksbdtSxz9nuzHKsfx4c2mwaD0+l5qKL2R290QdnN9gi9AV62p9DHkOgfBdyg6/a6ZlnQqnISi7C9avk/6VA==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.23.tgz",
+      "integrity": "sha512-Amh7mRoDzZyJJ4efqoePqdoZOzharmSOttZuJDlVE5yy07BoE8hL6ZRpa5fNYn0LCqn/KoWs8OHANWxhKDGhvQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.11.3.tgz",
-      "integrity": "sha512-QR4jAFrPbOcrO7O2z2ESg+eUeIZPe2bPIlQYgiJ04ltbSGW27FblOzdd5+S3RoOD/dsZGKAvvy6dadBEl0NgoA==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.23.tgz",
+      "integrity": "sha512-9wn489FIQm7m0UCD+HhktjWx6vskZzeZD9oDc2k9ZvbBzdXwPp5tiDqUBJ+eQpByAzCDfteAJwRn2lQCE0U+Iw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.11.3.tgz",
-      "integrity": "sha512-Ktjv89RZZiUmOFPspuSBVJ61mBZQ2+HuLmV67InNlh9TSUec/iDjGIwAn59dx0bF/LOSrM7qg5od3KKac4LJDQ==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.23.tgz",
+      "integrity": "sha512-nlk5EejSzEUfEngv0Jkhqq3/wINIfF2ED9wAofc22w/V1DV99ASh9l3/e/MIHOQFecIZ9MDqt0Em9/oDyB1Uew==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.11.3.tgz",
-      "integrity": "sha512-B3sLJx1rL2E9pfdD4mApiwOZSrX0a/KQSBWdlq1uAhFKqkl00yZaY4LejgZndsJAa4iKGQJlGnw4HCGeVt0+jA==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.23.tgz",
+      "integrity": "sha512-SJuPBp3Rc6vM92UtVTUxZQ/QlLhLfwTftt2XUiYohmGKB3RjGzpgduEFMCA0LEnucUckU6UHrJNFHiDm77C4PQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.11.3.tgz",
-      "integrity": "sha512-D/4cFKDXH6UYyKPu6J3Y8TzW11UzeQI0+wS9QcJzjlrrfKj0ENW7g9VihD1O2FvXkdkTjcCZYb6ai8MMTCsaVw==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.23.tgz",
+      "integrity": "sha512-NU+Qs3u7Qt6t3bJFdmmjd5CsvgI2bPPzO31KifM2Ez96/jsXYho5debtTQnimlb5NAqiHTSlxjh/F8ROcptmeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.11.3.tgz",
-      "integrity": "sha512-ergXuIb4nIvmf+TqyiDX5tsE49311DrBky6+jNLgsGDTBaN1GS3OFwFS8I6Ri/GGn6xOaT8sKu3q7/m+WdlFzg==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.23.tgz",
+      "integrity": "sha512-F78fZA2h6/ssiCSZOovlgIu0dUeI7ItKPsDDF3UUlIibef052GCXmliMinC90jVPbrjUADMd1BUwjfI0Z8OllQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.11.3.tgz",
-      "integrity": "sha512-snvEf+WB3OV0wj2A7kQ+ZQqBquMcrozSLXcdnMdEl7Tmn+KDCbmFKBt3Tk0X3qOU4RKQpLPnTxdM07TJNVtung==",
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.23.tgz",
+      "integrity": "sha512-IfJZQJn7d/YyqhmguBIGoCKjE9dKjbu6V6iNEPApfwf5JyyjHYyyfkLU4rf7hygj57bfH4sl1jtQ6r8HnT62lw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/hardhat-chai-matchers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.1.0.tgz",
-      "integrity": "sha512-GPhBNafh1fCnVD9Y7BYvoLnblnvfcq3j8YDbO1gGe/1nOFWzGmV7gFu5DkwFXF+IpYsS+t96o9qc/mPu3V3Vfw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.1.2.tgz",
+      "integrity": "sha512-NlUlde/ycXw2bLzA2gWjjbxQaD9xIRbAF30nsoEprAWzH8dXEI1ILZUKZMyux9n9iygEXTzN0SDVjE6zWDZi9g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2154,9 +2167,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ethers": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.1.0.tgz",
-      "integrity": "sha512-jx6fw3Ms7QBwFGT2MU6ICG292z0P81u6g54JjSV105+FbTZOF4FJqPksLfDybxkkOeq28eDxbqq7vpxRYyIlxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.1.3.tgz",
+      "integrity": "sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2165,19 +2178,19 @@
       },
       "peerDependencies": {
         "ethers": "^6.14.0",
-        "hardhat": "^2.26.0"
+        "hardhat": "^2.28.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition": {
-      "version": "0.15.13",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.13.tgz",
-      "integrity": "sha512-G4XGPWvxs9DJhZ6PE1wdvKjHkjErWbsETf4c7YxO6GUz+MJGlw+PtgbnCwhL3tQzSq3oD4MB0LGi+sK0polpUA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.16.tgz",
+      "integrity": "sha512-T0JTnuib7QcpsWkHCPLT7Z6F483EjTdcdjb1e00jqS9zTGCPqinPB66LLtR/duDLdvgoiCVS6K8WxTQkA/xR1Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ignition-core": "^0.15.13",
-        "@nomicfoundation/ignition-ui": "^0.15.12",
+        "@nomicfoundation/ignition-core": "^0.15.15",
+        "@nomicfoundation/ignition-ui": "^0.15.13",
         "chalk": "^4.0.0",
         "debug": "^4.3.2",
         "fs-extra": "^10.0.0",
@@ -2190,24 +2203,24 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
-      "version": "0.15.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.14.tgz",
-      "integrity": "sha512-eq+5n+c1DW18/Xp8/QrHBBvG5QaKUxYF/byol4f1jrnZ1zAy0OrqEa/oaNFWchhpLalX7d7suk/2EL0PbT0CDQ==",
+      "version": "0.15.17",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.17.tgz",
+      "integrity": "sha512-io6Wrp1dUsJ94xEI3pw6qkPfhc9TFA+e6/+o16yQ8pvBTFMjgK5x8wIHKrrIHr9L3bkuTMtmDjyN4doqO2IqFQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.1.0",
-        "@nomicfoundation/hardhat-ignition": "^0.15.13",
-        "@nomicfoundation/ignition-core": "^0.15.13",
+        "@nomicfoundation/hardhat-ignition": "^0.15.16",
+        "@nomicfoundation/ignition-core": "^0.15.15",
         "ethers": "^6.14.0",
         "hardhat": "^2.26.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.1.0.tgz",
-      "integrity": "sha512-ZS+NulZuR99NUHt2VwcgZvgeD6Y63qrbORNRuKO+lTowJxNVsrJ0zbRx1j5De6G3dOno5pVGvuYSq2QVG0qCYg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.1.2.tgz",
+      "integrity": "sha512-p7HaUVDbLj7ikFivQVNhnfMHUBgiHYMwQWvGn9AriieuopGOELIrwj2KjyM2a6z70zai5YKO264Vwz+3UFJZPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2218,14 +2231,14 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-toolbox": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-6.1.0.tgz",
-      "integrity": "sha512-iAIl6pIK3F4R3JXeq+b6tiShXUrp1sQRiPfqoCMUE7QLUzoFifzGV97IDRL6e73pWsMKpUQBsHBvTCsqn+ZdpA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-6.1.2.tgz",
+      "integrity": "sha512-xKL2r43GC/UIcQzmtFSmj3L4KqLSQ4fK+kyUw0vbIp94nV+9o2ZkI1s3znB8EKXqitt9ClXo0qcKj9RKOFjqPQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
-        "@nomicfoundation/hardhat-ethers": "^3.1.0",
+        "@nomicfoundation/hardhat-ethers": "^3.1.3",
         "@nomicfoundation/hardhat-ignition-ethers": "^0.15.14",
         "@nomicfoundation/hardhat-network-helpers": "^1.1.0",
         "@nomicfoundation/hardhat-verify": "^2.1.0",
@@ -2236,18 +2249,18 @@
         "@types/node": ">=20.0.0",
         "chai": "^4.2.0",
         "ethers": "^6.14.0",
-        "hardhat": "^2.26.0",
+        "hardhat": "^2.28.0",
         "hardhat-gas-reporter": "^2.3.0",
-        "solidity-coverage": "^0.8.1",
+        "solidity-coverage": "^0.8.17",
         "ts-node": ">=8.0.0",
         "typechain": "^8.3.0",
         "typescript": ">=4.5.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-verify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.1.1.tgz",
-      "integrity": "sha512-K1plXIS42xSHDJZRkrE2TZikqxp9T4y6jUMUNI/imLgN5uCcEQokmfU0DlyP9zzHncYK92HlT5IWP35UVCLrPw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.1.3.tgz",
+      "integrity": "sha512-danbGjPp2WBhLkJdQy9/ARM3WQIK+7vwzE0urNem1qZJjh9f54Kf5f1xuQv8DvqewUAkuPxVt/7q4Grz5WjqSg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2267,9 +2280,9 @@
       }
     },
     "node_modules/@nomicfoundation/ignition-core": {
-      "version": "0.15.13",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.13.tgz",
-      "integrity": "sha512-Z4T1WIbw0EqdsN9RxtnHeQXBi7P/piAmCu8bZmReIdDo/2h06qgKWxjDoNfc9VBFZJ0+Dx79tkgQR3ewxMDcpA==",
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.15.tgz",
+      "integrity": "sha512-JdKFxYknTfOYtFXMN6iFJ1vALJPednuB+9p9OwGIRdoI6HYSh4ZBzyRURgyXtHFyaJ/SF9lBpsYV9/1zEpcYwg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2325,10 +2338,11 @@
       }
     },
     "node_modules/@nomicfoundation/ignition-ui": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.12.tgz",
-      "integrity": "sha512-nQl8tusvmt1ANoyIj5RQl9tVSEmG0FnNbtwnWbTim+F8JLm4YLHWS0yEgYUZC+BEO3oS0D8r6V8a02JGZJgqiQ==",
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.13.tgz",
+      "integrity": "sha512-HbTszdN1iDHCkUS9hLeooqnLEW2U45FaqFwFEYT8nIno2prFZhG+n68JEERjmfFCB5u0WgbuJwk3CgLoqtSL7Q==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
@@ -2416,7 +2430,7 @@
         "node": ">= 12"
       }
     },
-    "node_modules/@nomicfoundation/solidity-analyzer/node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.2.tgz",
       "integrity": "sha512-Fdjli4DCcFHb4Zgsz0uEJXZ2K7VEO+w5KVv7HmT7WO10iODdU9csC2az4jrhEsRtiR9Gfd74FlG0NYlw1BMdyA==",
@@ -2786,9 +2800,9 @@
       "peer": true
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2936,13 +2950,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -2984,9 +2998,9 @@
       }
     },
     "node_modules/@types/secp256k1": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
-      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.7.tgz",
+      "integrity": "sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3009,9 +3023,9 @@
       "peer": true
     },
     "node_modules/abitype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.0.tgz",
-      "integrity": "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3032,9 +3046,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3046,9 +3060,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3104,9 +3118,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3291,7 +3305,8 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3344,16 +3359,16 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3428,9 +3443,9 @@
       "license": "MIT"
     },
     "node_modules/bn.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3471,9 +3486,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3584,15 +3599,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3765,14 +3780,15 @@
       "license": "MIT"
     },
     "node_modules/cipher-base": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
-      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1"
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.10"
@@ -4143,9 +4159,9 @@
       "peer": true
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4263,9 +4279,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4363,9 +4379,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4401,9 +4417,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4694,9 +4710,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
-      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
       "dev": true,
       "funding": [
         {
@@ -4888,9 +4904,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -4906,9 +4922,9 @@
       "peer": true
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -4981,9 +4997,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -5046,9 +5062,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5075,7 +5091,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -14469,6 +14484,7 @@
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
       "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -14563,9 +14579,9 @@
       }
     },
     "node_modules/globby/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -14578,7 +14594,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -14598,9 +14614,9 @@
       }
     },
     "node_modules/globby/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -14643,9 +14659,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -14702,15 +14718,15 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.26.3",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.26.3.tgz",
-      "integrity": "sha512-gBfjbxCCEaRgMCRgTpjo1CEoJwqNPhyGMMVHYZJxoQ3LLftp2erSVf8ZF6hTQC0r2wst4NcqNmLWqMnHg1quTw==",
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.28.6.tgz",
+      "integrity": "sha512-zQze7qe+8ltwHvhX5NQ8sN1N37WWZGw8L63y+2XcPxGwAjc/SMF829z3NS6o1krX0sryhAsVBK/xrwUqlsot4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@ethersproject/abi": "^5.1.2",
-        "@nomicfoundation/edr": "^0.11.3",
+        "@nomicfoundation/edr": "0.12.0-next.23",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "adm-zip": "^0.4.16",
@@ -14894,9 +14910,10 @@
       }
     },
     "node_modules/hardhat-gas-reporter/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -14916,14 +14933,14 @@
       }
     },
     "node_modules/hardhat-gas-reporter/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -14933,11 +14950,11 @@
       }
     },
     "node_modules/hardhat-gas-reporter/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -15081,6 +15098,19 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/hardhat/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/hardhat/node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -15166,19 +15196,67 @@
       }
     },
     "node_modules/hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.8"
       }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -15192,9 +15270,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15219,7 +15297,8 @@
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
       "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -15241,20 +15320,24 @@
       "license": "ISC"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-signature": {
@@ -15337,9 +15420,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -15663,9 +15746,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15748,9 +15831,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16208,9 +16291,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -16331,7 +16414,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -16349,9 +16432,9 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -16692,9 +16775,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
-      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "version": "0.14.20",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
+      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
       "dev": true,
       "funding": [
         {
@@ -16711,7 +16794,7 @@
         "@noble/hashes": "^1.8.0",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.9",
+        "abitype": "^1.2.3",
         "eventemitter3": "5.0.1"
       },
       "peerDependencies": {
@@ -16724,9 +16807,9 @@
       }
     },
     "node_modules/ox/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -16832,9 +16915,9 @@
       }
     },
     "node_modules/patch-package": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
-      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16843,15 +16926,14 @@
         "ci-info": "^3.7.0",
         "cross-spawn": "^7.0.3",
         "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^10.0.0",
         "json-stable-stringify": "^1.0.2",
         "klaw-sync": "^6.0.0",
         "minimist": "^1.2.6",
         "open": "^7.4.2",
-        "rimraf": "^2.6.3",
         "semver": "^7.5.3",
         "slash": "^2.0.0",
-        "tmp": "^0.0.33",
+        "tmp": "^0.2.4",
         "yaml": "^2.2.2"
       },
       "bin": {
@@ -16878,26 +16960,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/patch-package/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/patch-package/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -16969,11 +17035,11 @@
       }
     },
     "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -17010,55 +17076,21 @@
       }
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
-      "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "create-hash": "~1.1.3",
+        "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "ripemd160": "=2.0.1",
+        "ripemd160": "^2.0.3",
         "safe-buffer": "^5.2.1",
-        "sha.js": "^2.4.11",
-        "to-buffer": "^1.2.0"
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.1"
       },
       "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/pbkdf2/node_modules/create-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-      "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/pbkdf2/node_modules/hash-base": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-      "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1"
-      }
-    },
-    "node_modules/pbkdf2/node_modules/ripemd160": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-      "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
+        "node": ">= 0.10"
       }
     },
     "node_modules/performance-now": {
@@ -17076,9 +17108,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17166,6 +17198,13 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -17182,12 +17221,15 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -17223,9 +17265,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -17265,16 +17307,16 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -17418,9 +17460,9 @@
       }
     },
     "node_modules/recursive-readdir/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -17430,9 +17472,9 @@
       }
     },
     "node_modules/recursive-readdir/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -17517,7 +17559,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -17591,9 +17633,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17605,7 +17647,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -17624,9 +17666,9 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -17637,14 +17679,17 @@
       }
     },
     "node_modules/ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/rlp": {
@@ -17752,9 +17797,9 @@
       }
     },
     "node_modules/sc-istanbul/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -17767,7 +17812,7 @@
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -17794,9 +17839,9 @@
       }
     },
     "node_modules/sc-istanbul/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -17824,9 +17869,9 @@
       }
     },
     "node_modules/sc-istanbul/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -18167,9 +18212,9 @@
       }
     },
     "node_modules/shelljs/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -18182,7 +18227,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -18202,9 +18247,9 @@
       }
     },
     "node_modules/shelljs/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -18236,14 +18281,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18406,10 +18451,23 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/solc/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/solidity-coverage": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.16.tgz",
-      "integrity": "sha512-qKqgm8TPpcnCK0HCDLJrjbOA2tQNEJY4dHX/LSSQ9iwYFS973MwjtgYn2Iv3vfCEQJTj5xtm4cuUMzlJsJSMbg==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.17.tgz",
+      "integrity": "sha512-5P8vnB6qVX9tt1MfuONtCTEaEGO/O4WuEidPHIAJjx4sktHHKhO3rFvnE0q8L30nWJPTrcqGQMT7jpE29B2qow==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -18540,9 +18598,9 @@
       }
     },
     "node_modules/solidity-coverage/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -18643,9 +18701,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -18718,9 +18776,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18916,9 +18974,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -18945,6 +19003,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
       "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18994,14 +19053,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -19029,9 +19088,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19042,22 +19101,19 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-buffer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
-      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19196,9 +19252,9 @@
       }
     },
     "node_modules/ts-generator/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19252,7 +19308,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -19281,9 +19337,9 @@
       }
     },
     "node_modules/ts-generator/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -19359,9 +19415,9 @@
       }
     },
     "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -19467,9 +19523,9 @@
       }
     },
     "node_modules/typechain/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -19498,7 +19554,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -19529,9 +19585,9 @@
       }
     },
     "node_modules/typechain/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -19583,9 +19639,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -19637,9 +19693,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },
@@ -19695,9 +19751,9 @@
       "license": "MIT"
     },
     "node_modules/url/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -19728,6 +19784,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -19769,9 +19826,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.37.5",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.37.5.tgz",
-      "integrity": "sha512-bLKvKgLcge6KWBMLk8iP9weu5tHNr0hkxPNwQd+YQrHEgek7ogTBBeE10T0V6blwBMYmeZFZHLnMhDmPjp63/A==",
+      "version": "2.48.11",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.11.tgz",
+      "integrity": "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw==",
       "dev": true,
       "funding": [
         {
@@ -19786,9 +19843,9 @@
         "@noble/hashes": "1.8.0",
         "@scure/bip32": "1.7.0",
         "@scure/bip39": "1.6.0",
-        "abitype": "1.1.0",
+        "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.9.3",
+        "ox": "0.14.20",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -20022,9 +20079,9 @@
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20199,9 +20256,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -20209,6 +20266,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,14 +1,14 @@
 {
   "name": "hardhat-project",
   "scripts": {
-    "postinstall": "patch-package && node ./scripts/postinstall.js --protocolVersion=2.5.0",
+    "postinstall": "patch-package && node ./scripts/postinstall.js --protocolVersion=2.5.1",
     "deploy": "hardhat run ./scripts/deploy.js --network localhost",
     "deploy:ropsten": "hardhat run ./scripts/deploy.js --network ropsten",
     "deploy:kovan": "hardhat run ./scripts/deploy.js --network kovan",
     "node": "hardhat node --hostname 0.0.0.0"
   },
   "devDependencies": {
-    "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#efd5d1a8f23c3bca7c25273ea4c912a367250119",
+    "@bosonprotocol/boson-protocol-contracts": "github:bosonprotocol/boson-protocol-contracts#858661679cc8ba2be97eedf3cbc3acd0f5c1903e",
     "@manifoldxyz/royalty-registry-solidity": "github:manifoldxyz/royalty-registry-solidity#e5369fc79279ce2e4c6ea2eb5914df51e89e8bd8",
     "@nomicfoundation/hardhat-ethers": "^3.0.9",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.13",
@@ -16,10 +16,10 @@
     "chai": "^4.3.6",
     "dotenv": "^16.0.1",
     "ethereum-waffle": "^3.4.4",
-    "ethers": "^6.15.0",
+    "ethers": "^6.16.0",
     "ethersv5": "npm:ethers@^5.7.2",
     "glob": "^9.1.0",
-    "hardhat": "^2.25.0",
+    "hardhat": "^2.28.6",
     "hardhat-abi-exporter": "^2.9.0",
     "patch-package": "^8.0.0",
     "seaport": "github:ProjectOpenSea/seaport#e9c5a9f17cb5ee658ccc9cb1a8eeab02c1f5a4cd"

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - host.docker.internal:host-gateway
 
   boson-protocol-node:
-    image: boson-protocol-node:efd5d1a8f23c3bca7c25273ea4c912a367250119_2
+    image: boson-protocol-node:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_0
     build:
       context: ../.
       dockerfile: ./contracts/Dockerfile
@@ -46,7 +46,7 @@ services:
       - "8545:8545"
 
   boson-subgraph:
-    image: boson-subgraph:efd5d1a8f23c3bca7c25273ea4c912a367250119_3
+    image: boson-subgraph:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_0
     build:
       context: ../
       dockerfile: ./packages/subgraph/Dockerfile

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - host.docker.internal:host-gateway
 
   boson-protocol-node:
-    image: boson-protocol-node:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_0
+    image: boson-protocol-node:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_1
     build:
       context: ../.
       dockerfile: ./contracts/Dockerfile

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - host.docker.internal:host-gateway
 
   boson-protocol-node:
-    image: boson-protocol-node:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_1
+    image: boson-protocol-node:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_2
     build:
       context: ../.
       dockerfile: ./contracts/Dockerfile
@@ -46,7 +46,7 @@ services:
       - "8545:8545"
 
   boson-subgraph:
-    image: boson-subgraph:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_0
+    image: boson-subgraph:858661679cc8ba2be97eedf3cbc3acd0f5c1903e_1
     build:
       context: ../
       dockerfile: ./packages/subgraph/Dockerfile

--- a/package-lock.json
+++ b/package-lock.json
@@ -4593,6 +4593,7 @@
       "version": "0.97.1",
       "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.97.1.tgz",
       "integrity": "sha512-j5dc2Tl694jMZmVQu8SSl5Yt3VURiBPgglQEpx30aW6UJ89eLR/x46Nn7S6eflV69fmB5IHAuAACnuTzo8MD0Q==",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@float-capital/float-subgraph-uncrashable": "0.0.0-internal-testing.5",
@@ -4633,12 +4634,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/@graphprotocol/graph-cli/node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -4654,6 +4657,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4666,6 +4670,7 @@
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4680,6 +4685,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
       "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -4695,6 +4701,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4707,6 +4714,7 @@
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
       "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
@@ -4725,6 +4733,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -4740,6 +4749,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -4753,6 +4763,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4765,6 +4776,7 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.9.0.tgz",
       "integrity": "sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4774,6 +4786,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
       "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -4786,6 +4799,7 @@
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.38.1.tgz",
       "integrity": "sha512-CEE2mJugPuukPugMY4bJRW8t8lOqdNa6Y3Oc0x8xc0EwidjF1LRBcfbuC5Ep5gfvWILNC/IQTT1p+QYW8cz4Hw==",
+      "dev": true,
       "dependencies": {
         "assemblyscript": "0.27.31"
       }
@@ -4794,6 +4808,7 @@
       "version": "0.27.31",
       "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.27.31.tgz",
       "integrity": "sha512-Ra8kiGhgJQGZcBxjtMcyVRxOEJZX64kd+XGpjWzjcjgxWJVv+CAQO0aDBk4GQVhjYbOkATarC83mHjAVGtwPBQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "binaryen": "116.0.0-nightly.20240114",
@@ -4816,6 +4831,7 @@
       "version": "116.0.0-nightly.20240114",
       "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-116.0.0-nightly.20240114.tgz",
       "integrity": "sha512-0GZrojJnuhoe+hiwji7QFaL3tBlJoA+KFUN7ouYSDGZLSo9CKM8swQX8n/UcbR0d1VuZKU+nhogNzv423JEu5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "wasm-opt": "bin/wasm-opt",
@@ -6657,6 +6673,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
       "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
@@ -6666,6 +6683,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
       "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
@@ -6678,6 +6696,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -6695,6 +6714,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6707,6 +6727,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -6724,6 +6745,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -10645,6 +10667,7 @@
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/@pinax/graph-networks-registry/-/graph-networks-registry-0.6.7.tgz",
       "integrity": "sha512-xogeCEZ50XRMxpBwE3TZjJ8RCO8Guv39gDRrrKtlpDEDEMLm0MzD3A0SQObgj7aF7qTZNRTWzsuvQdxgzw25wQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -15025,6 +15048,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15042,6 +15066,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15059,6 +15084,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15076,6 +15102,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15093,6 +15120,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15110,6 +15138,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15127,6 +15156,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15144,6 +15174,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15161,6 +15192,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15178,6 +15210,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20906,6 +20939,37 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -22690,7 +22754,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -23730,6 +23793,25 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/decompress": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -23740,6 +23822,190 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/decompress-tar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-tar/node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/decompress-tar/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decompress-tar/node_modules/tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/decompress-tarbz2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-tarbz2/node_modules/file-type": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+      "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-tarbz2/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decompress-targz": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-targz/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decompress-unzip": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-unzip/node_modules/file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decompress-unzip/node_modules/get-stream": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decompress-unzip/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decompress/node_modules/make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress/node_modules/make-dir/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/dedent": {
@@ -24154,6 +24420,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.2.0.tgz",
       "integrity": "sha512-wIU1eHk3Op7dFgELRdmOYlPYS4gP8HhH1ZmZa13QZF59y0fblzFDFmKPhyc05phCy2hze9OEvNZAsoljrs+72w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.2.2"
@@ -24166,6 +24433,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -24423,6 +24691,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ee-first": {
@@ -24502,6 +24771,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emojis-list": {
@@ -26887,6 +27157,15 @@
         "asap": "~2.0.3"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
@@ -26963,6 +27242,15 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/filelist": {
@@ -27417,7 +27705,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -27881,6 +28168,7 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
       "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -27923,6 +28211,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
       "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -27938,6 +28227,7 @@
       "version": "11.2.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
       "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
@@ -27947,6 +28237,7 @@
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
       "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
@@ -27962,6 +28253,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
       "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -29300,6 +29592,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.2.tgz",
       "integrity": "sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -30211,6 +30504,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-natural-number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+      "license": "MIT"
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -30592,7 +30891,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -40203,6 +40501,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -40260,6 +40564,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pino": {
@@ -42184,7 +42509,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -42288,7 +42612,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/process-warning": {
@@ -42305,6 +42628,15 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/progress-events": {
@@ -45924,7 +46256,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -47052,6 +47383,25 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "license": "MIT"
+    },
+    "node_modules/seek-bzip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.8.1"
+      },
+      "bin": {
+        "seek-bunzip": "bin/seek-bunzip",
+        "seek-table": "bin/seek-bzip-table"
+      }
+    },
+    "node_modules/seek-bzip/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/select-hose": {
@@ -48236,6 +48586,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -48250,12 +48601,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -48424,6 +48777,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -48440,6 +48794,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -48452,6 +48807,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -48478,6 +48834,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/strip-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-natural-number": "^4.0.1"
       }
     },
     "node_modules/strip-final-newline": {
@@ -49482,7 +49847,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -51032,6 +51396,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/unbzip2-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/unc-path-regex": {
@@ -54020,6 +54418,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -54037,6 +54436,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -54195,6 +54595,36 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xhr": {
@@ -54402,6 +54832,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {
@@ -55252,8 +55692,8 @@
       "version": "1.35.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@graphprotocol/graph-cli": "^0.97.1",
-        "@graphprotocol/graph-ts": "^0.38.1"
+        "@graphprotocol/graph-cli": "0.98.1",
+        "@graphprotocol/graph-ts": "0.38.2"
       },
       "devDependencies": {
         "@bosonprotocol/common": "^1.32.2",
@@ -55263,6 +55703,426 @@
         "ipfs-utils": "^9.0.14",
         "matchstick-as": "^0.6.0",
         "ts-node": "^10.7.0"
+      }
+    },
+    "packages/subgraph/node_modules/@graphprotocol/graph-cli": {
+      "version": "0.98.1",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.98.1.tgz",
+      "integrity": "sha512-GrWFcRCBlLcRT+gIGundQl7yyrX3YWUPj66bxThKf5CJvvWXdZoNxrj27dMMqulsSwYmpCkb3YmpCiVJFGdpHw==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@float-capital/float-subgraph-uncrashable": "0.0.0-internal-testing.5",
+        "@oclif/core": "4.5.5",
+        "@oclif/plugin-autocomplete": "^3.2.11",
+        "@oclif/plugin-not-found": "^3.2.29",
+        "@oclif/plugin-warn-if-update-available": "^3.1.24",
+        "@pinax/graph-networks-registry": "^0.7.0",
+        "@whatwg-node/fetch": "^0.10.1",
+        "assemblyscript": "0.19.23",
+        "chokidar": "4.0.3",
+        "debug": "4.4.3",
+        "decompress": "^4.2.1",
+        "docker-compose": "1.3.0",
+        "fs-extra": "11.3.2",
+        "glob": "11.0.3",
+        "gluegun": "5.2.0",
+        "graphql": "16.11.0",
+        "immutable": "5.1.4",
+        "jayson": "4.2.0",
+        "js-yaml": "4.1.0",
+        "kubo-rpc-client": "^5.0.2",
+        "open": "10.2.0",
+        "prettier": "3.6.2",
+        "progress": "^2.0.3",
+        "semver": "7.7.3",
+        "tmp-promise": "3.0.3",
+        "undici": "7.16.0",
+        "web3-eth-abi": "4.4.1",
+        "yaml": "2.8.1"
+      },
+      "bin": {
+        "graph": "bin/run.js"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "packages/subgraph/node_modules/@graphprotocol/graph-ts": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.38.2.tgz",
+      "integrity": "sha512-87KIFSFs2+Te+mnmb7Y+M57oqzlLy20cIyPIRbn9qJfpZFSZHTKtBLT6KQmcsK0YkoWis9Ur3c3M2c9mmaaEHQ==",
+      "dependencies": {
+        "assemblyscript": "0.27.31"
+      }
+    },
+    "packages/subgraph/node_modules/@graphprotocol/graph-ts/node_modules/assemblyscript": {
+      "version": "0.27.31",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.27.31.tgz",
+      "integrity": "sha512-Ra8kiGhgJQGZcBxjtMcyVRxOEJZX64kd+XGpjWzjcjgxWJVv+CAQO0aDBk4GQVhjYbOkATarC83mHjAVGtwPBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "binaryen": "116.0.0-nightly.20240114",
+        "long": "^5.2.1"
+      },
+      "bin": {
+        "asc": "bin/asc.js",
+        "asinit": "bin/asinit.js"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "packages/subgraph/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/subgraph/node_modules/@oclif/core": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.5.tgz",
+      "integrity": "sha512-iQzlaJQgPeUXrtrX71OzDwxPikQ7c2FhNd8U8rBB7BCtj2XYfmzBT/Hmbc+g9OKDIG/JkbJT0fXaWMMBrhi+1A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.2",
+        "ansis": "^3.17.0",
+        "clean-stack": "^3.0.1",
+        "cli-spinners": "^2.9.2",
+        "debug": "^4.4.3",
+        "ejs": "^3.1.10",
+        "get-package-type": "^0.1.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lilconfig": "^3.1.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "string-width": "^4.2.3",
+        "supports-color": "^8",
+        "tinyglobby": "^0.2.14",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/subgraph/node_modules/@pinax/graph-networks-registry": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@pinax/graph-networks-registry/-/graph-networks-registry-0.7.1.tgz",
+      "integrity": "sha512-Gn2kXRiEd5COAaMY/aDCRO0V+zfb1uQKCu5HFPoWka+EsZW27AlTINA7JctYYYEMuCbjMia5FBOzskjgEvj6LA==",
+      "license": "MIT"
+    },
+    "packages/subgraph/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "packages/subgraph/node_modules/binaryen": {
+      "version": "116.0.0-nightly.20240114",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-116.0.0-nightly.20240114.tgz",
+      "integrity": "sha512-0GZrojJnuhoe+hiwji7QFaL3tBlJoA+KFUN7ouYSDGZLSo9CKM8swQX8n/UcbR0d1VuZKU+nhogNzv423JEu5A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt",
+        "wasm2js": "bin/wasm2js"
+      }
+    },
+    "packages/subgraph/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/subgraph/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/subgraph/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/subgraph/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/subgraph/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/subgraph/node_modules/docker-compose": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.0.tgz",
+      "integrity": "sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "packages/subgraph/node_modules/fs-extra": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "packages/subgraph/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/subgraph/node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/subgraph/node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/subgraph/node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/subgraph/node_modules/immutable": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
+      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "license": "MIT"
+    },
+    "packages/subgraph/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/subgraph/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/subgraph/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/subgraph/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/subgraph/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/subgraph/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/subgraph/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/subgraph/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/subgraph/node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "packages/subgraph/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     }
   }

--- a/packages/common/src/abis/IBosonAccountHandler.json
+++ b/packages/common/src/abis/IBosonAccountHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/common/src/abis/IBosonConfigHandler.json
+++ b/packages/common/src/abis/IBosonConfigHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },
@@ -1166,6 +1171,25 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mutualizerGasStipend",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "MutualizerGasStipendChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "priceDiscoveryAddress",
@@ -1402,6 +1426,19 @@
   {
     "inputs": [],
     "name": "getMinResolutionPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMutualizerGasStipend",
     "outputs": [
       {
         "internalType": "uint256",
@@ -1693,6 +1730,19 @@
       }
     ],
     "name": "setMinResolutionPeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_mutualizerGasStipend",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMutualizerGasStipend",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/common/src/abis/IBosonDisputeHandler.json
+++ b/packages/common/src/abis/IBosonDisputeHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/common/src/abis/IBosonExchangeCommitHandler.json
+++ b/packages/common/src/abis/IBosonExchangeCommitHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/common/src/abis/IBosonExchangeHandler.json
+++ b/packages/common/src/abis/IBosonExchangeHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/common/src/abis/IBosonFundsHandler.json
+++ b/packages/common/src/abis/IBosonFundsHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/common/src/abis/IBosonGroupHandler.json
+++ b/packages/common/src/abis/IBosonGroupHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/common/src/abis/IBosonMetaTransactionsHandler.json
+++ b/packages/common/src/abis/IBosonMetaTransactionsHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },
@@ -1001,6 +1006,50 @@
       }
     ],
     "name": "executeMetaTransaction",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_userAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_functionName",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_functionSignature",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_signature",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_tokenTransferAuthorization",
+        "type": "bytes"
+      }
+    ],
+    "name": "executeMetaTransactionWithTokenTransferAuthorization",
     "outputs": [
       {
         "internalType": "bytes",

--- a/packages/common/src/abis/IBosonOfferHandler.json
+++ b/packages/common/src/abis/IBosonOfferHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/common/src/abis/IBosonOrchestrationHandler.json
+++ b/packages/common/src/abis/IBosonOrchestrationHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },
@@ -1119,6 +1124,103 @@
       {
         "indexed": true,
         "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "buyerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offerId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "buyerId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "finalizedDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum BosonTypes.ExchangeState",
+            "name": "state",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address payable",
+            "name": "mutualizerAddress",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct BosonTypes.Exchange",
+        "name": "exchange",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "committedDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntilDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "redeemedDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "expired",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct BosonTypes.Voucher",
+        "name": "voucher",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "BuyerCommitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
         "name": "buyerId",
         "type": "uint256"
       },
@@ -1153,6 +1255,66 @@
       }
     ],
     "name": "BuyerCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "sellerId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "collectionIndex",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address payable[]",
+                "name": "recipients",
+                "type": "address[]"
+              },
+              {
+                "internalType": "uint256[]",
+                "name": "bps",
+                "type": "uint256[]"
+              }
+            ],
+            "internalType": "struct BosonTypes.RoyaltyInfo",
+            "name": "royaltyInfo",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address payable",
+            "name": "mutualizerAddress",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct BosonTypes.SellerOfferParams",
+        "name": "sellerParams",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "BuyerInitiatedOfferSetSellerParams",
     "type": "event"
   },
   {
@@ -1232,6 +1394,160 @@
       }
     ],
     "name": "CollectionCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum BosonTypes.GatingType",
+        "name": "gating",
+        "type": "uint8"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "buyerAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "commitCount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxCommits",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionalCommitAuthorized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "mutualizerAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "DRFeeRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "returnAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "mutualizerAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "DRFeeReturnFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "returnAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "mutualizerAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "DRFeeReturned",
     "type": "event"
   },
   {
@@ -1577,6 +1893,173 @@
       }
     ],
     "name": "DisputeResolverUpdatePending",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "buyerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "ExchangeCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "entityId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FundsDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "entityId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "exchangeToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "FundsEncumbered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "entityId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "exchangeToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "FundsReleased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "sellerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawnTo",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "FundsWithdrawn",
     "type": "event"
   },
   {
@@ -2160,6 +2643,37 @@
       {
         "indexed": true,
         "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "exchangeToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "ProtocolFeeCollected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
         "name": "offerId",
         "type": "uint256"
       },
@@ -2232,6 +2746,103 @@
       }
     ],
     "name": "RoyaltyRecipientsChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "sellerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offerId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "buyerId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "finalizedDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum BosonTypes.ExchangeState",
+            "name": "state",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address payable",
+            "name": "mutualizerAddress",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct BosonTypes.Exchange",
+        "name": "exchange",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "committedDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntilDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "redeemedDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "expired",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct BosonTypes.Voucher",
+        "name": "voucher",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "SellerCommitted",
     "type": "event"
   },
   {
@@ -2746,6 +3357,199 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "VoucherCanceled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "VoucherExpired",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validUntil",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "VoucherExtended",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "VoucherRedeemed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "VoucherRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "exchangeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newBuyerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "executedBy",
+        "type": "address"
+      }
+    ],
+    "name": "VoucherTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_offerId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "commitToConditionalOfferAndRedeemVoucher",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_offerId",
+        "type": "uint256"
+      }
+    ],
+    "name": "commitToOfferAndRedeemVoucher",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "components": [
@@ -3146,6 +3950,258 @@
     "name": "createOfferAndTwinWithBundle",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sellerId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "price",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sellerDeposit",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "buyerCancelPenalty",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "quantityAvailable",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address",
+                "name": "exchangeToken",
+                "type": "address"
+              },
+              {
+                "internalType": "enum BosonTypes.PriceType",
+                "name": "priceType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "enum BosonTypes.OfferCreator",
+                "name": "creator",
+                "type": "uint8"
+              },
+              {
+                "internalType": "string",
+                "name": "metadataUri",
+                "type": "string"
+              },
+              {
+                "internalType": "string",
+                "name": "metadataHash",
+                "type": "string"
+              },
+              {
+                "internalType": "bool",
+                "name": "voided",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "collectionIndex",
+                "type": "uint256"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "address payable[]",
+                    "name": "recipients",
+                    "type": "address[]"
+                  },
+                  {
+                    "internalType": "uint256[]",
+                    "name": "bps",
+                    "type": "uint256[]"
+                  }
+                ],
+                "internalType": "struct BosonTypes.RoyaltyInfo[]",
+                "name": "royaltyInfo",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "uint256",
+                "name": "buyerId",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct BosonTypes.Offer",
+            "name": "offer",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "validFrom",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "validUntil",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "voucherRedeemableFrom",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "voucherRedeemableUntil",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct BosonTypes.OfferDates",
+            "name": "offerDates",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "disputePeriod",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "voucherValid",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "resolutionPeriod",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct BosonTypes.OfferDurations",
+            "name": "offerDurations",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "disputeResolverId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "mutualizerAddress",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct BosonTypes.DRParameters",
+            "name": "drParameters",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum BosonTypes.EvaluationMethod",
+                "name": "method",
+                "type": "uint8"
+              },
+              {
+                "internalType": "enum BosonTypes.TokenType",
+                "name": "tokenType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "tokenAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "enum BosonTypes.GatingType",
+                "name": "gating",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "minTokenId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "threshold",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxCommits",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxTokenId",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct BosonTypes.Condition",
+            "name": "condition",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "agentId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "feeLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "useDepositedFunds",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct BosonTypes.FullOffer",
+        "name": "_fullOffer",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_offerCreator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_signature",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_conditionalTokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "createOfferCommitAndRedeem",
+    "outputs": [],
+    "stateMutability": "payable",
     "type": "function"
   },
   {

--- a/packages/common/src/abis/IBosonPriceDiscoveryHandler.json
+++ b/packages/common/src/abis/IBosonPriceDiscoveryHandler.json
@@ -641,6 +641,11 @@
   },
   {
     "inputs": [],
+    "name": "OfferCreatorMustBeSeller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OfferExpiredOrVoided",
     "type": "error"
   },

--- a/packages/ethers-sdk/src/contracts/IBosonConfigHandler.ts
+++ b/packages/ethers-sdk/src/contracts/IBosonConfigHandler.ts
@@ -30,6 +30,7 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
     "getMaxTotalOfferFeePercentage()": FunctionFragment;
     "getMinDisputePeriod()": FunctionFragment;
     "getMinResolutionPeriod()": FunctionFragment;
+    "getMutualizerGasStipend()": FunctionFragment;
     "getPriceDiscoveryAddress()": FunctionFragment;
     "getProtocolFee(address,uint256)": FunctionFragment;
     "getProtocolFeeFlatBoson()": FunctionFragment;
@@ -48,6 +49,7 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
     "setMaxTotalOfferFeePercentage(uint16)": FunctionFragment;
     "setMinDisputePeriod(uint256)": FunctionFragment;
     "setMinResolutionPeriod(uint256)": FunctionFragment;
+    "setMutualizerGasStipend(uint256)": FunctionFragment;
     "setPriceDiscoveryAddress(address)": FunctionFragment;
     "setProtocolFeeFlatBoson(uint256)": FunctionFragment;
     "setProtocolFeePercentage(uint256)": FunctionFragment;
@@ -95,6 +97,10 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "getMinResolutionPeriod",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "getMutualizerGasStipend",
     values?: undefined
   ): string;
   encodeFunctionData(
@@ -170,6 +176,10 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
     values: [BigNumberish]
   ): string;
   encodeFunctionData(
+    functionFragment: "setMutualizerGasStipend",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
     functionFragment: "setPriceDiscoveryAddress",
     values: [string]
   ): string;
@@ -236,6 +246,10 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "getMinResolutionPeriod",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "getMutualizerGasStipend",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -311,6 +325,10 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "setMutualizerGasStipend",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "setPriceDiscoveryAddress",
     data: BytesLike
   ): Result;
@@ -352,6 +370,7 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
     "MaxTotalOfferFeePercentageChanged(uint16,address)": EventFragment;
     "MinDisputePeriodChanged(uint256,address)": EventFragment;
     "MinResolutionPeriodChanged(uint256,address)": EventFragment;
+    "MutualizerGasStipendChanged(uint256,address)": EventFragment;
     "PriceDiscoveryAddressChanged(address,address)": EventFragment;
     "ProtocolFeeFlatBosonChanged(uint256,address)": EventFragment;
     "ProtocolFeePercentageChanged(uint256,address)": EventFragment;
@@ -384,6 +403,9 @@ export interface IBosonConfigHandlerInterface extends utils.Interface {
   ): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MinDisputePeriodChanged"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MinResolutionPeriodChanged"): EventFragment;
+  getEvent(
+    nameOrSignatureOrTopic: "MutualizerGasStipendChanged"
+  ): EventFragment;
   getEvent(
     nameOrSignatureOrTopic: "PriceDiscoveryAddressChanged"
   ): EventFragment;
@@ -500,6 +522,14 @@ export type MinResolutionPeriodChangedEvent = TypedEvent<
 export type MinResolutionPeriodChangedEventFilter =
   TypedEventFilter<MinResolutionPeriodChangedEvent>;
 
+export type MutualizerGasStipendChangedEvent = TypedEvent<
+  [BigNumber, string],
+  { mutualizerGasStipend: BigNumber; executedBy: string }
+>;
+
+export type MutualizerGasStipendChangedEventFilter =
+  TypedEventFilter<MutualizerGasStipendChangedEvent>;
+
 export type PriceDiscoveryAddressChangedEvent = TypedEvent<
   [string, string],
   { priceDiscoveryAddress: string; executedBy: string }
@@ -603,6 +633,8 @@ export interface IBosonConfigHandler extends BaseContract {
 
     getMinResolutionPeriod(overrides?: CallOverrides): Promise<[BigNumber]>;
 
+    getMutualizerGasStipend(overrides?: CallOverrides): Promise<[BigNumber]>;
+
     getPriceDiscoveryAddress(overrides?: CallOverrides): Promise<[string]>;
 
     getProtocolFee(
@@ -690,6 +722,11 @@ export interface IBosonConfigHandler extends BaseContract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
 
+    setMutualizerGasStipend(
+      _mutualizerGasStipend: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
     setPriceDiscoveryAddress(
       _priceDiscovery: string,
       overrides?: Overrides & { from?: string | Promise<string> }
@@ -752,6 +789,8 @@ export interface IBosonConfigHandler extends BaseContract {
   getMinDisputePeriod(overrides?: CallOverrides): Promise<BigNumber>;
 
   getMinResolutionPeriod(overrides?: CallOverrides): Promise<BigNumber>;
+
+  getMutualizerGasStipend(overrides?: CallOverrides): Promise<BigNumber>;
 
   getPriceDiscoveryAddress(overrides?: CallOverrides): Promise<string>;
 
@@ -838,6 +877,11 @@ export interface IBosonConfigHandler extends BaseContract {
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
 
+  setMutualizerGasStipend(
+    _mutualizerGasStipend: BigNumberish,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
   setPriceDiscoveryAddress(
     _priceDiscovery: string,
     overrides?: Overrides & { from?: string | Promise<string> }
@@ -902,6 +946,8 @@ export interface IBosonConfigHandler extends BaseContract {
     getMinDisputePeriod(overrides?: CallOverrides): Promise<BigNumber>;
 
     getMinResolutionPeriod(overrides?: CallOverrides): Promise<BigNumber>;
+
+    getMutualizerGasStipend(overrides?: CallOverrides): Promise<BigNumber>;
 
     getPriceDiscoveryAddress(overrides?: CallOverrides): Promise<string>;
 
@@ -985,6 +1031,11 @@ export interface IBosonConfigHandler extends BaseContract {
 
     setMinResolutionPeriod(
       _minResolutionPeriod: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setMutualizerGasStipend(
+      _mutualizerGasStipend: BigNumberish,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -1141,6 +1192,15 @@ export interface IBosonConfigHandler extends BaseContract {
       executedBy?: string | null
     ): MinResolutionPeriodChangedEventFilter;
 
+    "MutualizerGasStipendChanged(uint256,address)"(
+      mutualizerGasStipend?: null,
+      executedBy?: string | null
+    ): MutualizerGasStipendChangedEventFilter;
+    MutualizerGasStipendChanged(
+      mutualizerGasStipend?: null,
+      executedBy?: string | null
+    ): MutualizerGasStipendChangedEventFilter;
+
     "PriceDiscoveryAddressChanged(address,address)"(
       priceDiscoveryAddress?: string | null,
       executedBy?: string | null
@@ -1226,6 +1286,8 @@ export interface IBosonConfigHandler extends BaseContract {
 
     getMinResolutionPeriod(overrides?: CallOverrides): Promise<BigNumber>;
 
+    getMutualizerGasStipend(overrides?: CallOverrides): Promise<BigNumber>;
+
     getPriceDiscoveryAddress(overrides?: CallOverrides): Promise<BigNumber>;
 
     getProtocolFee(
@@ -1306,6 +1368,11 @@ export interface IBosonConfigHandler extends BaseContract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
+    setMutualizerGasStipend(
+      _mutualizerGasStipend: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
     setPriceDiscoveryAddress(
       _priceDiscovery: string,
       overrides?: Overrides & { from?: string | Promise<string> }
@@ -1383,6 +1450,10 @@ export interface IBosonConfigHandler extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     getMinResolutionPeriod(
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    getMutualizerGasStipend(
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
@@ -1473,6 +1544,11 @@ export interface IBosonConfigHandler extends BaseContract {
 
     setMinResolutionPeriod(
       _minResolutionPeriod: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setMutualizerGasStipend(
+      _mutualizerGasStipend: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/packages/ethers-sdk/src/contracts/IBosonMetaTransactionsHandler.ts
+++ b/packages/ethers-sdk/src/contracts/IBosonMetaTransactionsHandler.ts
@@ -23,6 +23,7 @@ export interface IBosonMetaTransactionsHandlerInterface
   contractName: "IBosonMetaTransactionsHandler";
   functions: {
     "executeMetaTransaction(address,string,bytes,uint256,bytes)": FunctionFragment;
+    "executeMetaTransactionWithTokenTransferAuthorization(address,string,bytes,uint256,bytes,bytes)": FunctionFragment;
     "isFunctionAllowlisted(string)": FunctionFragment;
     "isUsedNonce(address,uint256)": FunctionFragment;
     "setAllowlistedFunctions(bytes32[],bool)": FunctionFragment;
@@ -31,6 +32,10 @@ export interface IBosonMetaTransactionsHandlerInterface
   encodeFunctionData(
     functionFragment: "executeMetaTransaction",
     values: [string, string, BytesLike, BigNumberish, BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "executeMetaTransactionWithTokenTransferAuthorization",
+    values: [string, string, BytesLike, BigNumberish, BytesLike, BytesLike]
   ): string;
   encodeFunctionData(
     functionFragment: "isFunctionAllowlisted",
@@ -47,6 +52,10 @@ export interface IBosonMetaTransactionsHandlerInterface
 
   decodeFunctionResult(
     functionFragment: "executeMetaTransaction",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "executeMetaTransactionWithTokenTransferAuthorization",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -129,6 +138,16 @@ export interface IBosonMetaTransactionsHandler extends BaseContract {
       overrides?: PayableOverrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
 
+    executeMetaTransactionWithTokenTransferAuthorization(
+      _userAddress: string,
+      _functionName: string,
+      _functionSignature: BytesLike,
+      _nonce: BigNumberish,
+      _signature: BytesLike,
+      _tokenTransferAuthorization: BytesLike,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
     "isFunctionAllowlisted(string)"(
       _functionName: string,
       overrides?: CallOverrides
@@ -161,6 +180,16 @@ export interface IBosonMetaTransactionsHandler extends BaseContract {
     overrides?: PayableOverrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
 
+  executeMetaTransactionWithTokenTransferAuthorization(
+    _userAddress: string,
+    _functionName: string,
+    _functionSignature: BytesLike,
+    _nonce: BigNumberish,
+    _signature: BytesLike,
+    _tokenTransferAuthorization: BytesLike,
+    overrides?: PayableOverrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
   "isFunctionAllowlisted(string)"(
     _functionName: string,
     overrides?: CallOverrides
@@ -190,6 +219,16 @@ export interface IBosonMetaTransactionsHandler extends BaseContract {
       _functionSignature: BytesLike,
       _nonce: BigNumberish,
       _signature: BytesLike,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    executeMetaTransactionWithTokenTransferAuthorization(
+      _userAddress: string,
+      _functionName: string,
+      _functionSignature: BytesLike,
+      _nonce: BigNumberish,
+      _signature: BytesLike,
+      _tokenTransferAuthorization: BytesLike,
       overrides?: CallOverrides
     ): Promise<string>;
 
@@ -252,6 +291,16 @@ export interface IBosonMetaTransactionsHandler extends BaseContract {
       overrides?: PayableOverrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
+    executeMetaTransactionWithTokenTransferAuthorization(
+      _userAddress: string,
+      _functionName: string,
+      _functionSignature: BytesLike,
+      _nonce: BigNumberish,
+      _signature: BytesLike,
+      _tokenTransferAuthorization: BytesLike,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
     "isFunctionAllowlisted(string)"(
       _functionName: string,
       overrides?: CallOverrides
@@ -282,6 +331,16 @@ export interface IBosonMetaTransactionsHandler extends BaseContract {
       _functionSignature: BytesLike,
       _nonce: BigNumberish,
       _signature: BytesLike,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    executeMetaTransactionWithTokenTransferAuthorization(
+      _userAddress: string,
+      _functionName: string,
+      _functionSignature: BytesLike,
+      _nonce: BigNumberish,
+      _signature: BytesLike,
+      _tokenTransferAuthorization: BytesLike,
       overrides?: PayableOverrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/packages/ethers-sdk/src/contracts/IBosonOrchestrationHandler.ts
+++ b/packages/ethers-sdk/src/contracts/IBosonOrchestrationHandler.ts
@@ -52,6 +52,50 @@ export declare namespace BosonTypes {
     twinIds: BigNumber[];
   };
 
+  export type ExchangeStruct = {
+    id: BigNumberish;
+    offerId: BigNumberish;
+    buyerId: BigNumberish;
+    finalizedDate: BigNumberish;
+    state: BigNumberish;
+    mutualizerAddress: string;
+  };
+
+  export type ExchangeStructOutput = [
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    number,
+    string
+  ] & {
+    id: BigNumber;
+    offerId: BigNumber;
+    buyerId: BigNumber;
+    finalizedDate: BigNumber;
+    state: number;
+    mutualizerAddress: string;
+  };
+
+  export type VoucherStruct = {
+    committedDate: BigNumberish;
+    validUntilDate: BigNumberish;
+    redeemedDate: BigNumberish;
+    expired: boolean;
+  };
+
+  export type VoucherStructOutput = [
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    boolean
+  ] & {
+    committedDate: BigNumber;
+    validUntilDate: BigNumber;
+    redeemedDate: BigNumber;
+    expired: boolean;
+  };
+
   export type BuyerStruct = {
     id: BigNumberish;
     wallet: string;
@@ -62,6 +106,29 @@ export declare namespace BosonTypes {
     id: BigNumber;
     wallet: string;
     active: boolean;
+  };
+
+  export type RoyaltyInfoStruct = { recipients: string[]; bps: BigNumberish[] };
+
+  export type RoyaltyInfoStructOutput = [string[], BigNumber[]] & {
+    recipients: string[];
+    bps: BigNumber[];
+  };
+
+  export type SellerOfferParamsStruct = {
+    collectionIndex: BigNumberish;
+    royaltyInfo: BosonTypes.RoyaltyInfoStruct;
+    mutualizerAddress: string;
+  };
+
+  export type SellerOfferParamsStructOutput = [
+    BigNumber,
+    BosonTypes.RoyaltyInfoStructOutput,
+    string
+  ] & {
+    collectionIndex: BigNumber;
+    royaltyInfo: BosonTypes.RoyaltyInfoStructOutput;
+    mutualizerAddress: string;
   };
 
   export type DisputeResolverStruct = {
@@ -148,13 +215,6 @@ export declare namespace BosonTypes {
     threshold: BigNumber;
     maxCommits: BigNumber;
     maxTokenId: BigNumber;
-  };
-
-  export type RoyaltyInfoStruct = { recipients: string[]; bps: BigNumberish[] };
-
-  export type RoyaltyInfoStructOutput = [string[], BigNumber[]] & {
-    recipients: string[];
-    bps: BigNumber[];
   };
 
   export type OfferStruct = {
@@ -358,6 +418,37 @@ export declare namespace BosonTypes {
     mutualizerAddress: string;
   };
 
+  export type FullOfferStruct = {
+    offer: BosonTypes.OfferStruct;
+    offerDates: BosonTypes.OfferDatesStruct;
+    offerDurations: BosonTypes.OfferDurationsStruct;
+    drParameters: BosonTypes.DRParametersStruct;
+    condition: BosonTypes.ConditionStruct;
+    agentId: BigNumberish;
+    feeLimit: BigNumberish;
+    useDepositedFunds: boolean;
+  };
+
+  export type FullOfferStructOutput = [
+    BosonTypes.OfferStructOutput,
+    BosonTypes.OfferDatesStructOutput,
+    BosonTypes.OfferDurationsStructOutput,
+    BosonTypes.DRParametersStructOutput,
+    BosonTypes.ConditionStructOutput,
+    BigNumber,
+    BigNumber,
+    boolean
+  ] & {
+    offer: BosonTypes.OfferStructOutput;
+    offerDates: BosonTypes.OfferDatesStructOutput;
+    offerDurations: BosonTypes.OfferDurationsStructOutput;
+    drParameters: BosonTypes.DRParametersStructOutput;
+    condition: BosonTypes.ConditionStructOutput;
+    agentId: BigNumber;
+    feeLimit: BigNumber;
+    useDepositedFunds: boolean;
+  };
+
   export type PremintParametersStruct = {
     reservedRangeLength: BigNumberish;
     to: string;
@@ -384,8 +475,11 @@ export declare namespace BosonTypes {
 export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
   contractName: "IBosonOrchestrationHandler";
   functions: {
+    "commitToConditionalOfferAndRedeemVoucher(uint256,uint256)": FunctionFragment;
+    "commitToOfferAndRedeemVoucher(uint256)": FunctionFragment;
     "createOfferAddToGroup((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),uint256,uint256,uint256)": FunctionFragment;
     "createOfferAndTwinWithBundle((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),(uint256,uint256,uint256,uint256,uint256,address,uint8),uint256,uint256)": FunctionFragment;
+    "createOfferCommitAndRedeem(((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),(uint8,uint8,address,uint8,uint256,uint256,uint256,uint256),uint256,uint256,bool),address,bytes,uint256)": FunctionFragment;
     "createOfferWithCondition((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),(uint8,uint8,address,uint8,uint256,uint256,uint256,uint256),uint256,uint256)": FunctionFragment;
     "createOfferWithConditionAndTwinAndBundle((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),(uint8,uint8,address,uint8,uint256,uint256,uint256,uint256),(uint256,uint256,uint256,uint256,uint256,address,uint8),uint256,uint256)": FunctionFragment;
     "createPremintedOfferAddToGroup((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,uint8,string,string,bool,uint256,(address[],uint256[])[],uint256),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),(uint256,address),(uint256,address),uint256,uint256,uint256)": FunctionFragment;
@@ -403,6 +497,14 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
     "raiseAndEscalateDispute(uint256)": FunctionFragment;
   };
 
+  encodeFunctionData(
+    functionFragment: "commitToConditionalOfferAndRedeemVoucher",
+    values: [BigNumberish, BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "commitToOfferAndRedeemVoucher",
+    values: [BigNumberish]
+  ): string;
   encodeFunctionData(
     functionFragment: "createOfferAddToGroup",
     values: [
@@ -426,6 +528,10 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
       BigNumberish,
       BigNumberish
     ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "createOfferCommitAndRedeem",
+    values: [BosonTypes.FullOfferStruct, string, BytesLike, BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "createOfferWithCondition",
@@ -635,11 +741,23 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
   ): string;
 
   decodeFunctionResult(
+    functionFragment: "commitToConditionalOfferAndRedeemVoucher",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "commitToOfferAndRedeemVoucher",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "createOfferAddToGroup",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "createOfferAndTwinWithBundle",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "createOfferCommitAndRedeem",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -709,14 +827,25 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
     "AllowedSellersAdded(uint256,uint256[],address)": EventFragment;
     "AllowedSellersRemoved(uint256,uint256[],address)": EventFragment;
     "BundleCreated(uint256,uint256,tuple,address)": EventFragment;
+    "BuyerCommitted(uint256,uint256,uint256,tuple,tuple,address)": EventFragment;
     "BuyerCreated(uint256,tuple,address)": EventFragment;
+    "BuyerInitiatedOfferSetSellerParams(uint256,uint256,tuple,address)": EventFragment;
     "BuyerUpdated(uint256,tuple,address)": EventFragment;
     "CollectionCreated(uint256,uint256,address,string,address)": EventFragment;
+    "ConditionalCommitAuthorized(uint256,uint8,address,uint256,uint256,uint256)": EventFragment;
+    "DRFeeRequested(uint256,address,uint256,address,address)": EventFragment;
+    "DRFeeReturnFailed(uint256,address,uint256,address,address)": EventFragment;
+    "DRFeeReturned(uint256,address,uint256,address,address)": EventFragment;
     "DisputeResolverCreated(uint256,tuple,tuple[],uint256[],address)": EventFragment;
     "DisputeResolverFeesAdded(uint256,tuple[],address)": EventFragment;
     "DisputeResolverFeesRemoved(uint256,address[],address)": EventFragment;
     "DisputeResolverUpdateApplied(uint256,tuple,tuple,address)": EventFragment;
     "DisputeResolverUpdatePending(uint256,tuple,address)": EventFragment;
+    "ExchangeCompleted(uint256,uint256,uint256,address)": EventFragment;
+    "FundsDeposited(uint256,address,address,uint256)": EventFragment;
+    "FundsEncumbered(uint256,address,uint256,address)": EventFragment;
+    "FundsReleased(uint256,uint256,address,uint256,address)": EventFragment;
+    "FundsWithdrawn(uint256,address,address,uint256,address)": EventFragment;
     "GroupCreated(uint256,uint256,tuple,tuple,address)": EventFragment;
     "GroupUpdated(uint256,uint256,tuple,tuple,address)": EventFragment;
     "NonListedOfferVoided(bytes32,uint256,address)": EventFragment;
@@ -725,8 +854,10 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
     "OfferMutualizerUpdated(uint256,uint256,address,address)": EventFragment;
     "OfferRoyaltyInfoUpdated(uint256,uint256,tuple,address)": EventFragment;
     "OfferVoided(uint256,uint256,address)": EventFragment;
+    "ProtocolFeeCollected(uint256,address,uint256,address)": EventFragment;
     "RangeReserved(uint256,uint256,uint256,uint256,address,address)": EventFragment;
     "RoyaltyRecipientsChanged(uint256,tuple[],address)": EventFragment;
+    "SellerCommitted(uint256,uint256,uint256,tuple,tuple,address)": EventFragment;
     "SellerCreated(uint256,tuple,address,tuple,address)": EventFragment;
     "SellerUpdateApplied(uint256,tuple,tuple,tuple,tuple,address)": EventFragment;
     "SellerUpdatePending(uint256,tuple,tuple,address)": EventFragment;
@@ -735,6 +866,12 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
     "TwinTransferFailed(uint256,address,uint256,uint256,uint256,address)": EventFragment;
     "TwinTransferSkipped(uint256,uint256,address)": EventFragment;
     "TwinTransferred(uint256,address,uint256,uint256,uint256,address)": EventFragment;
+    "VoucherCanceled(uint256,uint256,address)": EventFragment;
+    "VoucherExpired(uint256,uint256,address)": EventFragment;
+    "VoucherExtended(uint256,uint256,uint256,address)": EventFragment;
+    "VoucherRedeemed(uint256,uint256,address)": EventFragment;
+    "VoucherRevoked(uint256,uint256,address)": EventFragment;
+    "VoucherTransferred(uint256,uint256,uint256,address)": EventFragment;
   };
 
   getEvent(nameOrSignatureOrTopic: "AgentCreated"): EventFragment;
@@ -742,9 +879,19 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "AllowedSellersAdded"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "AllowedSellersRemoved"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "BundleCreated"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "BuyerCommitted"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "BuyerCreated"): EventFragment;
+  getEvent(
+    nameOrSignatureOrTopic: "BuyerInitiatedOfferSetSellerParams"
+  ): EventFragment;
   getEvent(nameOrSignatureOrTopic: "BuyerUpdated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "CollectionCreated"): EventFragment;
+  getEvent(
+    nameOrSignatureOrTopic: "ConditionalCommitAuthorized"
+  ): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "DRFeeRequested"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "DRFeeReturnFailed"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "DRFeeReturned"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "DisputeResolverCreated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "DisputeResolverFeesAdded"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "DisputeResolverFeesRemoved"): EventFragment;
@@ -754,6 +901,11 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
   getEvent(
     nameOrSignatureOrTopic: "DisputeResolverUpdatePending"
   ): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "ExchangeCompleted"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "FundsDeposited"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "FundsEncumbered"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "FundsReleased"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "FundsWithdrawn"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "GroupCreated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "GroupUpdated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "NonListedOfferVoided"): EventFragment;
@@ -762,8 +914,10 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "OfferMutualizerUpdated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OfferRoyaltyInfoUpdated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OfferVoided"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "ProtocolFeeCollected"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "RangeReserved"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "RoyaltyRecipientsChanged"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "SellerCommitted"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "SellerCreated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "SellerUpdateApplied"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "SellerUpdatePending"): EventFragment;
@@ -772,6 +926,12 @@ export interface IBosonOrchestrationHandlerInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "TwinTransferFailed"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "TwinTransferSkipped"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "TwinTransferred"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "VoucherCanceled"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "VoucherExpired"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "VoucherExtended"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "VoucherRedeemed"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "VoucherRevoked"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "VoucherTransferred"): EventFragment;
 }
 
 export type AgentCreatedEvent = TypedEvent<
@@ -832,6 +992,27 @@ export type BundleCreatedEvent = TypedEvent<
 
 export type BundleCreatedEventFilter = TypedEventFilter<BundleCreatedEvent>;
 
+export type BuyerCommittedEvent = TypedEvent<
+  [
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BosonTypes.ExchangeStructOutput,
+    BosonTypes.VoucherStructOutput,
+    string
+  ],
+  {
+    offerId: BigNumber;
+    buyerId: BigNumber;
+    exchangeId: BigNumber;
+    exchange: BosonTypes.ExchangeStructOutput;
+    voucher: BosonTypes.VoucherStructOutput;
+    executedBy: string;
+  }
+>;
+
+export type BuyerCommittedEventFilter = TypedEventFilter<BuyerCommittedEvent>;
+
 export type BuyerCreatedEvent = TypedEvent<
   [BigNumber, BosonTypes.BuyerStructOutput, string],
   {
@@ -842,6 +1023,19 @@ export type BuyerCreatedEvent = TypedEvent<
 >;
 
 export type BuyerCreatedEventFilter = TypedEventFilter<BuyerCreatedEvent>;
+
+export type BuyerInitiatedOfferSetSellerParamsEvent = TypedEvent<
+  [BigNumber, BigNumber, BosonTypes.SellerOfferParamsStructOutput, string],
+  {
+    offerId: BigNumber;
+    sellerId: BigNumber;
+    sellerParams: BosonTypes.SellerOfferParamsStructOutput;
+    executedBy: string;
+  }
+>;
+
+export type BuyerInitiatedOfferSetSellerParamsEventFilter =
+  TypedEventFilter<BuyerInitiatedOfferSetSellerParamsEvent>;
 
 export type BuyerUpdatedEvent = TypedEvent<
   [BigNumber, BosonTypes.BuyerStructOutput, string],
@@ -867,6 +1061,61 @@ export type CollectionCreatedEvent = TypedEvent<
 
 export type CollectionCreatedEventFilter =
   TypedEventFilter<CollectionCreatedEvent>;
+
+export type ConditionalCommitAuthorizedEvent = TypedEvent<
+  [BigNumber, number, string, BigNumber, BigNumber, BigNumber],
+  {
+    offerId: BigNumber;
+    gating: number;
+    buyerAddress: string;
+    tokenId: BigNumber;
+    commitCount: BigNumber;
+    maxCommits: BigNumber;
+  }
+>;
+
+export type ConditionalCommitAuthorizedEventFilter =
+  TypedEventFilter<ConditionalCommitAuthorizedEvent>;
+
+export type DRFeeRequestedEvent = TypedEvent<
+  [BigNumber, string, BigNumber, string, string],
+  {
+    exchangeId: BigNumber;
+    tokenAddress: string;
+    feeAmount: BigNumber;
+    mutualizerAddress: string;
+    executedBy: string;
+  }
+>;
+
+export type DRFeeRequestedEventFilter = TypedEventFilter<DRFeeRequestedEvent>;
+
+export type DRFeeReturnFailedEvent = TypedEvent<
+  [BigNumber, string, BigNumber, string, string],
+  {
+    exchangeId: BigNumber;
+    tokenAddress: string;
+    returnAmount: BigNumber;
+    mutualizerAddress: string;
+    executedBy: string;
+  }
+>;
+
+export type DRFeeReturnFailedEventFilter =
+  TypedEventFilter<DRFeeReturnFailedEvent>;
+
+export type DRFeeReturnedEvent = TypedEvent<
+  [BigNumber, string, BigNumber, string, string],
+  {
+    exchangeId: BigNumber;
+    tokenAddress: string;
+    returnAmount: BigNumber;
+    mutualizerAddress: string;
+    executedBy: string;
+  }
+>;
+
+export type DRFeeReturnedEventFilter = TypedEventFilter<DRFeeReturnedEvent>;
 
 export type DisputeResolverCreatedEvent = TypedEvent<
   [
@@ -941,6 +1190,69 @@ export type DisputeResolverUpdatePendingEvent = TypedEvent<
 
 export type DisputeResolverUpdatePendingEventFilter =
   TypedEventFilter<DisputeResolverUpdatePendingEvent>;
+
+export type ExchangeCompletedEvent = TypedEvent<
+  [BigNumber, BigNumber, BigNumber, string],
+  {
+    offerId: BigNumber;
+    buyerId: BigNumber;
+    exchangeId: BigNumber;
+    executedBy: string;
+  }
+>;
+
+export type ExchangeCompletedEventFilter =
+  TypedEventFilter<ExchangeCompletedEvent>;
+
+export type FundsDepositedEvent = TypedEvent<
+  [BigNumber, string, string, BigNumber],
+  {
+    entityId: BigNumber;
+    executedBy: string;
+    tokenAddress: string;
+    amount: BigNumber;
+  }
+>;
+
+export type FundsDepositedEventFilter = TypedEventFilter<FundsDepositedEvent>;
+
+export type FundsEncumberedEvent = TypedEvent<
+  [BigNumber, string, BigNumber, string],
+  {
+    entityId: BigNumber;
+    exchangeToken: string;
+    amount: BigNumber;
+    executedBy: string;
+  }
+>;
+
+export type FundsEncumberedEventFilter = TypedEventFilter<FundsEncumberedEvent>;
+
+export type FundsReleasedEvent = TypedEvent<
+  [BigNumber, BigNumber, string, BigNumber, string],
+  {
+    exchangeId: BigNumber;
+    entityId: BigNumber;
+    exchangeToken: string;
+    amount: BigNumber;
+    executedBy: string;
+  }
+>;
+
+export type FundsReleasedEventFilter = TypedEventFilter<FundsReleasedEvent>;
+
+export type FundsWithdrawnEvent = TypedEvent<
+  [BigNumber, string, string, BigNumber, string],
+  {
+    sellerId: BigNumber;
+    withdrawnTo: string;
+    tokenAddress: string;
+    amount: BigNumber;
+    executedBy: string;
+  }
+>;
+
+export type FundsWithdrawnEventFilter = TypedEventFilter<FundsWithdrawnEvent>;
 
 export type GroupCreatedEvent = TypedEvent<
   [
@@ -1060,6 +1372,19 @@ export type OfferVoidedEvent = TypedEvent<
 
 export type OfferVoidedEventFilter = TypedEventFilter<OfferVoidedEvent>;
 
+export type ProtocolFeeCollectedEvent = TypedEvent<
+  [BigNumber, string, BigNumber, string],
+  {
+    exchangeId: BigNumber;
+    exchangeToken: string;
+    amount: BigNumber;
+    executedBy: string;
+  }
+>;
+
+export type ProtocolFeeCollectedEventFilter =
+  TypedEventFilter<ProtocolFeeCollectedEvent>;
+
 export type RangeReservedEvent = TypedEvent<
   [BigNumber, BigNumber, BigNumber, BigNumber, string, string],
   {
@@ -1085,6 +1410,27 @@ export type RoyaltyRecipientsChangedEvent = TypedEvent<
 
 export type RoyaltyRecipientsChangedEventFilter =
   TypedEventFilter<RoyaltyRecipientsChangedEvent>;
+
+export type SellerCommittedEvent = TypedEvent<
+  [
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BosonTypes.ExchangeStructOutput,
+    BosonTypes.VoucherStructOutput,
+    string
+  ],
+  {
+    offerId: BigNumber;
+    sellerId: BigNumber;
+    exchangeId: BigNumber;
+    exchange: BosonTypes.ExchangeStructOutput;
+    voucher: BosonTypes.VoucherStructOutput;
+    executedBy: string;
+  }
+>;
+
+export type SellerCommittedEventFilter = TypedEventFilter<SellerCommittedEvent>;
 
 export type SellerCreatedEvent = TypedEvent<
   [
@@ -1201,6 +1547,59 @@ export type TwinTransferredEvent = TypedEvent<
 
 export type TwinTransferredEventFilter = TypedEventFilter<TwinTransferredEvent>;
 
+export type VoucherCanceledEvent = TypedEvent<
+  [BigNumber, BigNumber, string],
+  { offerId: BigNumber; exchangeId: BigNumber; executedBy: string }
+>;
+
+export type VoucherCanceledEventFilter = TypedEventFilter<VoucherCanceledEvent>;
+
+export type VoucherExpiredEvent = TypedEvent<
+  [BigNumber, BigNumber, string],
+  { offerId: BigNumber; exchangeId: BigNumber; executedBy: string }
+>;
+
+export type VoucherExpiredEventFilter = TypedEventFilter<VoucherExpiredEvent>;
+
+export type VoucherExtendedEvent = TypedEvent<
+  [BigNumber, BigNumber, BigNumber, string],
+  {
+    offerId: BigNumber;
+    exchangeId: BigNumber;
+    validUntil: BigNumber;
+    executedBy: string;
+  }
+>;
+
+export type VoucherExtendedEventFilter = TypedEventFilter<VoucherExtendedEvent>;
+
+export type VoucherRedeemedEvent = TypedEvent<
+  [BigNumber, BigNumber, string],
+  { offerId: BigNumber; exchangeId: BigNumber; executedBy: string }
+>;
+
+export type VoucherRedeemedEventFilter = TypedEventFilter<VoucherRedeemedEvent>;
+
+export type VoucherRevokedEvent = TypedEvent<
+  [BigNumber, BigNumber, string],
+  { offerId: BigNumber; exchangeId: BigNumber; executedBy: string }
+>;
+
+export type VoucherRevokedEventFilter = TypedEventFilter<VoucherRevokedEvent>;
+
+export type VoucherTransferredEvent = TypedEvent<
+  [BigNumber, BigNumber, BigNumber, string],
+  {
+    offerId: BigNumber;
+    exchangeId: BigNumber;
+    newBuyerId: BigNumber;
+    executedBy: string;
+  }
+>;
+
+export type VoucherTransferredEventFilter =
+  TypedEventFilter<VoucherTransferredEvent>;
+
 export interface IBosonOrchestrationHandler extends BaseContract {
   contractName: "IBosonOrchestrationHandler";
   connect(signerOrProvider: Signer | Provider | string): this;
@@ -1229,6 +1628,17 @@ export interface IBosonOrchestrationHandler extends BaseContract {
   removeListener: OnEvent<this>;
 
   functions: {
+    commitToConditionalOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      _tokenId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
+    commitToOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
     createOfferAddToGroup(
       _offer: BosonTypes.OfferStruct,
       _offerDates: BosonTypes.OfferDatesStruct,
@@ -1249,6 +1659,14 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       _agentId: BigNumberish,
       _feeLimit: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
+    createOfferCommitAndRedeem(
+      _fullOffer: BosonTypes.FullOfferStruct,
+      _offerCreator: string,
+      _signature: BytesLike,
+      _conditionalTokenId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
 
     createOfferWithCondition(
@@ -1445,6 +1863,17 @@ export interface IBosonOrchestrationHandler extends BaseContract {
     ): Promise<ContractTransaction>;
   };
 
+  commitToConditionalOfferAndRedeemVoucher(
+    _offerId: BigNumberish,
+    _tokenId: BigNumberish,
+    overrides?: PayableOverrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
+  commitToOfferAndRedeemVoucher(
+    _offerId: BigNumberish,
+    overrides?: PayableOverrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
   createOfferAddToGroup(
     _offer: BosonTypes.OfferStruct,
     _offerDates: BosonTypes.OfferDatesStruct,
@@ -1465,6 +1894,14 @@ export interface IBosonOrchestrationHandler extends BaseContract {
     _agentId: BigNumberish,
     _feeLimit: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
+  createOfferCommitAndRedeem(
+    _fullOffer: BosonTypes.FullOfferStruct,
+    _offerCreator: string,
+    _signature: BytesLike,
+    _conditionalTokenId: BigNumberish,
+    overrides?: PayableOverrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
 
   createOfferWithCondition(
@@ -1661,6 +2098,17 @@ export interface IBosonOrchestrationHandler extends BaseContract {
   ): Promise<ContractTransaction>;
 
   callStatic: {
+    commitToConditionalOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      _tokenId: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    commitToOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
     createOfferAddToGroup(
       _offer: BosonTypes.OfferStruct,
       _offerDates: BosonTypes.OfferDatesStruct,
@@ -1680,6 +2128,14 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       _twin: BosonTypes.TwinStruct,
       _agentId: BigNumberish,
       _feeLimit: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    createOfferCommitAndRedeem(
+      _fullOffer: BosonTypes.FullOfferStruct,
+      _offerCreator: string,
+      _signature: BytesLike,
+      _conditionalTokenId: BigNumberish,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -1935,6 +2391,23 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       executedBy?: string | null
     ): BundleCreatedEventFilter;
 
+    "BuyerCommitted(uint256,uint256,uint256,tuple,tuple,address)"(
+      offerId?: BigNumberish | null,
+      buyerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      exchange?: null,
+      voucher?: null,
+      executedBy?: null
+    ): BuyerCommittedEventFilter;
+    BuyerCommitted(
+      offerId?: BigNumberish | null,
+      buyerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      exchange?: null,
+      voucher?: null,
+      executedBy?: null
+    ): BuyerCommittedEventFilter;
+
     "BuyerCreated(uint256,tuple,address)"(
       buyerId?: BigNumberish | null,
       buyer?: null,
@@ -1945,6 +2418,19 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       buyer?: null,
       executedBy?: string | null
     ): BuyerCreatedEventFilter;
+
+    "BuyerInitiatedOfferSetSellerParams(uint256,uint256,tuple,address)"(
+      offerId?: BigNumberish | null,
+      sellerId?: BigNumberish | null,
+      sellerParams?: null,
+      executedBy?: null
+    ): BuyerInitiatedOfferSetSellerParamsEventFilter;
+    BuyerInitiatedOfferSetSellerParams(
+      offerId?: BigNumberish | null,
+      sellerId?: BigNumberish | null,
+      sellerParams?: null,
+      executedBy?: null
+    ): BuyerInitiatedOfferSetSellerParamsEventFilter;
 
     "BuyerUpdated(uint256,tuple,address)"(
       buyerId?: BigNumberish | null,
@@ -1971,6 +2457,68 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       externalId?: string | null,
       executedBy?: string | null
     ): CollectionCreatedEventFilter;
+
+    "ConditionalCommitAuthorized(uint256,uint8,address,uint256,uint256,uint256)"(
+      offerId?: BigNumberish | null,
+      gating?: null,
+      buyerAddress?: string | null,
+      tokenId?: BigNumberish | null,
+      commitCount?: null,
+      maxCommits?: null
+    ): ConditionalCommitAuthorizedEventFilter;
+    ConditionalCommitAuthorized(
+      offerId?: BigNumberish | null,
+      gating?: null,
+      buyerAddress?: string | null,
+      tokenId?: BigNumberish | null,
+      commitCount?: null,
+      maxCommits?: null
+    ): ConditionalCommitAuthorizedEventFilter;
+
+    "DRFeeRequested(uint256,address,uint256,address,address)"(
+      exchangeId?: BigNumberish | null,
+      tokenAddress?: string | null,
+      feeAmount?: null,
+      mutualizerAddress?: string | null,
+      executedBy?: null
+    ): DRFeeRequestedEventFilter;
+    DRFeeRequested(
+      exchangeId?: BigNumberish | null,
+      tokenAddress?: string | null,
+      feeAmount?: null,
+      mutualizerAddress?: string | null,
+      executedBy?: null
+    ): DRFeeRequestedEventFilter;
+
+    "DRFeeReturnFailed(uint256,address,uint256,address,address)"(
+      exchangeId?: BigNumberish | null,
+      tokenAddress?: string | null,
+      returnAmount?: null,
+      mutualizerAddress?: string | null,
+      executedBy?: null
+    ): DRFeeReturnFailedEventFilter;
+    DRFeeReturnFailed(
+      exchangeId?: BigNumberish | null,
+      tokenAddress?: string | null,
+      returnAmount?: null,
+      mutualizerAddress?: string | null,
+      executedBy?: null
+    ): DRFeeReturnFailedEventFilter;
+
+    "DRFeeReturned(uint256,address,uint256,address,address)"(
+      exchangeId?: BigNumberish | null,
+      tokenAddress?: string | null,
+      returnAmount?: null,
+      mutualizerAddress?: string | null,
+      executedBy?: null
+    ): DRFeeReturnedEventFilter;
+    DRFeeReturned(
+      exchangeId?: BigNumberish | null,
+      tokenAddress?: string | null,
+      returnAmount?: null,
+      mutualizerAddress?: string | null,
+      executedBy?: null
+    ): DRFeeReturnedEventFilter;
 
     "DisputeResolverCreated(uint256,tuple,tuple[],uint256[],address)"(
       disputeResolverId?: BigNumberish | null,
@@ -2032,6 +2580,75 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       pendingDisputeResolver?: null,
       executedBy?: string | null
     ): DisputeResolverUpdatePendingEventFilter;
+
+    "ExchangeCompleted(uint256,uint256,uint256,address)"(
+      offerId?: BigNumberish | null,
+      buyerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: null
+    ): ExchangeCompletedEventFilter;
+    ExchangeCompleted(
+      offerId?: BigNumberish | null,
+      buyerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: null
+    ): ExchangeCompletedEventFilter;
+
+    "FundsDeposited(uint256,address,address,uint256)"(
+      entityId?: BigNumberish | null,
+      executedBy?: string | null,
+      tokenAddress?: string | null,
+      amount?: null
+    ): FundsDepositedEventFilter;
+    FundsDeposited(
+      entityId?: BigNumberish | null,
+      executedBy?: string | null,
+      tokenAddress?: string | null,
+      amount?: null
+    ): FundsDepositedEventFilter;
+
+    "FundsEncumbered(uint256,address,uint256,address)"(
+      entityId?: BigNumberish | null,
+      exchangeToken?: string | null,
+      amount?: null,
+      executedBy?: string | null
+    ): FundsEncumberedEventFilter;
+    FundsEncumbered(
+      entityId?: BigNumberish | null,
+      exchangeToken?: string | null,
+      amount?: null,
+      executedBy?: string | null
+    ): FundsEncumberedEventFilter;
+
+    "FundsReleased(uint256,uint256,address,uint256,address)"(
+      exchangeId?: BigNumberish | null,
+      entityId?: BigNumberish | null,
+      exchangeToken?: string | null,
+      amount?: null,
+      executedBy?: null
+    ): FundsReleasedEventFilter;
+    FundsReleased(
+      exchangeId?: BigNumberish | null,
+      entityId?: BigNumberish | null,
+      exchangeToken?: string | null,
+      amount?: null,
+      executedBy?: null
+    ): FundsReleasedEventFilter;
+
+    "FundsWithdrawn(uint256,address,address,uint256,address)"(
+      sellerId?: BigNumberish | null,
+      withdrawnTo?: string | null,
+      tokenAddress?: string | null,
+      amount?: null,
+      executedBy?: null
+    ): FundsWithdrawnEventFilter;
+    FundsWithdrawn(
+      sellerId?: BigNumberish | null,
+      withdrawnTo?: string | null,
+      tokenAddress?: string | null,
+      amount?: null,
+      executedBy?: null
+    ): FundsWithdrawnEventFilter;
 
     "GroupCreated(uint256,uint256,tuple,tuple,address)"(
       groupId?: BigNumberish | null,
@@ -2147,6 +2764,19 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       executedBy?: string | null
     ): OfferVoidedEventFilter;
 
+    "ProtocolFeeCollected(uint256,address,uint256,address)"(
+      exchangeId?: BigNumberish | null,
+      exchangeToken?: string | null,
+      amount?: null,
+      executedBy?: string | null
+    ): ProtocolFeeCollectedEventFilter;
+    ProtocolFeeCollected(
+      exchangeId?: BigNumberish | null,
+      exchangeToken?: string | null,
+      amount?: null,
+      executedBy?: string | null
+    ): ProtocolFeeCollectedEventFilter;
+
     "RangeReserved(uint256,uint256,uint256,uint256,address,address)"(
       offerId?: BigNumberish | null,
       sellerId?: BigNumberish | null,
@@ -2174,6 +2804,23 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       royaltyRecipients?: null,
       executedBy?: string | null
     ): RoyaltyRecipientsChangedEventFilter;
+
+    "SellerCommitted(uint256,uint256,uint256,tuple,tuple,address)"(
+      offerId?: BigNumberish | null,
+      sellerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      exchange?: null,
+      voucher?: null,
+      executedBy?: null
+    ): SellerCommittedEventFilter;
+    SellerCommitted(
+      offerId?: BigNumberish | null,
+      sellerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      exchange?: null,
+      voucher?: null,
+      executedBy?: null
+    ): SellerCommittedEventFilter;
 
     "SellerCreated(uint256,tuple,address,tuple,address)"(
       sellerId?: BigNumberish | null,
@@ -2288,9 +2935,90 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       amount?: null,
       executedBy?: null
     ): TwinTransferredEventFilter;
+
+    "VoucherCanceled(uint256,uint256,address)"(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherCanceledEventFilter;
+    VoucherCanceled(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherCanceledEventFilter;
+
+    "VoucherExpired(uint256,uint256,address)"(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherExpiredEventFilter;
+    VoucherExpired(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherExpiredEventFilter;
+
+    "VoucherExtended(uint256,uint256,uint256,address)"(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      validUntil?: null,
+      executedBy?: string | null
+    ): VoucherExtendedEventFilter;
+    VoucherExtended(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      validUntil?: null,
+      executedBy?: string | null
+    ): VoucherExtendedEventFilter;
+
+    "VoucherRedeemed(uint256,uint256,address)"(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherRedeemedEventFilter;
+    VoucherRedeemed(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherRedeemedEventFilter;
+
+    "VoucherRevoked(uint256,uint256,address)"(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherRevokedEventFilter;
+    VoucherRevoked(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      executedBy?: string | null
+    ): VoucherRevokedEventFilter;
+
+    "VoucherTransferred(uint256,uint256,uint256,address)"(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      newBuyerId?: BigNumberish | null,
+      executedBy?: null
+    ): VoucherTransferredEventFilter;
+    VoucherTransferred(
+      offerId?: BigNumberish | null,
+      exchangeId?: BigNumberish | null,
+      newBuyerId?: BigNumberish | null,
+      executedBy?: null
+    ): VoucherTransferredEventFilter;
   };
 
   estimateGas: {
+    commitToConditionalOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      _tokenId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    commitToOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
     createOfferAddToGroup(
       _offer: BosonTypes.OfferStruct,
       _offerDates: BosonTypes.OfferDatesStruct,
@@ -2311,6 +3039,14 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       _agentId: BigNumberish,
       _feeLimit: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    createOfferCommitAndRedeem(
+      _fullOffer: BosonTypes.FullOfferStruct,
+      _offerCreator: string,
+      _signature: BytesLike,
+      _conditionalTokenId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
     createOfferWithCondition(
@@ -2508,6 +3244,17 @@ export interface IBosonOrchestrationHandler extends BaseContract {
   };
 
   populateTransaction: {
+    commitToConditionalOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      _tokenId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    commitToOfferAndRedeemVoucher(
+      _offerId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
     createOfferAddToGroup(
       _offer: BosonTypes.OfferStruct,
       _offerDates: BosonTypes.OfferDatesStruct,
@@ -2528,6 +3275,14 @@ export interface IBosonOrchestrationHandler extends BaseContract {
       _agentId: BigNumberish,
       _feeLimit: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    createOfferCommitAndRedeem(
+      _fullOffer: BosonTypes.FullOfferStruct,
+      _offerCreator: string,
+      _signature: BytesLike,
+      _conditionalTokenId: BigNumberish,
+      overrides?: PayableOverrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
 
     createOfferWithCondition(

--- a/packages/ethers-sdk/src/contracts/factories/IBosonAccountHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonAccountHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/ethers-sdk/src/contracts/factories/IBosonConfigHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonConfigHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },
@@ -1177,6 +1182,25 @@ const _abi = [
     anonymous: false,
     inputs: [
       {
+        indexed: false,
+        internalType: "uint256",
+        name: "mutualizerGasStipend",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "MutualizerGasStipendChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
         indexed: true,
         internalType: "address",
         name: "priceDiscoveryAddress",
@@ -1413,6 +1437,19 @@ const _abi = [
   {
     inputs: [],
     name: "getMinResolutionPeriod",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getMutualizerGasStipend",
     outputs: [
       {
         internalType: "uint256",
@@ -1704,6 +1741,19 @@ const _abi = [
       },
     ],
     name: "setMinResolutionPeriod",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_mutualizerGasStipend",
+        type: "uint256",
+      },
+    ],
+    name: "setMutualizerGasStipend",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/packages/ethers-sdk/src/contracts/factories/IBosonDisputeHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonDisputeHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/ethers-sdk/src/contracts/factories/IBosonExchangeCommitHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonExchangeCommitHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/ethers-sdk/src/contracts/factories/IBosonExchangeHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonExchangeHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/ethers-sdk/src/contracts/factories/IBosonFundsHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonFundsHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/ethers-sdk/src/contracts/factories/IBosonGroupHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonGroupHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/ethers-sdk/src/contracts/factories/IBosonMetaTransactionsHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonMetaTransactionsHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },
@@ -1012,6 +1017,50 @@ const _abi = [
       },
     ],
     name: "executeMetaTransaction",
+    outputs: [
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_userAddress",
+        type: "address",
+      },
+      {
+        internalType: "string",
+        name: "_functionName",
+        type: "string",
+      },
+      {
+        internalType: "bytes",
+        name: "_functionSignature",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256",
+        name: "_nonce",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "_signature",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes",
+        name: "_tokenTransferAuthorization",
+        type: "bytes",
+      },
+    ],
+    name: "executeMetaTransactionWithTokenTransferAuthorization",
     outputs: [
       {
         internalType: "bytes",

--- a/packages/ethers-sdk/src/contracts/factories/IBosonOfferHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonOfferHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/ethers-sdk/src/contracts/factories/IBosonOrchestrationHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonOrchestrationHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },
@@ -1130,6 +1135,103 @@ const _abi = [
       {
         indexed: true,
         internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "buyerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "id",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "offerId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "buyerId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "finalizedDate",
+            type: "uint256",
+          },
+          {
+            internalType: "enum BosonTypes.ExchangeState",
+            name: "state",
+            type: "uint8",
+          },
+          {
+            internalType: "address payable",
+            name: "mutualizerAddress",
+            type: "address",
+          },
+        ],
+        indexed: false,
+        internalType: "struct BosonTypes.Exchange",
+        name: "exchange",
+        type: "tuple",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "committedDate",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "validUntilDate",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "redeemedDate",
+            type: "uint256",
+          },
+          {
+            internalType: "bool",
+            name: "expired",
+            type: "bool",
+          },
+        ],
+        indexed: false,
+        internalType: "struct BosonTypes.Voucher",
+        name: "voucher",
+        type: "tuple",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "BuyerCommitted",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
         name: "buyerId",
         type: "uint256",
       },
@@ -1164,6 +1266,66 @@ const _abi = [
       },
     ],
     name: "BuyerCreated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "sellerId",
+        type: "uint256",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "collectionIndex",
+            type: "uint256",
+          },
+          {
+            components: [
+              {
+                internalType: "address payable[]",
+                name: "recipients",
+                type: "address[]",
+              },
+              {
+                internalType: "uint256[]",
+                name: "bps",
+                type: "uint256[]",
+              },
+            ],
+            internalType: "struct BosonTypes.RoyaltyInfo",
+            name: "royaltyInfo",
+            type: "tuple",
+          },
+          {
+            internalType: "address payable",
+            name: "mutualizerAddress",
+            type: "address",
+          },
+        ],
+        indexed: false,
+        internalType: "struct BosonTypes.SellerOfferParams",
+        name: "sellerParams",
+        type: "tuple",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "BuyerInitiatedOfferSetSellerParams",
     type: "event",
   },
   {
@@ -1243,6 +1405,160 @@ const _abi = [
       },
     ],
     name: "CollectionCreated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "enum BosonTypes.GatingType",
+        name: "gating",
+        type: "uint8",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "buyerAddress",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "commitCount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "maxCommits",
+        type: "uint256",
+      },
+    ],
+    name: "ConditionalCommitAuthorized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "feeAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "mutualizerAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "DRFeeRequested",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "returnAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "mutualizerAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "DRFeeReturnFailed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "returnAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "mutualizerAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "DRFeeReturned",
     type: "event",
   },
   {
@@ -1588,6 +1904,173 @@ const _abi = [
       },
     ],
     name: "DisputeResolverUpdatePending",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "buyerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "ExchangeCompleted",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "entityId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "FundsDeposited",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "entityId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "exchangeToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "FundsEncumbered",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "entityId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "exchangeToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "FundsReleased",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "sellerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "withdrawnTo",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "FundsWithdrawn",
     type: "event",
   },
   {
@@ -2171,6 +2654,37 @@ const _abi = [
       {
         indexed: true,
         internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "exchangeToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "ProtocolFeeCollected",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
         name: "offerId",
         type: "uint256",
       },
@@ -2243,6 +2757,103 @@ const _abi = [
       },
     ],
     name: "RoyaltyRecipientsChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "sellerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "id",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "offerId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "buyerId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "finalizedDate",
+            type: "uint256",
+          },
+          {
+            internalType: "enum BosonTypes.ExchangeState",
+            name: "state",
+            type: "uint8",
+          },
+          {
+            internalType: "address payable",
+            name: "mutualizerAddress",
+            type: "address",
+          },
+        ],
+        indexed: false,
+        internalType: "struct BosonTypes.Exchange",
+        name: "exchange",
+        type: "tuple",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "committedDate",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "validUntilDate",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "redeemedDate",
+            type: "uint256",
+          },
+          {
+            internalType: "bool",
+            name: "expired",
+            type: "bool",
+          },
+        ],
+        indexed: false,
+        internalType: "struct BosonTypes.Voucher",
+        name: "voucher",
+        type: "tuple",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "SellerCommitted",
     type: "event",
   },
   {
@@ -2757,6 +3368,199 @@ const _abi = [
     type: "event",
   },
   {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "VoucherCanceled",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "VoucherExpired",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "validUntil",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "VoucherExtended",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "VoucherRedeemed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "VoucherRevoked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "exchangeId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "newBuyerId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "executedBy",
+        type: "address",
+      },
+    ],
+    name: "VoucherTransferred",
+    type: "event",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_offerId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "_tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "commitToConditionalOfferAndRedeemVoucher",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_offerId",
+        type: "uint256",
+      },
+    ],
+    name: "commitToOfferAndRedeemVoucher",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
     inputs: [
       {
         components: [
@@ -3157,6 +3961,258 @@ const _abi = [
     name: "createOfferAndTwinWithBundle",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              {
+                internalType: "uint256",
+                name: "id",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "sellerId",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "price",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "sellerDeposit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "buyerCancelPenalty",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "quantityAvailable",
+                type: "uint256",
+              },
+              {
+                internalType: "address",
+                name: "exchangeToken",
+                type: "address",
+              },
+              {
+                internalType: "enum BosonTypes.PriceType",
+                name: "priceType",
+                type: "uint8",
+              },
+              {
+                internalType: "enum BosonTypes.OfferCreator",
+                name: "creator",
+                type: "uint8",
+              },
+              {
+                internalType: "string",
+                name: "metadataUri",
+                type: "string",
+              },
+              {
+                internalType: "string",
+                name: "metadataHash",
+                type: "string",
+              },
+              {
+                internalType: "bool",
+                name: "voided",
+                type: "bool",
+              },
+              {
+                internalType: "uint256",
+                name: "collectionIndex",
+                type: "uint256",
+              },
+              {
+                components: [
+                  {
+                    internalType: "address payable[]",
+                    name: "recipients",
+                    type: "address[]",
+                  },
+                  {
+                    internalType: "uint256[]",
+                    name: "bps",
+                    type: "uint256[]",
+                  },
+                ],
+                internalType: "struct BosonTypes.RoyaltyInfo[]",
+                name: "royaltyInfo",
+                type: "tuple[]",
+              },
+              {
+                internalType: "uint256",
+                name: "buyerId",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct BosonTypes.Offer",
+            name: "offer",
+            type: "tuple",
+          },
+          {
+            components: [
+              {
+                internalType: "uint256",
+                name: "validFrom",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "validUntil",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "voucherRedeemableFrom",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "voucherRedeemableUntil",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct BosonTypes.OfferDates",
+            name: "offerDates",
+            type: "tuple",
+          },
+          {
+            components: [
+              {
+                internalType: "uint256",
+                name: "disputePeriod",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "voucherValid",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "resolutionPeriod",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct BosonTypes.OfferDurations",
+            name: "offerDurations",
+            type: "tuple",
+          },
+          {
+            components: [
+              {
+                internalType: "uint256",
+                name: "disputeResolverId",
+                type: "uint256",
+              },
+              {
+                internalType: "address payable",
+                name: "mutualizerAddress",
+                type: "address",
+              },
+            ],
+            internalType: "struct BosonTypes.DRParameters",
+            name: "drParameters",
+            type: "tuple",
+          },
+          {
+            components: [
+              {
+                internalType: "enum BosonTypes.EvaluationMethod",
+                name: "method",
+                type: "uint8",
+              },
+              {
+                internalType: "enum BosonTypes.TokenType",
+                name: "tokenType",
+                type: "uint8",
+              },
+              {
+                internalType: "address",
+                name: "tokenAddress",
+                type: "address",
+              },
+              {
+                internalType: "enum BosonTypes.GatingType",
+                name: "gating",
+                type: "uint8",
+              },
+              {
+                internalType: "uint256",
+                name: "minTokenId",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "threshold",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "maxCommits",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "maxTokenId",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct BosonTypes.Condition",
+            name: "condition",
+            type: "tuple",
+          },
+          {
+            internalType: "uint256",
+            name: "agentId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "feeLimit",
+            type: "uint256",
+          },
+          {
+            internalType: "bool",
+            name: "useDepositedFunds",
+            type: "bool",
+          },
+        ],
+        internalType: "struct BosonTypes.FullOffer",
+        name: "_fullOffer",
+        type: "tuple",
+      },
+      {
+        internalType: "address",
+        name: "_offerCreator",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "_signature",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256",
+        name: "_conditionalTokenId",
+        type: "uint256",
+      },
+    ],
+    name: "createOfferCommitAndRedeem",
+    outputs: [],
+    stateMutability: "payable",
     type: "function",
   },
   {

--- a/packages/ethers-sdk/src/contracts/factories/IBosonPriceDiscoveryHandler__factory.ts
+++ b/packages/ethers-sdk/src/contracts/factories/IBosonPriceDiscoveryHandler__factory.ts
@@ -652,6 +652,11 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "OfferCreatorMustBeSeller",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OfferExpiredOrVoided",
     type: "error",
   },

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -27,8 +27,8 @@
     }
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.97.1",
-    "@graphprotocol/graph-ts": "^0.38.1"
+    "@graphprotocol/graph-cli": "0.98.1",
+    "@graphprotocol/graph-ts": "0.38.2"
   },
   "devDependencies": {
     "@bosonprotocol/common": "^1.32.2",


### PR DESCRIPTION
This pull request updates the Boson Protocol contracts and related tooling to newer versions, introduces new contract ABI methods and errors, and updates development dependencies. The main changes focus on upgrading Solidity versions, aligning the Hardhat configuration and Docker images with the latest protocol release, and extending ABI interfaces with new features and error handling.

**Protocol and Contract Upgrades:**

* Upgraded Solidity compiler version to `0.8.35` in all relevant contracts (`MockBosonVoucher.sol`, `MockBosonSellerHandler.sol`, `OpenSeaWrapper.sol`, `OpenSeaWrapperFactory.sol`) and updated the Hardhat configuration to use Solidity `0.8.35`, EVM version `cancun`, and hardfork `cancun` for local development. Optimizer runs changed from 100 to 50. [[1]](diffhunk://#diff-0f8c8f5d26ccb3131bd0ec587550c4a4f6f09eeea986bbda8abc67265d646e07L2-R2) [[2]](diffhunk://#diff-d1203cca5551497950d8a2659357d7448206c0e8531dc187c81eef4c72f3ad75L2-R2) [[3]](diffhunk://#diff-29b8a055fd2110fe7b3cd8656c06a235a31a7f74a5f89ae3448305db2ec91298L2-R2) [[4]](diffhunk://#diff-bda1d4b7d02ac72f7fb8f4aba1201575010fd529d18fb9ef06d85a94991610f6L2-R2) [[5]](diffhunk://#diff-66c6bc2b2884a92115a66c66978a8d9557d61ac7638cc3760db255fb29fb5f98L137-R151) [[6]](diffhunk://#diff-66c6bc2b2884a92115a66c66978a8d9557d61ac7638cc3760db255fb29fb5f98R181-R182)

* Updated Docker Compose and package dependencies to reference the latest Boson Protocol contracts and subgraph images (`858661679cc8ba2be97eedf3cbc3acd0f5c1903e`), and bumped the protocol version used in scripts to `2.5.1`. [[1]](diffhunk://#diff-6e968fd9eb2b070c0878f0f075eebdec7c319c7b9f90533017e0ceddfd8ee1d2L41-R49) [[2]](diffhunk://#diff-8fdb4aff7a0e74ab6d27fe514bc7e0baaa77fcf61286ae7ce7ef69f7aabfa23bL4-R22)

**ABI and Interface Enhancements:**

* Added a new error, `OfferCreatorMustBeSeller`, to multiple ABI interfaces: `IBosonAccountHandler`, `IBosonConfigHandler`, `IBosonDisputeHandler`, `IBosonExchangeCommitHandler`, `IBosonExchangeHandler`, `IBosonFundsHandler`, `IBosonGroupHandler`, `IBosonMetaTransactionsHandler`, `IBosonOfferHandler`, and `IBosonPriceDiscoveryHandler`. [[1]](diffhunk://#diff-a670d368321799f770a91017046b1f1ada2c4280d20048ce130f076a406152e6R642-R646) [[2]](diffhunk://#diff-5ea74bd4cc1318c09705c0598f4ef49df6a70ce7c53b71131a208a544092f77eR642-R646) [[3]](diffhunk://#diff-87e085e3d9f3f8d42816226715efc3fce8a5ce3ff6adad9e564e146e5b9e216dR642-R646) [[4]](diffhunk://#diff-5fbd95556ab8c2147a0766ff53f58c75c3d4ff36791343d474d090ba761e9640R642-R646) [[5]](diffhunk://#diff-41e6d2570e927cb4c2b1ce150b5eae63f36c173015797f9e183fafe3dcbfba15R642-R646) [[6]](diffhunk://#diff-2cf07067ccb39d59bd3ac6862bc950bc16c33e944360f79d47991b727c4eb361R642-R646) [[7]](diffhunk://#diff-0d8a53014fd80a7810d16175d8dab12ea38548e4575177bab7f3c216c3d1bccbR642-R646) [[8]](diffhunk://#diff-44193dea6d24b984a1698bf1f2b8f1aef4f2e1457704a2f933707150a67e4c7eR642-R646) [[9]](diffhunk://#diff-7e2f634f7d0f272859e4607d0daa38072ab6032e5571d3d80d4bf4375e5dcc39R642-R646) [[10]](diffhunk://#diff-26d737a3d3e982a1c52c25230de393e26af40040234086f8f702285fafe9cd62R642-R646)

* Extended `IBosonConfigHandler` ABI with new methods and events for managing the `mutualizerGasStipend` parameter: added `MutualizerGasStipendChanged` event, `getMutualizerGasStipend` getter, and `setMutualizerGasStipend` setter. [[1]](diffhunk://#diff-5ea74bd4cc1318c09705c0598f4ef49df6a70ce7c53b71131a208a544092f77eR1170-R1188) [[2]](diffhunk://#diff-5ea74bd4cc1318c09705c0598f4ef49df6a70ce7c53b71131a208a544092f77eR1439-R1451) [[3]](diffhunk://#diff-5ea74bd4cc1318c09705c0598f4ef49df6a70ce7c53b71131a208a544092f77eR1737-R1749)

* Added a new function `executeMetaTransactionWithTokenTransferAuthorization` to the `IBosonMetaTransactionsHandler` ABI.

**Dependency Updates:**

* Updated several development dependencies in `contracts/package.json`, including `@bosonprotocol/boson-protocol-contracts`, `ethers`, `hardhat`, and the OpenSea seaport dependency.

* Updated `@graphprotocol/graph-cli` and `@graphprotocol/graph-ts` versions in `packages/subgraph/package.json`.## 
