### PR TITLE
test: unskip e2e meta-tx transferAuthorizations tests

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3"
 services:
   meta-tx-gateway:
-    image: ghcr.io/bosonprotocol/meta-tx-gateway:bump-common-alpha-5
-    # image: bosonprotocol/meta-tx-gateway:bump-common-alpha-5 # can be pulled from Docker Hub as well
+    image: ghcr.io/bosonprotocol/meta-tx-gateway:main
+    # image: bosonprotocol/meta-tx-gateway:main # can be pulled from Docker Hub as well
     user: "node:node"
     ports:
       - "8888:8888"

--- a/e2e/tests/core-sdk-token-auth.test.ts
+++ b/e2e/tests/core-sdk-token-auth.test.ts
@@ -667,11 +667,7 @@ describe("core-sdk-token-auth", () => {
     });
   });
 
-  // Skipped: meta-tx-gateway image still expects the legacy `bytes`
-  // transferAuthorizations form; this branch ships the regenerated ABI
-  // (bytes[]) only. Re-enabled once the gateway image is rebuilt + the
-  // SDK-side wrapper-drop PR lands.
-  describe.skip("meta-tx with transfer authorizations", () => {
+  describe("meta-tx with transfer authorizations", () => {
     describe("commitToOffer", () => {
       STRATEGIES.forEach((strategy) => {
         test(`${strategy} auth — non-native exchange token offer`, async () => {

--- a/e2e/tests/meta-tx.test.ts
+++ b/e2e/tests/meta-tx.test.ts
@@ -2619,11 +2619,7 @@ describe("meta-tx", () => {
       );
     });
 
-    // Skipped: meta-tx-gateway image still expects the legacy `bytes`
-    // transferAuthorizations form; this branch ships the regenerated ABI
-    // (bytes[]) only. Re-enabled once the gateway image is rebuilt + the
-    // SDK-side wrapper-drop PR lands.
-    test.skip("with transferAuthorizations (ERC3009): signed by buyer, paid by random funded wallet", async () => {
+    test("with transferAuthorizations (ERC3009): signed by buyer, paid by random funded wallet", async () => {
       // 1. Set up a DR that accepts the ERC3009 token (drFee = 0).
       const { fundedWallet: drFundedWallet } =
         await initCoreSDKWithFundedWallet(sellerWallet);


### PR DESCRIPTION
## Summary
Re-enables 13 e2e tests that were silently left skipped on \`main\`:
- \`e2e/tests/core-sdk-token-auth.test.ts\` — the entire \`meta-tx with transfer authorizations\` describe block (12 tests: ERC3009 / EIP2612 / Permit2 × commitToOffer / commitToConditionalOffer / commitToBuyerOffer / createOfferAndCommit).
- \`e2e/tests/meta-tx.test.ts\` — \`with transferAuthorizations (ERC3009): signed by buyer, paid by random funded wallet\`.

Also reverts \`e2e/docker-compose.yml\` meta-tx-gateway image tag from \`bump-common-alpha-5\` back to \`:main\` now that the \`bytes[]\` transferAuthorizations support is on the gateway repo's main.

## Why these were skipped
PR #1030 added \`.skip\` to these tests because the contracts-bump branch (which shipped the new \`bytes[]\` ABI) could not pass them against the old meta-tx-gateway image. PR #1029 was supposed to un-skip them in the same commit that dropped the \`encodeTransferAuthorizationQueue\` wrapper.

The un-skips never made it onto \`main\`. PR #1030 was squash-merged first, putting the skip lines on main. PR #1029 was then squash-merged with a diff computed against the pre-#1030 merge-base — its add-then-remove of the skip lines collapsed to a no-op on the e2e files. \`git show <#1029-merge-sha> --stat\` confirms zero changes to \`e2e/tests/*\`. The 13 tests have therefore not been running against the rebuilt gateway image even though everything else is in place.

## Test plan
- [ ] Local: \`docker compose up\` (e2e/) with the \`:main\` gateway image, then \`npm run e2e:test -- core-sdk-token-auth meta-tx\` — all 13 re-enabled tests pass.
- [ ] CI e2e job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)