### PR TITLE
fix: short-circuit ensureAllowance when returnTxInfo is set

### DIFF
--- a/packages/core-sdk/src/erc20/handler.ts
+++ b/packages/core-sdk/src/erc20/handler.ts
@@ -193,7 +193,11 @@ export async function ensureAllowance(args: {
   value: BigNumberish;
   web3Lib: Web3LibAdapter;
   txRequest?: TransactionRequest;
+  returnTxInfo?: boolean;
 }) {
+  if (args.returnTxInfo) {
+    return;
+  }
   const allowance = await getAllowance(args);
   if (BigNumber.from(allowance).lt(args.value)) {
     const approveTx = await approve(args);

--- a/packages/core-sdk/src/erc20/handler.ts
+++ b/packages/core-sdk/src/erc20/handler.ts
@@ -200,7 +200,7 @@ export async function ensureAllowance(args: {
   }
   const allowance = await getAllowance(args);
   if (BigNumber.from(allowance).lt(args.value)) {
-    const approveTx = await approve(args);
+    const approveTx = await approve({ ...args, returnTxInfo: false });
     await approveTx.wait();
   }
 }

--- a/packages/core-sdk/src/exchanges/handler.ts
+++ b/packages/core-sdk/src/exchanges/handler.ts
@@ -141,7 +141,8 @@ export async function commitToOffer(
       spender: args.contractAddress,
       contractAddress: offer.exchangeToken.address,
       value: offer.price,
-      web3Lib: args.web3Lib
+      web3Lib: args.web3Lib,
+      returnTxInfo: args.returnTxInfo
     });
   }
 
@@ -203,7 +204,8 @@ export async function commitToBuyerOffer(
       spender: args.contractAddress,
       contractAddress: offer.exchangeToken.address,
       value: offer.price,
-      web3Lib: args.web3Lib
+      web3Lib: args.web3Lib,
+      returnTxInfo: args.returnTxInfo
     });
   }
 
@@ -263,7 +265,8 @@ export async function commitToConditionalOffer(
       spender: args.contractAddress,
       contractAddress: offer.exchangeToken.address,
       value: offer.price,
-      web3Lib: args.web3Lib
+      web3Lib: args.web3Lib,
+      returnTxInfo: args.returnTxInfo
     });
   }
 
@@ -384,7 +387,8 @@ export async function createOfferAndCommit(args: {
       spender: args.contractAddress,
       contractAddress: exchangeToken,
       value: committerPayment,
-      web3Lib: args.web3Lib
+      web3Lib: args.web3Lib,
+      returnTxInfo: args.returnTxInfo
     });
   }
 

--- a/packages/core-sdk/src/orchestration/handler.ts
+++ b/packages/core-sdk/src/orchestration/handler.ts
@@ -751,7 +751,7 @@ export async function createOfferCommitAndRedeem(args: {
   const committerPayment =
     creator === OfferCreator.Buyer ? sellerDeposit : price;
 
-  if (exchangeToken !== AddressZero) {
+  if (exchangeToken !== AddressZero && !args.returnTxInfo) {
     const owner = await args.web3Lib.getSignerAddress();
     await ensureAllowance({
       owner,

--- a/packages/core-sdk/src/orchestration/handler.ts
+++ b/packages/core-sdk/src/orchestration/handler.ts
@@ -586,7 +586,8 @@ export async function commitToOfferAndRedeemVoucher(args: {
       spender: args.contractAddress,
       contractAddress: offer.exchangeToken.address,
       value: offer.price,
-      web3Lib: args.web3Lib
+      web3Lib: args.web3Lib,
+      returnTxInfo: args.returnTxInfo
     });
   }
 
@@ -647,7 +648,8 @@ export async function commitToConditionalOfferAndRedeemVoucher(args: {
       spender: args.contractAddress,
       contractAddress: offer.exchangeToken.address,
       value: offer.price,
-      web3Lib: args.web3Lib
+      web3Lib: args.web3Lib,
+      returnTxInfo: args.returnTxInfo
     });
   }
 
@@ -751,14 +753,15 @@ export async function createOfferCommitAndRedeem(args: {
   const committerPayment =
     creator === OfferCreator.Buyer ? sellerDeposit : price;
 
-  if (exchangeToken !== AddressZero && !args.returnTxInfo) {
+  if (exchangeToken !== AddressZero) {
     const owner = await args.web3Lib.getSignerAddress();
     await ensureAllowance({
       owner,
       spender: args.contractAddress,
       contractAddress: exchangeToken,
       value: committerPayment,
-      web3Lib: args.web3Lib
+      web3Lib: args.web3Lib,
+      returnTxInfo: args.returnTxInfo
     });
   }
 


### PR DESCRIPTION
## Summary
- The handler functions in `core-sdk` (`commitToOffer`, `commitToBuyerOffer`, `commitToConditionalOffer`, `createOfferAndCommit`, `commitToOfferAndRedeemVoucher`, `commitToConditionalOfferAndRedeemVoucher`, `createOfferCommitAndRedeem`) all support `returnTxInfo: true` for callers (e.g. the MCP server) that only need the encoded transaction.
- However, they all invoked `ensureAllowance` unconditionally, which attempts an ERC20 `approve` transaction and breaks for callers without a signer.
- Centralize the fix: `ensureAllowance` now short-circuits when `returnTxInfo` is true, and every call site passes the flag through.

## Test plan
- [ ] Call each affected handler with `returnTxInfo: true` and an ERC20 exchange token — verify it returns a `TransactionRequest` without hitting `ensureAllowance`/`approve`.
- [ ] Call each handler with `returnTxInfo` unset / `false` — verify allowance is still ensured before sending the transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)