### PR TITLE
feat: migrate subgraph provider from Ormi to Goldsky

### DIFF
--- a/.github/workflows/deploy-testing-subgraph.yaml
+++ b/.github/workflows/deploy-testing-subgraph.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
+      GOLDSKY_API_KEY_TESTING:
+        required: true
       ORMI_0x_GRAPH_API_KEY_TESTING:
         required: true
       THE_GRAPH_STUDIO_DEPLOY_KEY:
@@ -11,10 +13,19 @@ on:
       GH_TOKEN:
         required: true
 
+# Deployments wait for the new version to be synced, so a run can last hours: queue
+# overlapping runs instead of cancelling one in the middle of a tag move
+concurrency:
+  group: deploy-testing-subgraph
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy subgraph
+    # Both deployments wait for the new version to be synced, capped at
+    # GOLDSKY_SYNC_TIMEOUT_MINUTES each, and have to fit in GitHub's 6h job limit
+    timeout-minutes: 330
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,31 +50,27 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git pull
-      - name: Deploy subgraph to amoy
-        run: cd ./packages/subgraph && npm run deploy:testing:amoy
-        env:
-          ORMI_0x_GRAPH_API_KEY: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
+      # GOLDSKY_WAIT_FOR_SYNC makes the 'latest' tag move - and the previously tagged
+      # version get deleted - only once the new version is synced and healthy
       - name: Deploy subgraph to sepolia
         run: cd ./packages/subgraph && npm run deploy:testing:sepolia
         env:
-          ORMI_0x_GRAPH_API_KEY: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
+          GOLDSKY_API_KEY: ${{ secrets.GOLDSKY_API_KEY_TESTING }}
+          GOLDSKY_WAIT_FOR_SYNC: "true"
+          GOLDSKY_SYNC_TIMEOUT_MINUTES: "150"
       - name: Deploy subgraph to base sepolia
         run: cd ./packages/subgraph && npm run deploy:testing:base
         env:
-          ORMI_0x_GRAPH_API_KEY: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
-      - name: Deploy subgraph to optimism sepolia
-        run: cd ./packages/subgraph && npm run deploy:testing:optimism
-        env:
-          ORMI_0x_GRAPH_API_KEY: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
-      - name: Deploy subgraph to arbitrum sepolia
-        run: cd ./packages/subgraph && npm run deploy:testing:arbitrum
-        env:
-          ORMI_0x_GRAPH_API_KEY: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
+          GOLDSKY_API_KEY: ${{ secrets.GOLDSKY_API_KEY_TESTING }}
+          GOLDSKY_WAIT_FOR_SYNC: "true"
+          GOLDSKY_SYNC_TIMEOUT_MINUTES: "150"
       - name: Commit & Push
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git add .
-          git commit -m "chore: deploy testing subgraphs [skip ci]"
+          # Goldsky itself records which version is deployed, so a run usually has
+          # nothing to commit - which must not fail the job
+          git diff --cached --quiet || git commit -m "chore: deploy testing subgraphs [skip ci]"
           git push origin HEAD

--- a/.github/workflows/publish-alpha.yaml
+++ b/.github/workflows/publish-alpha.yaml
@@ -93,6 +93,7 @@ jobs:
     needs: publish
     if: needs.publish.outputs.SUBGRAPH_CHANGES == 'true'
     secrets:
+      GOLDSKY_API_KEY_TESTING: ${{ secrets.GOLDSKY_API_KEY_TESTING }}
       ORMI_0x_GRAPH_API_KEY_TESTING: ${{ secrets.ORMI_0x_GRAPH_API_KEY_TESTING }}
       THE_GRAPH_STUDIO_DEPLOY_KEY: ${{ secrets.THE_GRAPH_STUDIO_DEPLOY_KEY }}
       GH_TOKEN: ${{ secrets.BSNORG_ACTIONS_SECRET }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4589,6 +4589,14 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@goldskycom/cli": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@goldskycom/cli/-/cli-13.8.0.tgz",
+      "integrity": "sha512-pSM8nu6Vysf3KM9lzL59Zla1WThZlWYprsv5ncOe+ZuVtNHV3cmLafg9zB032Xe3X7RSpeQeT9RP5QlIHtALAA==",
+      "bin": {
+        "goldsky": "bin/goldsky"
+      }
+    },
     "node_modules/@graphprotocol/graph-cli": {
       "version": "0.97.1",
       "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.97.1.tgz",
@@ -55693,6 +55701,7 @@
       "version": "1.36.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@goldskycom/cli": "^13.8.0",
         "@graphprotocol/graph-cli": "0.98.1",
         "@graphprotocol/graph-ts": "0.38.2"
       },

--- a/packages/common/src/inputs/subgraphs.json
+++ b/packages/common/src/inputs/subgraphs.json
@@ -9,7 +9,7 @@
       "https://api.0xgraph.xyz/api/public/c56471f5-5b1d-4a62-b1de-450044cb7ebc/subgraphs/boson-testing-amoy/latest/gn"
     ],
     "testing-11155111-0": [
-      "https://api.0xgraph.xyz/api/public/c56471f5-5b1d-4a62-b1de-450044cb7ebc/subgraphs/boson-testing-sepolia/latest/gn"
+      "https://api.goldsky.com/api/public/project_cmsd7juc4rocz01u5566b9h93/subgraphs/boson-testing-sepolia/latest/gn"
     ],
     "testing-84532-0": [
       "https://api.0xgraph.xyz/api/public/c56471f5-5b1d-4a62-b1de-450044cb7ebc/subgraphs/boson-testing-base/latest/gn"

--- a/packages/common/src/inputs/subgraphs.json
+++ b/packages/common/src/inputs/subgraphs.json
@@ -12,7 +12,7 @@
       "https://api.goldsky.com/api/public/project_cmsd7juc4rocz01u5566b9h93/subgraphs/boson-testing-sepolia/latest/gn"
     ],
     "testing-84532-0": [
-      "https://api.0xgraph.xyz/api/public/c56471f5-5b1d-4a62-b1de-450044cb7ebc/subgraphs/boson-testing-base/latest/gn"
+      "https://api.goldsky.com/api/public/project_cmsd7juc4rocz01u5566b9h93/subgraphs/boson-testing-base/latest/gn"
     ],
     "testing-11155420-0": [
       "https://api.0xgraph.xyz/api/public/c56471f5-5b1d-4a62-b1de-450044cb7ebc/subgraphs/boson-testing-optimism/latest/gn"

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -27,6 +27,7 @@
     }
   },
   "dependencies": {
+    "@goldskycom/cli": "^13.8.0",
     "@graphprotocol/graph-cli": "0.98.1",
     "@graphprotocol/graph-ts": "0.38.2"
   },
@@ -60,9 +61,11 @@
     "manifest:production:optimism": "npm run manifest -- production production-10-0 && npm run codegen",
     "manifest:production:arbitrum": "npm run manifest -- production production-42161-0 && npm run codegen",
     "codegen": "graph codegen",
+    "build:subgraph": "graph build",
     "create:local": "graph create --node http://localhost:8020/ boson/corecomponents",
     "remove:local": "graph remove --node http://localhost:8020/ boson/corecomponents",
     "post-deploy:ormi": "ts-node -P ../../tsconfig.base.json ./scripts/post-deploy-on-ormi.ts",
+    "deploy:goldsky": "ts-node -P ../../tsconfig.base.json ./scripts/deploy-on-goldsky.ts",
     "deploy:cmd:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 boson/corecomponents -l 0.0.1",
     "deploy:cmd:testing:amoy": "run-script-os",
     "deploy:cmd:testing:amoy:default": "graph deploy --node $npm_package_config_node --ipfs $npm_package_config_ipfs -l $npm_package_version --deploy-key $ORMI_0x_GRAPH_API_KEY $npm_package_config_testing_amoy",
@@ -111,8 +114,8 @@
     "deploy:cmd:production:arbitrum:win32": "graph deploy --node %npm_package_config_node% --ipfs %npm_package_config_ipfs% -l %npm_package_version% --deploy-key %ORMI_0x_GRAPH_API_KEY% %npm_package_config_production_arbitrum%",
     "deploy:local": "npm run manifest:local && npm run create:local && npm run deploy:cmd:local",
     "deploy:testing:amoy": "npm run manifest:testing:amoy && npm run deploy:cmd:testing:amoy && npm run post-deploy:ormi -- --env=testing_amoy",
-    "deploy:testing:sepolia": "npm run manifest:testing:sepolia && npm run deploy:cmd:testing:sepolia && npm run post-deploy:ormi -- --env=testing_sepolia",
-    "deploy:testing:base": "npm run manifest:testing:base && npm run deploy:cmd:testing:base && npm run post-deploy:ormi -- --env=testing_base",
+    "deploy:testing:sepolia": "npm run manifest:testing:sepolia && npm run build:subgraph && npm run deploy:goldsky -- --env=testing_sepolia",
+    "deploy:testing:base": "npm run manifest:testing:base && npm run build:subgraph && npm run deploy:goldsky -- --env=testing_base",
     "deploy:testing:optimism": "npm run manifest:testing:optimism && npm run deploy:cmd:testing:optimism && npm run post-deploy:ormi -- --env=testing_optimism",
     "deploy:testing:arbitrum": "npm run manifest:testing:arbitrum && npm run deploy:cmd:testing:arbitrum && npm run post-deploy:ormi -- --env=testing_arbitrum",
     "deploy:staging:amoy": "npm run manifest:staging:amoy && npm run deploy:cmd:staging:amoy && npm run post-deploy:ormi -- --env=staging_amoy",

--- a/packages/subgraph/scripts/deploy-on-goldsky.ts
+++ b/packages/subgraph/scripts/deploy-on-goldsky.ts
@@ -1,0 +1,347 @@
+import { spawn } from "child_process";
+import path from "path";
+import { Option, program } from "commander";
+
+program
+  .description(
+    "Deploy the subgraph on Goldsky, move the 'latest' tag onto the new version and remove the previously tagged one"
+  )
+  .addOption(
+    new Option(
+      "--env <ENV>",
+      `Deployed environment (Boson env + chain): "testing_amoy", "testing_sepolia", ...`
+    )
+      .makeOptionMandatory(true)
+      .choices([
+        "testing_amoy",
+        "testing_sepolia",
+        "testing_base",
+        "testing_optimism",
+        "testing_arbitrum",
+        "staging_amoy",
+        "staging_sepolia",
+        "staging_base",
+        "staging_optimism",
+        "staging_arbitrum",
+        "production_polygon",
+        "production_ethereum",
+        "production_base",
+        "production_optimism",
+        "production_arbitrum"
+      ])
+  )
+  .parse(process.argv);
+
+const { env } = program.opts();
+
+const subgraphTag = "latest";
+const subgraphDir = path.join(__dirname, "..");
+// `bin/goldsky` is a thin `require("../dist/index.js")` shim, so the CLI entry point can
+// be run directly with the current node binary - which behaves the same way on win32.
+const goldskyCli = require.resolve("@goldskycom/cli");
+
+const requiredEnvVars = [
+  "GOLDSKY_API_KEY", // should be set in GH pipeline from GH action secret depending on the env
+  `npm_package_config_${env}`, // subgraphName
+  "npm_package_version" // newVersion
+];
+
+/**
+ * Syncing a freshly deployed version can take several hours, so waiting for it is opt-in:
+ * - unset (default): the 'latest' tag is moved onto the new version straight after the
+ *   deployment, which is the quickest way to get a new version served.
+ * - truthy: the 'latest' tag is only moved - and the previously tagged version only
+ *   deleted - once the new version is fully synced and healthy. If it never gets there,
+ *   the script fails and both the 'latest' tag and the old version are left untouched.
+ */
+const waitForSync = isTruthy(process.env["GOLDSKY_WAIT_FOR_SYNC"]);
+const syncTimeoutMinutes = Number(
+  process.env["GOLDSKY_SYNC_TIMEOUT_MINUTES"] || 300
+);
+const syncPollSeconds = Number(process.env["GOLDSKY_SYNC_POLL_SECONDS"] || 60);
+
+function isTruthy(value: string | undefined): boolean {
+  return ["true", "1", "yes", "on"].includes(
+    (value || "").trim().toLowerCase()
+  );
+}
+
+function checkEnvVars() {
+  for (const envVar of requiredEnvVars) {
+    if (!process.env[envVar]) {
+      throw new Error(`Missing environment variable '${envVar}'`);
+    }
+  }
+  const numericEnvVars: [string, number][] = [
+    ["GOLDSKY_SYNC_TIMEOUT_MINUTES", syncTimeoutMinutes],
+    ["GOLDSKY_SYNC_POLL_SECONDS", syncPollSeconds]
+  ];
+  for (const [envVar, value] of numericEnvVars) {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(
+        `Environment variable '${envVar}' must be a positive number`
+      );
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Run the Goldsky CLI. The API key is passed with the global `--token` option so that no
+ * credentials get persisted in `~/.goldsky/auth_token`, and colors are disabled so that
+ * the captured output stays parsable.
+ */
+async function goldsky(
+  args: string[],
+  options: { capture?: boolean } = {}
+): Promise<string> {
+  const apiKey = process.env["GOLDSKY_API_KEY"] as string;
+  console.log(`goldsky ${args.join(" ")}`);
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [goldskyCli, ...args, "--token", apiKey, "--no-color"],
+      {
+        cwd: subgraphDir,
+        stdio: ["ignore", options.capture ? "pipe" : "inherit", "inherit"]
+      }
+    );
+    let stdout = "";
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(
+          new Error(`'goldsky ${args.join(" ")}' exited with code ${code}`)
+        );
+      }
+    });
+  });
+}
+
+/**
+ * Ask Goldsky which version a tag currently points to. `goldsky subgraph list` prints one
+ * line per tag, formatted as "* <subgraphName>/<tag> -> <subgraphName>/<targetVersion>".
+ */
+async function getTaggedVersion(
+  subgraphName: string,
+  tag: string
+): Promise<string | undefined> {
+  let stdout: string;
+  try {
+    stdout = await goldsky(
+      ["subgraph", "list", subgraphName, "--filter", "tags", "--summary"],
+      { capture: true }
+    );
+  } catch (e) {
+    // Either the subgraph does not exist yet (first deployment on Goldsky), or the
+    // listing failed. Either way we know of no previous version, which only means that
+    // no old version will be deleted.
+    console.warn(`Could not list the tags of '${subgraphName}'`, e);
+    return undefined;
+  }
+  const pattern = new RegExp(
+    `^\\*\\s+${escapeRegExp(`${subgraphName}/${tag}`)}\\s+->\\s+${escapeRegExp(
+      subgraphName
+    )}/(\\S+)\\s*$`,
+    "m"
+  );
+  const version = stdout.match(pattern)?.[1];
+  console.log(`getTaggedVersion(${subgraphName}, ${tag})`, { version });
+  return version;
+}
+
+type DeploymentStatus = {
+  health: string | undefined;
+  synced: boolean;
+  progress: string | undefined;
+  fatalError: boolean;
+};
+
+/**
+ * Read the indexing status of a deployed version out of `goldsky subgraph list`, which
+ * prints "Status: <health>", "Synced: <check mark>|<percentage>%" and, when the
+ * deployment failed, a "Fatal error:" line.
+ */
+async function getDeploymentStatus(
+  subgraphName: string,
+  subgraphVersion: string
+): Promise<DeploymentStatus> {
+  const stdout = await goldsky(
+    ["subgraph", "list", `${subgraphName}/${subgraphVersion}`],
+    { capture: true }
+  );
+  const health = stdout.match(/^\s*Status:\s*(\S+)/m)?.[1];
+  const syncState = stdout.match(/^\s*Synced:\s*(.+?)\s*$/m)?.[1];
+  const progress = syncState?.endsWith("%") ? syncState : undefined;
+  const status = {
+    health,
+    // The CLI prints a check mark once Goldsky flags the deployment as synced, and the
+    // indexing progress until then. That flag is not reliable - a fully indexed, healthy
+    // deployment can sit at "100%" for weeks - so a reported 100% counts as synced too.
+    // The CLI rounds the progress to 3 significant digits, so "100%" means ">= 99.95%".
+    synced: !!syncState && (!progress || progress === "100%"),
+    progress,
+    fatalError: /^\s*Fatal error:/m.test(stdout)
+  };
+  console.log(
+    `getDeploymentStatus(${subgraphName}, ${subgraphVersion})`,
+    status
+  );
+  return status;
+}
+
+async function waitUntilSynced(
+  subgraphName: string,
+  subgraphVersion: string
+): Promise<void> {
+  console.log(
+    `Waiting for ${subgraphName}/${subgraphVersion} to be synced (timeout: ${syncTimeoutMinutes} minutes)`
+  );
+  const deadline = Date.now() + syncTimeoutMinutes * 60 * 1000;
+  for (;;) {
+    let status: DeploymentStatus | undefined;
+    try {
+      status = await getDeploymentStatus(subgraphName, subgraphVersion);
+    } catch (e) {
+      // Goldsky may not report the deployment right after it has been created: keep
+      // polling until the timeout rather than failing on a transient error.
+      console.warn(
+        `Could not read the status of ${subgraphName}/${subgraphVersion}`,
+        e
+      );
+    }
+    const { health, synced, progress, fatalError } = status || {
+      health: undefined,
+      synced: false,
+      progress: undefined,
+      fatalError: false
+    };
+    if (fatalError || health === "failed") {
+      throw new Error(
+        `${subgraphName}/${subgraphVersion} failed to index - the '${subgraphTag}' tag has not been moved`
+      );
+    }
+    if (synced) {
+      if (health !== "healthy") {
+        throw new Error(
+          `${subgraphName}/${subgraphVersion} is synced but not healthy (status: ${health}) - the '${subgraphTag}' tag has not been moved`
+        );
+      }
+      console.log(`${subgraphName}/${subgraphVersion} is synced and healthy`);
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `${subgraphName}/${subgraphVersion} is still not synced (${progress}) after ${syncTimeoutMinutes} minutes - the '${subgraphTag}' tag has not been moved`
+      );
+    }
+    await sleep(syncPollSeconds * 1000);
+  }
+}
+
+async function deploySubgraph(subgraphName: string, subgraphVersion: string) {
+  // `goldsky subgraph deploy` uploads the ./build directory, it does not build anything
+  await goldsky([
+    "subgraph",
+    "deploy",
+    `${subgraphName}/${subgraphVersion}`,
+    "--path",
+    "."
+  ]);
+}
+
+/**
+ * Goldsky tags are mutable pointers keyed by tag name, so creating a tag that already
+ * exists simply repoints it onto the given version - no intermediate tag is needed.
+ */
+async function createTag(
+  subgraphName: string,
+  subgraphVersion: string,
+  tag: string
+) {
+  await goldsky([
+    "subgraph",
+    "tag",
+    "create",
+    `${subgraphName}/${subgraphVersion}`,
+    "--tag",
+    tag
+  ]);
+}
+
+async function removeSubgraph(subgraphName: string, subgraphVersion: string) {
+  await goldsky([
+    "subgraph",
+    "delete",
+    `${subgraphName}/${subgraphVersion}`,
+    "--force"
+  ]);
+}
+
+async function main() {
+  /**
+   * 1. get the version the "latest" tag currently points to - this has to be done before
+   *    deploying, as moving the tag is what makes that information unrecoverable
+   * 2. deploy the new version
+   * 3. if GOLDSKY_WAIT_FOR_SYNC is set, wait for the new version to be synced and healthy
+   * 4. move the "latest" tag onto the new version
+   * 5. if the old version has been found (and is different from the new version), and the
+   *    "latest" tag does point to the new version, delete the old version
+   */
+  checkEnvVars();
+  const subgraphName = process.env[`npm_package_config_${env}`] as string;
+  const newVersion = process.env["npm_package_version"] as string;
+
+  const oldVersion = await getTaggedVersion(subgraphName, subgraphTag);
+
+  await deploySubgraph(subgraphName, newVersion);
+
+  if (waitForSync) {
+    await waitUntilSynced(subgraphName, newVersion);
+  } else {
+    console.log(
+      `Not waiting for ${subgraphName}/${newVersion} to be synced - set GOLDSKY_WAIT_FOR_SYNC=true to only tag and clean up once it is`
+    );
+  }
+
+  await createTag(subgraphName, newVersion, subgraphTag);
+
+  if (oldVersion && oldVersion !== newVersion) {
+    // Never delete the old version unless the tag has really been moved over
+    const taggedVersion = await getTaggedVersion(subgraphName, subgraphTag);
+    if (taggedVersion !== newVersion) {
+      throw new Error(
+        `'${subgraphTag}' points to '${taggedVersion}' instead of '${newVersion}' - not deleting ${subgraphName}/${oldVersion}`
+      );
+    }
+    await removeSubgraph(subgraphName, oldVersion);
+  }
+
+  console.log(
+    `${subgraphName}/${newVersion} deployed and tagged '${subgraphTag}'`,
+    { oldVersion, waitForSync }
+  );
+}
+
+main()
+  .then(() => {
+    console.log("OK");
+    process.exit(0);
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -19,8 +19,8 @@ dataSources:
         - BaseMetadataEntity
         - ProductV1MetadataEntity
         - Offer
-        - ExchangeToken
         - ProductV1Brand
+        - ExchangeToken
       abis:
         - name: IBosonOfferHandler
           file: ../common/src/abis/IBosonOfferHandler.json


### PR DESCRIPTION
Part of #1036 — first slice of the Ormi → Goldsky migration, scoped to the **testing** environment on **Sepolia** and **Base Sepolia**. The other three testing networks, plus staging and production, stay on Ormi for now.

## What changes

**Query endpoint** — `testing-11155111-0` now points at the Goldsky endpoint in `subgraphs.json`. The URL is tag-based (`.../subgraphs/boson-testing-sepolia/latest/gn`), so it stays stable across deployments.
Same change applied to `testing-84532-0` 

**New deploy script** — `packages/subgraph/scripts/deploy-on-goldsky.ts` replaces the `graph deploy` + `post-deploy-on-ormi.ts` pair for these two networks. It drives the Goldsky CLI through the whole sequence:

1. read the version the `latest` tag currently points to — **before** deploying, since moving the tag is what makes that unrecoverable
2. deploy the new version
3. optionally wait for it to be synced and healthy
4. move the `latest` tag onto the new version
5. re-read the tag to confirm it moved, then delete the previously tagged version

Goldsky tags are mutable pointers keyed by tag name, so step 4 is a single idempotent write — creating a tag that already exists just repoints it. No intermediate `new-latest` tag is needed.

`post-deploy-on-ormi.ts` is untouched, and the `deploy:cmd:testing:{sepolia,base}` entries are left in place for rollback.

**The sync gate** — syncing can take hours, so waiting for it is opt-in via `GOLDSKY_WAIT_FOR_SYNC`:

| | tag move + old-version delete |
|---|---|
| unset (default) | straight after the deployment — quick local iteration |
| truthy | only once the new version is synced and healthy |

If the new version never gets there, the script exits non-zero with `latest` still on the old version and the old version still present. `GOLDSKY_SYNC_TIMEOUT_MINUTES` (default 300) and `GOLDSKY_SYNC_POLL_SECONDS` (default 60) tune the wait.

**Workflow** — `deploy-testing-subgraph.yaml` now deploys only these two networks, with the gate on and the per-network timeout capped at 150 min so two sequential deploys fit inside GitHub's 6h job limit. Three supporting changes came with that:

- a `concurrency` group, because a job that pushes to a branch and now runs for hours can otherwise overlap with itself and race on the same subgraph's tags
- `timeout-minutes: 330` on the job
- the `Commit & Push` step no longer fails when there is nothing to commit. `subgraph.yaml` is gitignored, so the `logs/*` files were the only thing this job ever committed — and Goldsky now records which version is deployed, making them obsolete

`publish-alpha.yaml` passes the new secret through to the reusable workflow; a `required: true` secret has to be provided by the caller or the run errors before it starts.

## Action required before merge

**Create a `GOLDSKY_API_KEY_TESTING` repo/org secret.** The workflow will fail with `Missing environment variable 'GOLDSKY_API_KEY'` without it. The name follows the `ORMI_0x_GRAPH_API_KEY_TESTING` convention — rename in both workflow files if you'd prefer something else.

## Verification

- `npm run build` and `npm run lint:fix` pass
- both list-parsing paths were checked against the live Goldsky project (read-only): the tag lookup returns `1.36.0` and the status read returns `healthy` for both `boson-testing-sepolia` and `boson-testing-base`
- workflows: YAML parses, `prettier --check` clean, `@action-validator/cli` schema-clean, `actionlint` reports only pre-existing findings
- the deploy itself has **not** been exercised end-to-end — the first real run will be this workflow

Worth knowing: Goldsky's `synced` flag is unreliable. Both live deployments are healthy and indexed to head but still report `Synced: 100%` rather than the check mark, weeks after deployment. A gate keyed on the check mark alone would hang for the full timeout on every run, so the script treats a reported `100%` as synced (the CLI rounds to 3 significant digits, so that means ≥ 99.95%).

## Pre-existing, not addressed here

`actionlint` flags `actions/{checkout,setup-node,cache}@v3` in this workflow as too old to run. The rest of the repo is already on v4 — the only three holdouts are the testing/staging/prod subgraph deploy workflows. Happy to bump them in a follow-up.

## Follow-ups

- migrate the remaining testing networks, then staging and production
- publish a new `core-sdk` version once the endpoints are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)
